### PR TITLE
תיקון סדר קטלוגי: המפרשים הוצגו לפני המדרש עצמו (#649)

### DIFF
--- a/lib/data/data_providers/catalogue_order_revision.dart
+++ b/lib/data/data_providers/catalogue_order_revision.dart
@@ -1,0 +1,91 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:path/path.dart' as p;
+
+/// גרסת הסדר הקטלוגי שנצרב לאינדקס. הסדר מקודד ל-documentId בזמן
+/// האינדוקס, ולכן שינוי בלוגיקה של `SearchCatalogueOrderHelper` מחייב
+/// העלאת המספר — בלעדיה אינדקס קיים ימשיך להחזיר את הסדר הישן.
+///
+/// העלאת המספר מחייבת גם בניית האינדקס המוכן-מראש שמצורף לגרסה
+/// (`release_index_builder_cli.dart`) — אחרת הוא יימחק ויבנה מחדש
+/// אצל כל מי שיתקין אותו.
+const int kCatalogueOrderRevision = 2;
+
+/// קורא וכותב את גרסת הסדר הקטלוגי בתיקיית האינדקס, ומכריע אם אינדקס
+/// קיים נבנה בגרסה ישנה ולכן חייב בנייה מחדש.
+class CatalogueOrderRevision {
+  CatalogueOrderRevision._();
+
+  static const String fileName = 'otzaria_catalogue_order.json';
+
+  static File fileFor(String indexPath) => File(p.join(indexPath, fileName));
+
+  /// הגרסה השמורה, או null כשאין קובץ או שתוכנו אינו קריא.
+  ///
+  /// שני המצבים מתמזגים בכוונה: כשל קריאה מוביל לבנייה מחדש אחת שכותבת
+  /// חותם תקין, בעוד ההנחה ההפוכה ("כנראה עדכני") הייתה משאירה סדר שגוי
+  /// לצמיתות. הכתיבה ב-[write] אטומית כדי שקובץ חצוי לא ייווצר מלכתחילה.
+  static int? read(String indexPath) {
+    try {
+      final file = fileFor(indexPath);
+      if (!file.existsSync()) return null;
+      final decoded = jsonDecode(file.readAsStringSync());
+      if (decoded is Map<String, dynamic>) {
+        return decoded['catalogueOrderRevision'] as int?;
+      }
+      return null;
+    } catch (e) {
+      debugPrint('⚠️ קריאת גרסת הסדר הקטלוגי נכשלה: $e');
+      return null;
+    }
+  }
+
+  /// כותב את הגרסה הנוכחית ומחזיר האם הצליח. הכתיבה עוברת דרך קובץ זמני
+  /// ו-rename, כדי שהפסקה באמצע תשאיר את החותם הקודם ולא קובץ חצוי.
+  static bool write(
+    String indexPath, {
+    int revision = kCatalogueOrderRevision,
+  }) {
+    try {
+      final directory = Directory(indexPath);
+      if (!directory.existsSync()) {
+        directory.createSync(recursive: true);
+      }
+      final target = fileFor(indexPath);
+      final temp = File('${target.path}.tmp');
+      temp.writeAsStringSync(
+        jsonEncode({'catalogueOrderRevision': revision}),
+        flush: true,
+      );
+      temp.renameSync(target.path);
+      return true;
+    } catch (e) {
+      debugPrint('⚠️ כתיבת גרסת הסדר הקטלוגי נכשלה: $e');
+      return false;
+    }
+  }
+
+  /// האם מותר לחתום את הגרסה הנוכחית על האינדקס שבדיסק. חותמים רק על
+  /// אינדקס ריק שמצבו ידוע — חתימה על אינדקס מלא הייתה מכריזה סדר ישן
+  /// כתקין, ומצב לא ידוע (כשל קריאה או אינדקס זמני) אינו מעיד על ריקנות.
+  static bool shouldStamp({
+    required bool indexStateIsKnown,
+    required bool hasIndexedBooks,
+  }) => indexStateIsKnown && !hasIndexedBooks;
+
+  /// האם האינדקס הקיים נבנה בגרסת סדר ישנה. אינדקס בלי מסמכים חיים אינו
+  /// מיושן — אין בו סדר שגוי לתקן, וזה גם מצב ההתקנה הנקייה. מצב לא ידוע
+  /// אינו מכריז מיושן, כדי לא למחוק אינדקס תקין על סמך קריאה שנכשלה.
+  static bool isStale({
+    required int? storedRevision,
+    required bool hasIndexedBooks,
+    bool indexStateIsKnown = true,
+    int currentRevision = kCatalogueOrderRevision,
+  }) {
+    if (!indexStateIsKnown) return false;
+    if (!hasIndexedBooks) return false;
+    return storedRevision != currentRevision;
+  }
+}

--- a/lib/data/data_providers/tantivy_data_provider.dart
+++ b/lib/data/data_providers/tantivy_data_provider.dart
@@ -156,7 +156,9 @@ class TantivyDataProvider {
 
     // אינדוקס באותה הפעלה כבר מילא את האינדקס בסדר הנוכחי — ניסיון חוזר
     // לחתום מונע הכרזת "ישן" על אינדקס תקין בפתיחה מחדש שבאמצע ההפעלה.
-    ensureCatalogueOrderStamp();
+    if (indexStateIsKnown) {
+      ensureCatalogueOrderStamp();
+    }
 
     _catalogueOrderStale = CatalogueOrderRevision.isStale(
       storedRevision: CatalogueOrderRevision.read(indexPath),

--- a/lib/data/data_providers/tantivy_data_provider.dart
+++ b/lib/data/data_providers/tantivy_data_provider.dart
@@ -4,6 +4,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart' show rootBundle;
 import 'package:path/path.dart' as p;
 import 'package:otzaria_search_engine/otzaria_search_engine.dart';
+import 'package:otzaria/data/data_providers/catalogue_order_revision.dart';
 import 'package:otzaria/search/models/search_configuration.dart';
 import 'package:otzaria/search/search_engine_gateway.dart';
 import 'package:otzaria/search/magic_dictionary_downloader.dart';
@@ -49,6 +50,9 @@ class TantivyDataProvider {
   IndexCompatibility? _indexCompatibility;
   IndexCompatibility? get indexCompatibility => _indexCompatibility;
 
+  /// נקבע באתחול: האינדקס מכיל ספרים שנצרב בהם סדר קטלוגי מגרסה ישנה.
+  bool _catalogueOrderStale = false;
+
   /// Clear global cache when starting new search
   static void clearGlobalCache() {
     debugPrint(
@@ -90,7 +94,11 @@ class TantivyDataProvider {
     _indexCompatibility = _checkIndexCompatibility(indexPath);
 
     final engine = await _initEngine();
-    await _loadIndexedFilePaths(engine);
+    final indexedFilePathsLoaded = await _loadIndexedFilePaths(engine);
+    _syncCatalogueOrderRevision(
+      indexPath,
+      indexStateIsKnown: indexedFilePathsLoaded && !isTempFallback,
+    );
 
     // indexedFilePaths כעת משקפת את מצב האינדקס בפועל. צרכנים שמסיקים
     // "אין אינדקס" מתוך הקבוצה צריכים לחכות לסימן הזה כדי לא להציג שגוי בהפעלה.
@@ -115,16 +123,51 @@ class TantivyDataProvider {
     }
   }
 
+  /// מכריע אם הסדר הקטלוגי שבאינדקס מיושן. אינדקס ריק (התקנה נקייה או
+  /// אינדקס שאופס) מסומן מיד בגרסה הנוכחית, כדי שלא ידרוש בנייה מחדש.
+  ///
+  /// [indexStateIsKnown] false כשלא הצלחנו לקרוא את מצב האינדקס או שהמנוע
+  /// רץ על אינדקס זמני. חתימה במצב כזה הייתה מברכת אינדקס ישן ומלא כתקין,
+  /// והבאג היה נשאר אצל המשתמש בלי שום סימן — לכן לא כותבים ולא מסמנים.
+  void _syncCatalogueOrderRevision(
+    String indexPath, {
+    required bool indexStateIsKnown,
+  }) {
+    final hasIndexedBooks = indexedFilePaths.isNotEmpty;
+
+    if (CatalogueOrderRevision.shouldStamp(
+      indexStateIsKnown: indexStateIsKnown,
+      hasIndexedBooks: hasIndexedBooks,
+    )) {
+      _catalogueOrderStale = false;
+      CatalogueOrderRevision.write(indexPath);
+      return;
+    }
+
+    _catalogueOrderStale = CatalogueOrderRevision.isStale(
+      storedRevision: CatalogueOrderRevision.read(indexPath),
+      hasIndexedBooks: hasIndexedBooks,
+      indexStateIsKnown: indexStateIsKnown,
+    );
+
+    if (_catalogueOrderStale) {
+      debugPrint('⚠️ האינדקס נבנה בסדר קטלוגי ישן — נדרשת בנייה מחדש');
+    }
+  }
+
   /// טוען מהאינדקס עצמו את רשימת הספרים שיש להם מסמכים חיים.
-  Future<void> _loadIndexedFilePaths(SearchEngine engine) async {
+  /// מחזיר האם הקריאה הצליחה — קבוצה ריקה אחרי כשל אינה "אינדקס ריק".
+  Future<bool> _loadIndexedFilePaths(SearchEngine engine) async {
     indexedFilePaths.clear();
     try {
       indexedFilePaths.addAll(await engine.getIndexedFilePaths());
       debugPrint(
         '📚 נקראו ${indexedFilePaths.length} ספרים מאונדקסים מהאינדקס',
       );
+      return true;
     } catch (e) {
       debugPrint('⚠️ קריאת הספרים המאונדקסים מהאינדקס נכשלה: $e');
+      return false;
     }
   }
 
@@ -377,10 +420,11 @@ class TantivyDataProvider {
     }
   }
 
-  /// האם האינדקס הקיים דורש איפוס ובנייה מחדש, לפי בדיקת התאימות
-  /// שנקראה מהאינדקס עצמו בעת פתיחת המנוע.
+  /// האם האינדקס הקיים דורש איפוס ובנייה מחדש — בגלל אי-תאימות סכמה
+  /// שנקראה מהאינדקס עצמו, או בגלל שנצרב בו סדר קטלוגי מגרסה ישנה.
   bool get requiresManualReindex =>
-      isRebuildRequiredStatus(_indexCompatibility?.status);
+      isRebuildRequiredStatus(_indexCompatibility?.status) ||
+      _catalogueOrderStale;
 
   /// האם סטטוס תאימות נתון מחייב בנייה מחדש של האינדקס.
   @visibleForTesting

--- a/lib/data/data_providers/tantivy_data_provider.dart
+++ b/lib/data/data_providers/tantivy_data_provider.dart
@@ -53,6 +53,9 @@ class TantivyDataProvider {
   /// נקבע באתחול: האינדקס מכיל ספרים שנצרב בהם סדר קטלוגי מגרסה ישנה.
   bool _catalogueOrderStale = false;
 
+  /// תיקיית האינדקס שחתימת הסדר הקטלוגי עליה נכשלה באתחול, אם נכשלה.
+  String? _pendingCatalogueOrderStampPath;
+
   /// Clear global cache when starting new search
   static void clearGlobalCache() {
     debugPrint(
@@ -134,15 +137,26 @@ class TantivyDataProvider {
     required bool indexStateIsKnown,
   }) {
     final hasIndexedBooks = indexedFilePaths.isNotEmpty;
+    if (_pendingCatalogueOrderStampPath != indexPath) {
+      _pendingCatalogueOrderStampPath = null;
+    }
 
     if (CatalogueOrderRevision.shouldStamp(
       indexStateIsKnown: indexStateIsKnown,
       hasIndexedBooks: hasIndexedBooks,
     )) {
       _catalogueOrderStale = false;
-      CatalogueOrderRevision.write(indexPath);
+      // כשל כתיבה כאן שקט אך יקר: האינדקס המלא שייבנה מיד יימצא בלי חותם,
+      // כלומר "ישן", והמשתמש יידרש לבנות הכול מחדש.
+      _pendingCatalogueOrderStampPath = CatalogueOrderRevision.write(indexPath)
+          ? null
+          : indexPath;
       return;
     }
+
+    // אינדוקס באותה הפעלה כבר מילא את האינדקס בסדר הנוכחי — ניסיון חוזר
+    // לחתום מונע הכרזת "ישן" על אינדקס תקין בפתיחה מחדש שבאמצע ההפעלה.
+    ensureCatalogueOrderStamp();
 
     _catalogueOrderStale = CatalogueOrderRevision.isStale(
       storedRevision: CatalogueOrderRevision.read(indexPath),
@@ -153,6 +167,16 @@ class TantivyDataProvider {
     if (_catalogueOrderStale) {
       debugPrint('⚠️ האינדקס נבנה בסדר קטלוגי ישן — נדרשת בנייה מחדש');
     }
+  }
+
+  /// כותב מחדש חותם סדר קטלוגי שכתיבתו נכשלה באתחול, כשהאינדקס שעל הדיסק
+  /// אכן נבנה בסדר הנוכחי. מחזיר האם החותם קיים כעת (כולל "לא נדרש דבר").
+  bool ensureCatalogueOrderStamp() {
+    final pendingPath = _pendingCatalogueOrderStampPath;
+    if (pendingPath == null) return true;
+    if (!CatalogueOrderRevision.write(pendingPath)) return false;
+    _pendingCatalogueOrderStampPath = null;
+    return true;
   }
 
   /// טוען מהאינדקס עצמו את רשימת הספרים שיש להם מסמכים חיים.

--- a/lib/indexing/models/catalogue_order_resolver.dart
+++ b/lib/indexing/models/catalogue_order_resolver.dart
@@ -1,0 +1,48 @@
+import 'dart:math' as math;
+
+import 'package:flutter/foundation.dart';
+
+/// מוסר את הסדר הקטלוגי של ספר — המספר שנצרב לחצי העליון של מזהה המסמך
+/// באינדקס (`IndexingRepository.buildCatalogueDocumentId`).
+///
+/// המנוע מגדיר את `id` כמזהה מסמך ייחודי, ולכן סדר משותף לשני ספרים אינו
+/// רק מיון לא יציב: כתיבת האחד מוחקת את מסמכי האחר (מחיקה לפי `id`) והם
+/// חולקים `sectionId`. ספר שאינו במפת הספרייה מקבל כאן סדר משלו מיד אחרי
+/// הספר האחרון שבה, ולא ערך משותף.
+class CatalogueOrderResolver {
+  CatalogueOrderResolver(this._orderByKey)
+    : _nextFallbackOrder = _orderByKey.isEmpty
+          ? 0
+          : _orderByKey.values.reduce(math.max) + 1;
+
+  /// הסדר הגבוה ביותר שניתן לצרוב: `buildCatalogueDocumentId` מוסיף 1 לפני
+  /// ההזזה ב-32 סיביות, וערך גבוה יותר חורג מ-u64 ונחתך בגשר ל-Rust.
+  static const int maxCatalogueOrder = 0xFFFFFFFE;
+
+  final Map<String, int> _orderByKey;
+  final Map<String, int> _fallbackOrderByKey = {};
+  int _nextFallbackOrder;
+
+  /// מפתחות הספרים שלא נמצאו בספרייה וקיבלו סדר חלופי.
+  @visibleForTesting
+  Iterable<String> get fallbackKeys => _fallbackOrderByKey.keys;
+
+  /// הסדר של [key], או סדר חלופי ייחודי אם הספר אינו בספרייה.
+  int orderFor(String key) {
+    final known = _orderByKey[key];
+    if (known != null) return known;
+    return _fallbackOrderByKey.putIfAbsent(key, () => _allocateFallback(key));
+  }
+
+  int _allocateFallback(String key) {
+    if (_nextFallbackOrder > maxCatalogueOrder) {
+      throw StateError(
+        'אזל טווח הסדר הקטלוגי בעת הקצאת סדר לספר שאינו בספרייה: $key',
+      );
+    }
+    debugPrint(
+      '⚠️ ספר שאינו בקטלוג מקבל סדר חלופי ($_nextFallbackOrder): $key',
+    );
+    return _nextFallbackOrder++;
+  }
+}

--- a/lib/indexing/models/catalogue_order_resolver.dart
+++ b/lib/indexing/models/catalogue_order_resolver.dart
@@ -1,79 +1,26 @@
-import 'dart:math' as math;
-
-import 'package:flutter/foundation.dart';
-
 /// מוסר את הסדר הקטלוגי של ספר — המספר שנצרב לחצי העליון של מזהה המסמך
 /// באינדקס (`IndexingRepository.buildCatalogueDocumentId`).
 ///
-/// המנוע מגדיר את `id` כמזהה מסמך ייחודי, ולכן סדר משותף לשני ספרים אינו
-/// רק מיון לא יציב: כתיבת האחד מוחקת את מסמכי האחר (מחיקה לפי `id`) והם
-/// חולקים `sectionId`. ספר שאינו במפת הספרייה מקבל כאן סדר משלו בטווח
-/// שמור שמעל כל הספרייה, נגזר מהמפתח בלבד.
+/// כל ספר שנשלח לאינדוקס חייב להופיע במפת הספרייה. סדר חלופי אינו בטוח:
+/// טווח 32 סיביות אינו יכול למפות מפתחות שרירותיים בלי התנגשויות.
 class CatalogueOrderResolver {
-  CatalogueOrderResolver(this._orderByKey)
-    : _fallbackBase = _orderByKey.isEmpty
-          ? _reservedFallbackBase
-          : math.max(
-              _reservedFallbackBase,
-              _orderByKey.values.reduce(math.max) + 1,
-            );
+  CatalogueOrderResolver(this._orderByKey);
 
   /// הסדר הגבוה ביותר שניתן לצרוב: `buildCatalogueDocumentId` מוסיף 1 לפני
   /// ההזזה ב-32 סיביות, וערך גבוה יותר חורג מ-u64 ונחתך בגשר ל-Rust.
   static const int maxCatalogueOrder = 0xFFFFFFFE;
 
-  /// תחילת הטווח השמור לספרים שאינם בספרייה — מעל כל גודל ספרייה אפשרי,
-  /// כדי שהם ימוינו אחרונים בלי תלות בגודלה.
-  static const int _reservedFallbackBase = 0x80000000;
-
-  /// תקרת הדפסה: ספרייה שנטענה חלקית הייתה מציפה את תור ההדפסה של Flutter.
-  static const int _maxLoggedFallbacks = 20;
-
   final Map<String, int> _orderByKey;
-  final Map<String, int> _fallbackOrderByKey = {};
-  final Set<int> _takenFallbackOrders = {};
-  final int _fallbackBase;
 
-  /// מפתחות הספרים שלא נמצאו בספרייה וקיבלו סדר חלופי.
-  @visibleForTesting
-  Iterable<String> get fallbackKeys => _fallbackOrderByKey.keys;
-
-  /// הסדר של [key], או סדר חלופי ייחודי אם הספר אינו בספרייה.
+  /// מחזיר את הסדר של [key]. זורק אם המפתח אינו בקטלוג או אינו נכנס ב-u64.
   int orderFor(String key) {
-    final known = _orderByKey[key];
-    if (known != null) return known;
-    return _fallbackOrderByKey.putIfAbsent(key, () => _allocateFallback(key));
-  }
-
-  /// הסדר החלופי נגזר מהמפתח בלבד ולא ממונה רץ, כדי שאותו ספר יקבל את אותו
-  /// סדר בכל ריצה — אחרת ריצה אחרת הייתה מחלקת אותו לספר אחר.
-  int _allocateFallback(String key) {
-    final range = maxCatalogueOrder - _fallbackBase + 1;
-    var order = _fallbackBase + stableFallbackHash(key) % range;
-    for (var probe = 0; _takenFallbackOrders.contains(order); probe++) {
-      if (probe >= range) {
-        throw StateError(
-          'אזל טווח הסדר הקטלוגי בעת הקצאת סדר לספר שאינו בספרייה: $key',
-        );
-      }
-      order = _fallbackBase + (order - _fallbackBase + 1) % range;
+    final order = _orderByKey[key];
+    if (order == null) {
+      throw StateError('ספר שנשלח לאינדוקס אינו נמצא במפת הקטלוג: $key');
     }
-    _takenFallbackOrders.add(order);
-    if (_fallbackOrderByKey.length < _maxLoggedFallbacks) {
-      debugPrint('⚠️ ספר שאינו בקטלוג מקבל סדר חלופי ($order): $key');
+    if (order < 0 || order > maxCatalogueOrder) {
+      throw RangeError.range(order, 0, maxCatalogueOrder, 'catalogueOrder');
     }
     return order;
-  }
-
-  /// FNV-1a על 32 סיביות. מימוש מפורש ולא `hashCode`, שאינו מובטח יציב בין
-  /// ריצות — והסדר נצרב לאינדקס ולטביעת האצבע ולכן חייב לשרוד הפעלה מחדש.
-  @visibleForTesting
-  static int stableFallbackHash(String key) {
-    var hash = 0x811C9DC5;
-    for (final unit in key.codeUnits) {
-      hash = ((hash ^ (unit & 0xFF)) * 0x01000193) & 0xFFFFFFFF;
-      hash = ((hash ^ ((unit >> 8) & 0xFF)) * 0x01000193) & 0xFFFFFFFF;
-    }
-    return hash;
   }
 }

--- a/lib/indexing/models/catalogue_order_resolver.dart
+++ b/lib/indexing/models/catalogue_order_resolver.dart
@@ -7,21 +7,32 @@ import 'package:flutter/foundation.dart';
 ///
 /// המנוע מגדיר את `id` כמזהה מסמך ייחודי, ולכן סדר משותף לשני ספרים אינו
 /// רק מיון לא יציב: כתיבת האחד מוחקת את מסמכי האחר (מחיקה לפי `id`) והם
-/// חולקים `sectionId`. ספר שאינו במפת הספרייה מקבל כאן סדר משלו מיד אחרי
-/// הספר האחרון שבה, ולא ערך משותף.
+/// חולקים `sectionId`. ספר שאינו במפת הספרייה מקבל כאן סדר משלו בטווח
+/// שמור שמעל כל הספרייה, נגזר מהמפתח בלבד.
 class CatalogueOrderResolver {
   CatalogueOrderResolver(this._orderByKey)
-    : _nextFallbackOrder = _orderByKey.isEmpty
-          ? 0
-          : _orderByKey.values.reduce(math.max) + 1;
+    : _fallbackBase = _orderByKey.isEmpty
+          ? _reservedFallbackBase
+          : math.max(
+              _reservedFallbackBase,
+              _orderByKey.values.reduce(math.max) + 1,
+            );
 
   /// הסדר הגבוה ביותר שניתן לצרוב: `buildCatalogueDocumentId` מוסיף 1 לפני
   /// ההזזה ב-32 סיביות, וערך גבוה יותר חורג מ-u64 ונחתך בגשר ל-Rust.
   static const int maxCatalogueOrder = 0xFFFFFFFE;
 
+  /// תחילת הטווח השמור לספרים שאינם בספרייה — מעל כל גודל ספרייה אפשרי,
+  /// כדי שהם ימוינו אחרונים בלי תלות בגודלה.
+  static const int _reservedFallbackBase = 0x80000000;
+
+  /// תקרת הדפסה: ספרייה שנטענה חלקית הייתה מציפה את תור ההדפסה של Flutter.
+  static const int _maxLoggedFallbacks = 20;
+
   final Map<String, int> _orderByKey;
   final Map<String, int> _fallbackOrderByKey = {};
-  int _nextFallbackOrder;
+  final Set<int> _takenFallbackOrders = {};
+  final int _fallbackBase;
 
   /// מפתחות הספרים שלא נמצאו בספרייה וקיבלו סדר חלופי.
   @visibleForTesting
@@ -34,15 +45,35 @@ class CatalogueOrderResolver {
     return _fallbackOrderByKey.putIfAbsent(key, () => _allocateFallback(key));
   }
 
+  /// הסדר החלופי נגזר מהמפתח בלבד ולא ממונה רץ, כדי שאותו ספר יקבל את אותו
+  /// סדר בכל ריצה — אחרת ריצה אחרת הייתה מחלקת אותו לספר אחר.
   int _allocateFallback(String key) {
-    if (_nextFallbackOrder > maxCatalogueOrder) {
-      throw StateError(
-        'אזל טווח הסדר הקטלוגי בעת הקצאת סדר לספר שאינו בספרייה: $key',
-      );
+    final range = maxCatalogueOrder - _fallbackBase + 1;
+    var order = _fallbackBase + stableFallbackHash(key) % range;
+    for (var probe = 0; _takenFallbackOrders.contains(order); probe++) {
+      if (probe >= range) {
+        throw StateError(
+          'אזל טווח הסדר הקטלוגי בעת הקצאת סדר לספר שאינו בספרייה: $key',
+        );
+      }
+      order = _fallbackBase + (order - _fallbackBase + 1) % range;
     }
-    debugPrint(
-      '⚠️ ספר שאינו בקטלוג מקבל סדר חלופי ($_nextFallbackOrder): $key',
-    );
-    return _nextFallbackOrder++;
+    _takenFallbackOrders.add(order);
+    if (_fallbackOrderByKey.length < _maxLoggedFallbacks) {
+      debugPrint('⚠️ ספר שאינו בקטלוג מקבל סדר חלופי ($order): $key');
+    }
+    return order;
+  }
+
+  /// FNV-1a על 32 סיביות. מימוש מפורש ולא `hashCode`, שאינו מובטח יציב בין
+  /// ריצות — והסדר נצרב לאינדקס ולטביעת האצבע ולכן חייב לשרוד הפעלה מחדש.
+  @visibleForTesting
+  static int stableFallbackHash(String key) {
+    var hash = 0x811C9DC5;
+    for (final unit in key.codeUnits) {
+      hash = ((hash ^ (unit & 0xFF)) * 0x01000193) & 0xFFFFFFFF;
+      hash = ((hash ^ ((unit >> 8) & 0xFF)) * 0x01000193) & 0xFFFFFFFF;
+    }
+    return hash;
   }
 }

--- a/lib/indexing/repository/indexing_repository.dart
+++ b/lib/indexing/repository/indexing_repository.dart
@@ -593,7 +593,8 @@ class IndexingRepository {
       final topics = _bookTopics(book);
       final filePath = buildIndexedBookFilePath(book);
       final catalogueOrder =
-          catalogueOrderByBookKey[catalogueOrderKey(book)] ?? 0xFFFFFFFF;
+          catalogueOrderByBookKey[catalogueOrderKey(book)] ??
+          unknownCatalogueOrder;
       final generationOrder = chronologicalOrderForBook(book);
       final engineStopwatch = Stopwatch()..start();
       final extraFacets = _bookExtraFacets(book);
@@ -755,7 +756,8 @@ class IndexingRepository {
       topics: _bookTopics(book),
       filePath: buildIndexedBookFilePath(book),
       catalogueOrder:
-          catalogueOrderByBookKey[catalogueOrderKey(book)] ?? 0xFFFFFFFF,
+          catalogueOrderByBookKey[catalogueOrderKey(book)] ??
+          unknownCatalogueOrder,
       generationOrder: chronologicalOrderForBook(book),
       extraFacets: _bookExtraFacets(book),
       pages: [
@@ -794,7 +796,8 @@ class IndexingRepository {
         DocumentInput(
           id: buildCatalogueDocumentId(
             catalogueOrder:
-                catalogueOrderByBookKey[catalogueOrderKey(book)] ?? 0xFFFFFFFF,
+                catalogueOrderByBookKey[catalogueOrderKey(book)] ??
+                unknownCatalogueOrder,
             ordinal: 0,
           ),
           title: book.title,
@@ -1170,6 +1173,11 @@ class IndexingRepository {
     }
   }
 
+  /// הסדר שניתן לספר שאינו נמצא במפת הסדר הקטלוגי — ממוין אחרי כל הספרים
+  /// המוכרים. לא 0xFFFFFFFF: [buildCatalogueDocumentId] מוסיף 1 לפני ההזזה,
+  /// והתוצאה הייתה חורגת מ-u64 ונחתכת בגשר ל-1 — כלומר ראש הרשימה.
+  static const int unknownCatalogueOrder = 0xFFFFFFFE;
+
   @visibleForTesting
   static BigInt buildCatalogueDocumentId({
     required int catalogueOrder,
@@ -1259,7 +1267,7 @@ class IndexingRepository {
           topics: _bookTopics(textBook),
           catalogueOrder:
               catalogueOrderByBookKey[catalogueOrderKey(textBook)] ??
-              0xFFFFFFFF,
+              unknownCatalogueOrder,
           generationOrder: chronologicalOrderForBook(textBook),
           extraFacets: _bookExtraFacets(textBook),
         ) ==
@@ -1677,7 +1685,8 @@ class IndexingRepository {
           title: book.title,
           topics: _bookTopics(book),
           catalogueOrder:
-              catalogueOrderByBookKey[catalogueOrderKey(book)] ?? 0xFFFFFFFF,
+              catalogueOrderByBookKey[catalogueOrderKey(book)] ??
+              unknownCatalogueOrder,
           generationOrder: chronologicalOrderForBook(book),
           extraFacets: _bookExtraFacets(book),
         ));

--- a/lib/indexing/repository/indexing_repository.dart
+++ b/lib/indexing/repository/indexing_repository.dart
@@ -11,6 +11,7 @@ import 'package:otzaria/data/data_providers/user_books_database_holder.dart';
 import 'package:otzaria/find_ref/repository/reference_books_cache.dart';
 import 'package:otzaria/indexing/utils/book_facet_metadata_cache.dart';
 import 'package:otzaria/indexing/utils/pdf_extraction_prefetcher.dart';
+import 'package:otzaria/indexing/models/catalogue_order_resolver.dart';
 import 'package:otzaria/indexing/models/indexing_run_result.dart';
 import 'package:otzaria/migration/database/repository/seforim_repository.dart';
 import 'package:otzaria/library/models/library.dart';
@@ -265,11 +266,7 @@ class IndexingRepository {
       final engineForBulk = await _tantivyDataProvider.engine;
       await engineForBulk.setBulkIndexing(enabled: true);
 
-      final catalogueOrderByBookKey =
-          SearchCatalogueOrderHelper.buildKeyOrderMap(
-            library,
-            keyOf: (book) => catalogueOrderKey(book as Book),
-          );
+      final catalogueOrder = buildCatalogueOrderResolver(library);
       await Future.wait([
         GenerationCache.instance.warmUp(),
         ReferenceBooksCache.instance.warmUp(),
@@ -317,7 +314,7 @@ class IndexingRepository {
           try {
             final droppedPages = await _indexPdfBook(
               readyBook,
-              catalogueOrderByBookKey: catalogueOrderByBookKey,
+              catalogueOrder: catalogueOrder,
               preExtracted: ready.extraction,
               onActualIndexingStarted: () {
                 if (didStartActualIndexing) return;
@@ -343,7 +340,7 @@ class IndexingRepository {
             final handled = await _markPermanentPdfFailure(
               readyBook,
               failure,
-              catalogueOrderByBookKey,
+              catalogueOrder,
               failures,
             );
             if (handled) {
@@ -372,7 +369,7 @@ class IndexingRepository {
               onProgress(bookIndex + 1, totalBooks);
               await _indexTextBook(
                 textBookForIndex,
-                catalogueOrderByBookKey: catalogueOrderByBookKey,
+                catalogueOrder: catalogueOrder,
                 onActualIndexingStarted: () {
                   if (didStartActualIndexing) {
                     return;
@@ -411,7 +408,7 @@ class IndexingRepository {
               );
               final droppedPages = await _indexPdfBook(
                 book,
-                catalogueOrderByBookKey: catalogueOrderByBookKey,
+                catalogueOrder: catalogueOrder,
                 preExtracted: preExtracted,
                 onActualIndexingStarted: () {
                   if (didStartActualIndexing) {
@@ -479,7 +476,7 @@ class IndexingRepository {
           final handled = await _markPermanentPdfFailure(
             book,
             failure,
-            catalogueOrderByBookKey,
+            catalogueOrder,
             failures,
           );
           if (handled) {
@@ -510,6 +507,7 @@ class IndexingRepository {
           ..start();
         await index.commit();
         debugPrint('💾 commit סופי: ${commitStopwatch.elapsedMilliseconds}ms');
+        _stampCatalogueOrderAfterCommit();
         final optimizeStopwatch = Stopwatch()..start();
         await optimizeIndexBestEffort(index.optimize);
         debugPrint('⚙️ optimize: ${optimizeStopwatch.elapsedMilliseconds}ms');
@@ -546,7 +544,7 @@ class IndexingRepository {
 
   Future<void> _indexTextBook(
     TextBook book, {
-    required Map<String, int> catalogueOrderByBookKey,
+    required CatalogueOrderResolver catalogueOrder,
     void Function()? onActualIndexingStarted,
   }) async {
     // כל הכנת הספר — פיצול לשורות, מעקב reference trail, נרמול, טביעת
@@ -592,9 +590,7 @@ class IndexingRepository {
       final title = book.title;
       final topics = _bookTopics(book);
       final filePath = buildIndexedBookFilePath(book);
-      final catalogueOrder =
-          catalogueOrderByBookKey[catalogueOrderKey(book)] ??
-          unknownCatalogueOrder;
+      final order = catalogueOrder.orderFor(catalogueOrderKey(book));
       final generationOrder = chronologicalOrderForBook(book);
       final engineStopwatch = Stopwatch()..start();
       final extraFacets = _bookExtraFacets(book);
@@ -603,7 +599,7 @@ class IndexingRepository {
               title: title,
               topics: topics,
               filePath: filePath,
-              catalogueOrder: catalogueOrder,
+              catalogueOrder: order,
               generationOrder: generationOrder,
               text: bytes,
               extraFacets: extraFacets,
@@ -612,7 +608,7 @@ class IndexingRepository {
               title: title,
               topics: topics,
               filePath: filePath,
-              catalogueOrder: catalogueOrder,
+              catalogueOrder: order,
               generationOrder: generationOrder,
               text: text!,
               extraFacets: extraFacets,
@@ -635,14 +631,14 @@ class IndexingRepository {
       // אין תוכן ⇒ אין טביעת אצבע; במסלול המלא המנוע חותם אותה בעצמו.
       await _writeEmptyBookMarker(
         book,
-        catalogueOrderByBookKey: catalogueOrderByBookKey,
+        catalogueOrder: catalogueOrder,
       );
     }
   }
 
   Future<int> _indexPdfBook(
     PdfBook book, {
-    required Map<String, int> catalogueOrderByBookKey,
+    required CatalogueOrderResolver catalogueOrder,
     void Function()? onActualIndexingStarted,
     Future<PdfExtraction>? preExtracted,
   }) async {
@@ -675,7 +671,7 @@ class IndexingRepository {
       added = await _addPdfBookToEngine(
         book,
         pages,
-        catalogueOrderByBookKey: catalogueOrderByBookKey,
+        catalogueOrder: catalogueOrder,
         onActualIndexingStarted: onActualIndexingStarted,
       );
     }
@@ -687,7 +683,7 @@ class IndexingRepository {
         added = await _addPdfBookToEngine(
           book,
           sidecarPages,
-          catalogueOrderByBookKey: catalogueOrderByBookKey,
+          catalogueOrder: catalogueOrder,
           onActualIndexingStarted: onActualIndexingStarted,
         );
       }
@@ -713,7 +709,7 @@ class IndexingRepository {
     if (added == 0) {
       await _writeEmptyBookMarker(
         book,
-        catalogueOrderByBookKey: catalogueOrderByBookKey,
+        catalogueOrder: catalogueOrder,
       );
     }
     return extracted.droppedPages;
@@ -742,7 +738,7 @@ class IndexingRepository {
   Future<int> _addPdfBookToEngine(
     PdfBook book,
     List<({String reference, String text, int pageIndex})> pages, {
-    required Map<String, int> catalogueOrderByBookKey,
+    required CatalogueOrderResolver catalogueOrder,
     void Function()? onActualIndexingStarted,
   }) async {
     onActualIndexingStarted?.call();
@@ -755,9 +751,7 @@ class IndexingRepository {
       title: book.title,
       topics: _bookTopics(book),
       filePath: buildIndexedBookFilePath(book),
-      catalogueOrder:
-          catalogueOrderByBookKey[catalogueOrderKey(book)] ??
-          unknownCatalogueOrder,
+      catalogueOrder: catalogueOrder.orderFor(catalogueOrderKey(book)),
       generationOrder: chronologicalOrderForBook(book),
       extraFacets: _bookExtraFacets(book),
       pages: [
@@ -783,7 +777,7 @@ class IndexingRepository {
   /// הפעלה. בלי זה, מצב האינדוקס (שנקרא מהאינדקס) לעולם לא היה שלם.
   Future<void> _writeEmptyBookMarker(
     Book book, {
-    required Map<String, int> catalogueOrderByBookKey,
+    required CatalogueOrderResolver catalogueOrder,
   }) async {
     if (!_tantivyDataProvider.isIndexing.value) {
       return;
@@ -795,9 +789,7 @@ class IndexingRepository {
       docs: [
         DocumentInput(
           id: buildCatalogueDocumentId(
-            catalogueOrder:
-                catalogueOrderByBookKey[catalogueOrderKey(book)] ??
-                unknownCatalogueOrder,
+            catalogueOrder: catalogueOrder.orderFor(catalogueOrderKey(book)),
             ordinal: 0,
           ),
           title: book.title,
@@ -816,7 +808,7 @@ class IndexingRepository {
   Future<bool> _markPermanentPdfFailure(
     Book book,
     IndexingFailure failure,
-    Map<String, int> catalogueOrderByBookKey,
+    CatalogueOrderResolver catalogueOrder,
     List<IndexingFailure> failures,
   ) async {
     if (book is! PdfBook || failure.isRetryable) return false;
@@ -825,7 +817,7 @@ class IndexingRepository {
     try {
       await _writeEmptyBookMarker(
         book,
-        catalogueOrderByBookKey: catalogueOrderByBookKey,
+        catalogueOrder: catalogueOrder,
       );
     } catch (error, stackTrace) {
       failures.add(
@@ -1173,10 +1165,24 @@ class IndexingRepository {
     }
   }
 
-  /// הסדר שניתן לספר שאינו נמצא במפת הסדר הקטלוגי — ממוין אחרי כל הספרים
-  /// המוכרים. לא 0xFFFFFFFF: [buildCatalogueDocumentId] מוסיף 1 לפני ההזזה,
-  /// והתוצאה הייתה חורגת מ-u64 ונחתכת בגשר ל-1 — כלומר ראש הרשימה.
-  static const int unknownCatalogueOrder = 0xFFFFFFFE;
+  /// משלים חותם סדר קטלוגי שכתיבתו נכשלה באתחול. בלעדיו האינדקס שזה עתה
+  /// נחתם ייראה בהפעלה הבאה כאילו נבנה בסדר ישן, והמשתמש יידרש לבנות מחדש.
+  void _stampCatalogueOrderAfterCommit() {
+    if (_tantivyDataProvider.ensureCatalogueOrderStamp()) return;
+    debugPrint(
+      '⚠️ חותם הסדר הקטלוגי לא נכתב — ההפעלה הבאה תדרוש בניית אינדקס מחדש',
+    );
+  }
+
+  /// מוסר הסדר הקטלוגי של הספרייה — הבסיס לחצי העליון של מזהה המסמך.
+  @visibleForTesting
+  static CatalogueOrderResolver buildCatalogueOrderResolver(Library library) =>
+      CatalogueOrderResolver(
+        SearchCatalogueOrderHelper.buildKeyOrderMap(
+          library,
+          keyOf: (book) => catalogueOrderKey(book as Book),
+        ),
+      );
 
   @visibleForTesting
   static BigInt buildCatalogueDocumentId({
@@ -1252,10 +1258,7 @@ class IndexingRepository {
     final text = await _loadTextBookText(textBook);
     if (text == null) return false;
 
-    final catalogueOrderByBookKey = SearchCatalogueOrderHelper.buildKeyOrderMap(
-      library,
-      keyOf: (candidate) => catalogueOrderKey(candidate as Book),
-    );
+    final catalogueOrder = buildCatalogueOrderResolver(library);
     await Future.wait([
       GenerationCache.instance.warmUp(),
       ReferenceBooksCache.instance.warmUp(),
@@ -1265,9 +1268,7 @@ class IndexingRepository {
           text: text,
           title: textBook.title,
           topics: _bookTopics(textBook),
-          catalogueOrder:
-              catalogueOrderByBookKey[catalogueOrderKey(textBook)] ??
-              unknownCatalogueOrder,
+          catalogueOrder: catalogueOrder.orderFor(catalogueOrderKey(textBook)),
           generationOrder: chronologicalOrderForBook(textBook),
           extraFacets: _bookExtraFacets(textBook),
         ) ==
@@ -1319,12 +1320,8 @@ class IndexingRepository {
       );
     }
 
-    // בנה מפת סדר קטלוג מהספרייה הטרייה שהועברה כפרמטר
-    // חשוב: משתמשים בספרייה המלאה כדי שהסדר הגלובלי יהיה נכון לכל הספרים
-    final catalogueOrderByBookKey = SearchCatalogueOrderHelper.buildKeyOrderMap(
-      library,
-      keyOf: (book) => catalogueOrderKey(book as Book),
-    );
+    // הספרייה המלאה, ולא רשימת הספרים שמאונדקסת, כדי שהסדר יהיה גלובלי.
+    final catalogueOrder = buildCatalogueOrderResolver(library);
     await Future.wait([
       GenerationCache.instance.warmUp(),
       ReferenceBooksCache.instance.warmUp(),
@@ -1356,7 +1353,7 @@ class IndexingRepository {
               debugPrint('📖 מאנדקס ספר טקסט חדש: ${book.title}');
               await _indexTextBook(
                 textBookForIndex,
-                catalogueOrderByBookKey: catalogueOrderByBookKey,
+                catalogueOrder: catalogueOrder,
                 onActualIndexingStarted: () {
                   if (didStartActualIndexing) return;
                   didStartActualIndexing = true;
@@ -1378,7 +1375,7 @@ class IndexingRepository {
               debugPrint('📄 מאנדקס PDF חדש: ${book.title}');
               final droppedPages = await _indexPdfBook(
                 book,
-                catalogueOrderByBookKey: catalogueOrderByBookKey,
+                catalogueOrder: catalogueOrder,
                 onActualIndexingStarted: () {
                   if (didStartActualIndexing) return;
                   didStartActualIndexing = true;
@@ -1409,7 +1406,7 @@ class IndexingRepository {
           final handled = await _markPermanentPdfFailure(
             book,
             failure,
-            catalogueOrderByBookKey,
+            catalogueOrder,
             failures,
           );
           if (!handled &&
@@ -1434,6 +1431,7 @@ class IndexingRepository {
         final commitStopwatch = Stopwatch()..start();
         await index.commit();
         debugPrint('💾 commit: ${commitStopwatch.elapsedMilliseconds}ms');
+        _stampCatalogueOrderAfterCommit();
       }
     } finally {
       await _setDbReadBoost(false);
@@ -1666,11 +1664,8 @@ class IndexingRepository {
 
     final textLoader = loadText ?? _loadTextBookText;
     // שחזור אותה חתימה קנונית שהאינדוקס חותם — טקסט + metadata (קטגוריה,
-    // סדר קטלוגי, דור, ממדי סינון) — דורש את אותם מפה ומטמונים.
-    final catalogueOrderByBookKey = SearchCatalogueOrderHelper.buildKeyOrderMap(
-      library,
-      keyOf: (book) => catalogueOrderKey(book as Book),
-    );
+    // סדר קטלוגי, דור, ממדי סינון) — דורש את אותם מוסר ומטמונים.
+    final catalogueOrder = buildCatalogueOrderResolver(library);
     await Future.wait([
       GenerationCache.instance.warmUp(),
       ReferenceBooksCache.instance.warmUp(),
@@ -1684,9 +1679,7 @@ class IndexingRepository {
           text: text,
           title: book.title,
           topics: _bookTopics(book),
-          catalogueOrder:
-              catalogueOrderByBookKey[catalogueOrderKey(book)] ??
-              unknownCatalogueOrder,
+          catalogueOrder: catalogueOrder.orderFor(catalogueOrderKey(book)),
           generationOrder: chronologicalOrderForBook(book),
           extraFacets: _bookExtraFacets(book),
         ));

--- a/lib/indexing/repository/indexing_repository.dart
+++ b/lib/indexing/repository/indexing_repository.dart
@@ -450,6 +450,9 @@ class IndexingRepository {
             debugPrint(
               '💾 commit אחרי $indexedSinceCommit ספרים: ${commitStopwatch.elapsedMilliseconds}ms',
             );
+            // גם כאן, ולא רק ב-commit הסופי: ביטול או קריסה אחרי מאות
+            // ספרים שנשמרו היו מותירים אינדקס מלא בלי חותם.
+            _stampCatalogueOrderAfterCommit();
             indexedSinceCommit = 0;
           }
 

--- a/lib/search/utils/search_catalogue_order_helper.dart
+++ b/lib/search/utils/search_catalogue_order_helper.dart
@@ -68,15 +68,17 @@ class SearchCatalogueOrderHelper {
         );
       }
 
-      for (final subCategory in sortedSubCategories) {
-        collectBooks(subCategory);
-      }
-
+      // ספרי הקטגוריה קודמים לתת-הקטגוריות: "מפרשים" הוא תת-קטגוריה של
+      // הספר שהוא מפרש, וסריקתו קודם הציבה את המפרשים לפני המדרש עצמו.
       final sortedBooks = category.books.toList()
         ..sort((a, b) => a.order.compareTo(b.order));
 
       for (final book in sortedBooks) {
         orderedKeys.add(keyOf(book));
+      }
+
+      for (final subCategory in sortedSubCategories) {
+        collectBooks(subCategory);
       }
     }
 

--- a/test/data_providers/catalogue_order_revision_test.dart
+++ b/test/data_providers/catalogue_order_revision_test.dart
@@ -1,0 +1,197 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/data/data_providers/catalogue_order_revision.dart';
+import 'package:path/path.dart' as p;
+
+void main() {
+  group('CatalogueOrderRevision.shouldStamp', () {
+    test('אינדקס ריק שמצבו ידוע — נחתם', () {
+      expect(
+        CatalogueOrderRevision.shouldStamp(
+          indexStateIsKnown: true,
+          hasIndexedBooks: false,
+        ),
+        isTrue,
+      );
+    });
+
+    test('אינדקס מלא לעולם אינו נחתם — חתימה הייתה מכריזה סדר ישן כתקין', () {
+      expect(
+        CatalogueOrderRevision.shouldStamp(
+          indexStateIsKnown: true,
+          hasIndexedBooks: true,
+        ),
+        isFalse,
+      );
+    });
+
+    test('מצב לא ידוע אינו נחתם גם כשהרשימה ריקה', () {
+      // כשל קריאת הספרים או מנוע על אינדקס זמני משאירים רשימה ריקה בלי
+      // שהאינדקס שבדיסק ריק — חתימה כאן הייתה מנטרלת את המנגנון לצמיתות.
+      expect(
+        CatalogueOrderRevision.shouldStamp(
+          indexStateIsKnown: false,
+          hasIndexedBooks: false,
+        ),
+        isFalse,
+      );
+    });
+  });
+
+  group('CatalogueOrderRevision.isStale', () {
+    test('מצב לא ידוע אינו מכריז מיושן — לא מוחקים אינדקס על סמך ספק', () {
+      expect(
+        CatalogueOrderRevision.isStale(
+          storedRevision: null,
+          hasIndexedBooks: true,
+          indexStateIsKnown: false,
+        ),
+        isFalse,
+      );
+    });
+
+    test('אינדקס בלי ספרים לעולם אינו מיושן', () {
+      expect(
+        CatalogueOrderRevision.isStale(
+          storedRevision: null,
+          hasIndexedBooks: false,
+        ),
+        isFalse,
+      );
+      expect(
+        CatalogueOrderRevision.isStale(
+          storedRevision: 1,
+          hasIndexedBooks: false,
+        ),
+        isFalse,
+      );
+    });
+
+    test('אינדקס קיים בלי חותם גרסה מיושן — זה מצב המשתמש המשדרג', () {
+      expect(
+        CatalogueOrderRevision.isStale(
+          storedRevision: null,
+          hasIndexedBooks: true,
+        ),
+        isTrue,
+      );
+    });
+
+    test('אינדקס קיים עם גרסה ישנה מיושן', () {
+      expect(
+        CatalogueOrderRevision.isStale(
+          storedRevision: kCatalogueOrderRevision - 1,
+          hasIndexedBooks: true,
+        ),
+        isTrue,
+      );
+    });
+
+    test('אינדקס קיים עם הגרסה הנוכחית אינו מיושן', () {
+      expect(
+        CatalogueOrderRevision.isStale(
+          storedRevision: kCatalogueOrderRevision,
+          hasIndexedBooks: true,
+        ),
+        isFalse,
+      );
+    });
+
+    test('גרסה עתידית (חזרה לגרסה ישנה של התוכנה) מחייבת בנייה מחדש', () {
+      expect(
+        CatalogueOrderRevision.isStale(
+          storedRevision: kCatalogueOrderRevision + 1,
+          hasIndexedBooks: true,
+        ),
+        isTrue,
+      );
+    });
+  });
+
+  group('CatalogueOrderRevision קריאה וכתיבה', () {
+    late Directory tempDir;
+
+    setUp(() {
+      tempDir = Directory.systemTemp.createTempSync('otzaria_cat_rev_');
+    });
+
+    tearDown(() {
+      if (tempDir.existsSync()) {
+        tempDir.deleteSync(recursive: true);
+      }
+    });
+
+    test('read מחזיר null כשאין קובץ', () {
+      expect(CatalogueOrderRevision.read(tempDir.path), isNull);
+    });
+
+    test('write ואז read מחזירים את הגרסה הנוכחית', () {
+      expect(CatalogueOrderRevision.write(tempDir.path), isTrue);
+
+      expect(
+        CatalogueOrderRevision.read(tempDir.path),
+        kCatalogueOrderRevision,
+      );
+      expect(CatalogueOrderRevision.fileFor(tempDir.path).existsSync(), isTrue);
+    });
+
+    test('write אינו מותיר קובץ זמני אחריו', () {
+      CatalogueOrderRevision.write(tempDir.path);
+
+      final leftovers = tempDir
+          .listSync()
+          .map((entity) => p.basename(entity.path))
+          .where((name) => name.endsWith('.tmp'))
+          .toList();
+      expect(leftovers, isEmpty);
+    });
+
+    test('write חוזר על עצמו דורס את החותם הקודם', () {
+      CatalogueOrderRevision.write(tempDir.path, revision: 1);
+      expect(CatalogueOrderRevision.write(tempDir.path), isTrue);
+
+      expect(
+        CatalogueOrderRevision.read(tempDir.path),
+        kCatalogueOrderRevision,
+      );
+    });
+
+    test('write יוצר את תיקיית האינדקס אם אינה קיימת', () {
+      final nested = '${tempDir.path}${Platform.pathSeparator}index';
+
+      CatalogueOrderRevision.write(nested);
+
+      expect(CatalogueOrderRevision.read(nested), kCatalogueOrderRevision);
+    });
+
+    test('קובץ פגום נקרא כ-null ולא זורק', () {
+      CatalogueOrderRevision.fileFor(
+        tempDir.path,
+      ).writeAsStringSync('not json at all');
+
+      expect(CatalogueOrderRevision.read(tempDir.path), isNull);
+    });
+
+    test('JSON תקין בלי המפתח נקרא כ-null', () {
+      CatalogueOrderRevision.fileFor(
+        tempDir.path,
+      ).writeAsStringSync(jsonEncode({'other': 5}));
+
+      expect(CatalogueOrderRevision.read(tempDir.path), isNull);
+    });
+
+    test('גרסה ישנה שנכתבה נקראת כמיושנת', () {
+      CatalogueOrderRevision.write(tempDir.path, revision: 1);
+
+      expect(
+        CatalogueOrderRevision.isStale(
+          storedRevision: CatalogueOrderRevision.read(tempDir.path),
+          hasIndexedBooks: true,
+        ),
+        isTrue,
+      );
+    });
+  });
+}

--- a/test/data_providers/catalogue_order_revision_test.dart
+++ b/test/data_providers/catalogue_order_revision_test.dart
@@ -182,6 +182,27 @@ void main() {
       expect(CatalogueOrderRevision.read(tempDir.path), isNull);
     });
 
+    test('כתיבה שנכשלה מחזירה false ואינה מותירה חותם', () {
+      // רגרסיה: ערך ההחזרה נבלע, האינדקס המלא נבנה בלי חותם, ובהפעלה
+      // הבאה זוהה כישן — המשתמש נדרש למחוק ולבנות הכול מחדש.
+      final blocked = p.join(tempDir.path, 'index');
+      File(blocked).writeAsStringSync('קובץ במקום תיקיית האינדקס');
+
+      expect(CatalogueOrderRevision.write(blocked), isFalse);
+      expect(CatalogueOrderRevision.read(blocked), isNull);
+    });
+
+    test('כתיבה חוזרת אחרי כשל משלימה את החותם', () {
+      final blocked = p.join(tempDir.path, 'index');
+      final blocker = File(blocked)..writeAsStringSync('חוסם');
+      expect(CatalogueOrderRevision.write(blocked), isFalse);
+
+      blocker.deleteSync();
+
+      expect(CatalogueOrderRevision.write(blocked), isTrue);
+      expect(CatalogueOrderRevision.read(blocked), kCatalogueOrderRevision);
+    });
+
     test('גרסה ישנה שנכתבה נקראת כמיושנת', () {
       CatalogueOrderRevision.write(tempDir.path, revision: 1);
 

--- a/test/indexing/models/catalogue_order_resolver_test.dart
+++ b/test/indexing/models/catalogue_order_resolver_test.dart
@@ -1,0 +1,84 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/indexing/models/catalogue_order_resolver.dart';
+
+void main() {
+  group('CatalogueOrderResolver', () {
+    test('ספר שבספרייה מקבל את הסדר שנקבע לו', () {
+      final resolver = CatalogueOrderResolver({'id:1': 0, 'id:2': 1});
+
+      expect(resolver.orderFor('id:1'), 0);
+      expect(resolver.orderFor('id:2'), 1);
+      expect(resolver.fallbackKeys, isEmpty);
+    });
+
+    test('שני ספרים שאינם בספרייה מקבלים סדר שונה', () {
+      // רגרסיה: סדר משותף ⇒ מזהי מסמך זהים, והמנוע מוחק לפי id — כתיבת
+      // ספר אחד הייתה מוחקת את מסמכי האחר, והם חלקו גם sectionId.
+      final resolver = CatalogueOrderResolver({'id:1': 0, 'id:2': 1});
+
+      final first = resolver.orderFor('uid:404');
+      final second = resolver.orderFor('uid:405');
+
+      expect(first, isNot(second));
+      expect(resolver.fallbackKeys, {'uid:404', 'uid:405'});
+    });
+
+    test('הסדר החלופי בא אחרי הספר האחרון שבספרייה', () {
+      final resolver = CatalogueOrderResolver({'id:1': 0, 'id:2': 7});
+
+      expect(resolver.orderFor('uid:404'), 8);
+      expect(resolver.orderFor('uid:405'), 9);
+    });
+
+    test('מפתח חסר חוזר מחזיר את אותו סדר — לא מקצה חדש בכל קריאה', () {
+      final resolver = CatalogueOrderResolver({'id:1': 0});
+
+      final first = resolver.orderFor('uid:404');
+
+      expect(resolver.orderFor('uid:404'), first);
+      expect(resolver.fallbackKeys, hasLength(1));
+    });
+
+    test('ספרייה ריקה — הסדר החלופי מתחיל מאפס', () {
+      final resolver = CatalogueOrderResolver({});
+
+      expect(resolver.orderFor('uid:404'), 0);
+      expect(resolver.orderFor('uid:405'), 1);
+    });
+
+    test('מזהי המסמכים של שני ספרים חסרים אינם מתנגשים באותה שורה', () {
+      final resolver = CatalogueOrderResolver({'id:1': 0});
+
+      final ids = {
+        for (final key in ['uid:404', 'uid:405'])
+          key: [
+            for (var line = 0; line < 3; line++)
+              (BigInt.from(resolver.orderFor(key) + 1) << 32) +
+                  BigInt.from(line + 1),
+          ],
+      };
+
+      expect(
+        ids['uid:404']!.toSet().intersection(ids['uid:405']!.toSet()),
+        isEmpty,
+      );
+    });
+
+    test('חריגה מטווח הסדר זורקת במקום לגלוש מעבר ל-u64', () {
+      final resolver = CatalogueOrderResolver({
+        'id:1': CatalogueOrderResolver.maxCatalogueOrder,
+      });
+
+      expect(() => resolver.orderFor('uid:404'), throwsStateError);
+    });
+
+    test('הסדר המרבי נשאר בתוך u64 גם בשורות מאוחרות', () {
+      final u64Max = (BigInt.one << 64) - BigInt.one;
+      final id =
+          (BigInt.from(CatalogueOrderResolver.maxCatalogueOrder + 1) << 32) +
+          BigInt.from(1000000);
+
+      expect(id, lessThanOrEqualTo(u64Max));
+    });
+  });
+}

--- a/test/indexing/models/catalogue_order_resolver_test.dart
+++ b/test/indexing/models/catalogue_order_resolver_test.dart
@@ -23,13 +23,6 @@ void main() {
       expect(resolver.fallbackKeys, {'uid:404', 'uid:405'});
     });
 
-    test('הסדר החלופי בא אחרי הספר האחרון שבספרייה', () {
-      final resolver = CatalogueOrderResolver({'id:1': 0, 'id:2': 7});
-
-      expect(resolver.orderFor('uid:404'), 8);
-      expect(resolver.orderFor('uid:405'), 9);
-    });
-
     test('מפתח חסר חוזר מחזיר את אותו סדר — לא מקצה חדש בכל קריאה', () {
       final resolver = CatalogueOrderResolver({'id:1': 0});
 
@@ -37,13 +30,6 @@ void main() {
 
       expect(resolver.orderFor('uid:404'), first);
       expect(resolver.fallbackKeys, hasLength(1));
-    });
-
-    test('ספרייה ריקה — הסדר החלופי מתחיל מאפס', () {
-      final resolver = CatalogueOrderResolver({});
-
-      expect(resolver.orderFor('uid:404'), 0);
-      expect(resolver.orderFor('uid:405'), 1);
     });
 
     test('מזהי המסמכים של שני ספרים חסרים אינם מתנגשים באותה שורה', () {
@@ -64,12 +50,61 @@ void main() {
       );
     });
 
-    test('חריגה מטווח הסדר זורקת במקום לגלוש מעבר ל-u64', () {
-      final resolver = CatalogueOrderResolver({
-        'id:1': CatalogueOrderResolver.maxCatalogueOrder,
-      });
+    test('הסדר החלופי ממוין אחרי כל ספר אפשרי בספרייה', () {
+      final resolver = CatalogueOrderResolver({'id:1': 0, 'id:2': 7});
 
-      expect(() => resolver.orderFor('uid:404'), throwsStateError);
+      // מיליון ספרים הוא הרבה מעבר לספרייה בפועל, והטווח השמור מעליהם.
+      expect(resolver.orderFor('uid:404'), greaterThan(1000000));
+      expect(
+        resolver.orderFor('uid:404'),
+        lessThanOrEqualTo(CatalogueOrderResolver.maxCatalogueOrder),
+      );
+    });
+
+    test('אותו מפתח מקבל אותו סדר במוסרים נפרדים — יציב בין ריצות', () {
+      // רגרסיה: הקצאה לפי מונה רץ נתנה לספר חסר סדר שתלוי במי נשאל לפניו,
+      // ולכן ריצה אחרת חילקה אותו סדר לספר אחר — מזהי מסמך מתנגשים.
+      final first = CatalogueOrderResolver({'id:1': 0});
+      final second = CatalogueOrderResolver({'id:1': 0, 'id:2': 1, 'id:3': 2});
+
+      first.orderFor('uid:999');
+
+      expect(second.orderFor('uid:404'), first.orderFor('uid:404'));
+    });
+
+    test('סדר הקריאות אינו משפיע על הסדר שמוקצה', () {
+      final ascending = CatalogueOrderResolver({'id:1': 0});
+      final descending = CatalogueOrderResolver({'id:1': 0});
+
+      ascending.orderFor('uid:404');
+      ascending.orderFor('uid:405');
+      descending.orderFor('uid:405');
+      descending.orderFor('uid:404');
+
+      expect(ascending.orderFor('uid:404'), descending.orderFor('uid:404'));
+      expect(ascending.orderFor('uid:405'), descending.orderFor('uid:405'));
+    });
+
+    test('הגיבוב יציב ואינו נשען על hashCode', () {
+      expect(
+        CatalogueOrderResolver.stableFallbackHash('uid:404'),
+        CatalogueOrderResolver.stableFallbackHash('uid:404'),
+      );
+      expect(
+        CatalogueOrderResolver.stableFallbackHash('uid:404'),
+        isNot(CatalogueOrderResolver.stableFallbackHash('uid:405')),
+      );
+      // ערך מקובע: שינוי במימוש הגיבוב משנה מזהים שכבר נצרבו לאינדקס.
+      expect(CatalogueOrderResolver.stableFallbackHash(''), 0x811C9DC5);
+    });
+
+    test('התנגשות גיבוב אינה מייצרת סדר כפול', () {
+      final resolver = CatalogueOrderResolver({'id:1': 0});
+      final orders = {
+        for (var i = 0; i < 500; i++) resolver.orderFor('uid:$i'),
+      };
+
+      expect(orders, hasLength(500));
     });
 
     test('הסדר המרבי נשאר בתוך u64 גם בשורות מאוחרות', () {

--- a/test/indexing/models/catalogue_order_resolver_test.dart
+++ b/test/indexing/models/catalogue_order_resolver_test.dart
@@ -8,112 +8,57 @@ void main() {
 
       expect(resolver.orderFor('id:1'), 0);
       expect(resolver.orderFor('id:2'), 1);
-      expect(resolver.fallbackKeys, isEmpty);
     });
 
-    test('שני ספרים שאינם בספרייה מקבלים סדר שונה', () {
-      // רגרסיה: סדר משותף ⇒ מזהי מסמך זהים, והמנוע מוחק לפי id — כתיבת
-      // ספר אחד הייתה מוחקת את מסמכי האחר, והם חלקו גם sectionId.
-      final resolver = CatalogueOrderResolver({'id:1': 0, 'id:2': 1});
-
-      final first = resolver.orderFor('uid:404');
-      final second = resolver.orderFor('uid:405');
-
-      expect(first, isNot(second));
-      expect(resolver.fallbackKeys, {'uid:404', 'uid:405'});
-    });
-
-    test('מפתח חסר חוזר מחזיר את אותו סדר — לא מקצה חדש בכל קריאה', () {
+    test('ספר שאינו במפת הקטלוג נדחה לפני יצירת מזהה מסמך', () {
       final resolver = CatalogueOrderResolver({'id:1': 0});
 
-      final first = resolver.orderFor('uid:404');
-
-      expect(resolver.orderFor('uid:404'), first);
-      expect(resolver.fallbackKeys, hasLength(1));
+      expect(
+        () => resolver.orderFor('uid:404'),
+        throwsA(
+          isA<StateError>().having(
+            (error) => error.message,
+            'message',
+            contains('uid:404'),
+          ),
+        ),
+      );
     });
 
-    test('מזהי המסמכים של שני ספרים חסרים אינם מתנגשים באותה שורה', () {
+    test('מפתחות בעלי גיבוב זהה אינם מקבלים סדר משותף או תלוי-קריאה', () {
       final resolver = CatalogueOrderResolver({'id:1': 0});
 
-      final ids = {
-        for (final key in ['uid:404', 'uid:405'])
-          key: [
-            for (var line = 0; line < 3; line++)
-              (BigInt.from(resolver.orderFor(key) + 1) << 32) +
-                  BigInt.from(line + 1),
-          ],
-      };
+      for (final key in const [
+        'uid:1h5o88x:yde',
+        'uid:1x7q2cs:18w3',
+      ]) {
+        expect(() => resolver.orderFor(key), throwsStateError);
+      }
+    });
+
+    test('הסדר המרבי החוקי מתקבל', () {
+      final resolver = CatalogueOrderResolver({
+        'id:last': CatalogueOrderResolver.maxCatalogueOrder,
+      });
 
       expect(
-        ids['uid:404']!.toSet().intersection(ids['uid:405']!.toSet()),
-        isEmpty,
+        resolver.orderFor('id:last'),
+        CatalogueOrderResolver.maxCatalogueOrder,
       );
     });
 
-    test('הסדר החלופי ממוין אחרי כל ספר אפשרי בספרייה', () {
-      final resolver = CatalogueOrderResolver({'id:1': 0, 'id:2': 7});
+    test('סדר שחורג מטווח u64 נדחה לפני המעבר למנוע', () {
+      final resolver = CatalogueOrderResolver({
+        'id:overflow': CatalogueOrderResolver.maxCatalogueOrder + 1,
+      });
 
-      // מיליון ספרים הוא הרבה מעבר לספרייה בפועל, והטווח השמור מעליהם.
-      expect(resolver.orderFor('uid:404'), greaterThan(1000000));
-      expect(
-        resolver.orderFor('uid:404'),
-        lessThanOrEqualTo(CatalogueOrderResolver.maxCatalogueOrder),
-      );
+      expect(() => resolver.orderFor('id:overflow'), throwsRangeError);
     });
 
-    test('אותו מפתח מקבל אותו סדר במוסרים נפרדים — יציב בין ריצות', () {
-      // רגרסיה: הקצאה לפי מונה רץ נתנה לספר חסר סדר שתלוי במי נשאל לפניו,
-      // ולכן ריצה אחרת חילקה אותו סדר לספר אחר — מזהי מסמך מתנגשים.
-      final first = CatalogueOrderResolver({'id:1': 0});
-      final second = CatalogueOrderResolver({'id:1': 0, 'id:2': 1, 'id:3': 2});
+    test('סדר שלילי נדחה', () {
+      final resolver = CatalogueOrderResolver({'id:negative': -1});
 
-      first.orderFor('uid:999');
-
-      expect(second.orderFor('uid:404'), first.orderFor('uid:404'));
-    });
-
-    test('סדר הקריאות אינו משפיע על הסדר שמוקצה', () {
-      final ascending = CatalogueOrderResolver({'id:1': 0});
-      final descending = CatalogueOrderResolver({'id:1': 0});
-
-      ascending.orderFor('uid:404');
-      ascending.orderFor('uid:405');
-      descending.orderFor('uid:405');
-      descending.orderFor('uid:404');
-
-      expect(ascending.orderFor('uid:404'), descending.orderFor('uid:404'));
-      expect(ascending.orderFor('uid:405'), descending.orderFor('uid:405'));
-    });
-
-    test('הגיבוב יציב ואינו נשען על hashCode', () {
-      expect(
-        CatalogueOrderResolver.stableFallbackHash('uid:404'),
-        CatalogueOrderResolver.stableFallbackHash('uid:404'),
-      );
-      expect(
-        CatalogueOrderResolver.stableFallbackHash('uid:404'),
-        isNot(CatalogueOrderResolver.stableFallbackHash('uid:405')),
-      );
-      // ערך מקובע: שינוי במימוש הגיבוב משנה מזהים שכבר נצרבו לאינדקס.
-      expect(CatalogueOrderResolver.stableFallbackHash(''), 0x811C9DC5);
-    });
-
-    test('התנגשות גיבוב אינה מייצרת סדר כפול', () {
-      final resolver = CatalogueOrderResolver({'id:1': 0});
-      final orders = {
-        for (var i = 0; i < 500; i++) resolver.orderFor('uid:$i'),
-      };
-
-      expect(orders, hasLength(500));
-    });
-
-    test('הסדר המרבי נשאר בתוך u64 גם בשורות מאוחרות', () {
-      final u64Max = (BigInt.one << 64) - BigInt.one;
-      final id =
-          (BigInt.from(CatalogueOrderResolver.maxCatalogueOrder + 1) << 32) +
-          BigInt.from(1000000);
-
-      expect(id, lessThanOrEqualTo(u64Max));
+      expect(() => resolver.orderFor('id:negative'), throwsRangeError);
     });
   });
 }

--- a/test/indexing/repository/indexing_repository_test.dart
+++ b/test/indexing/repository/indexing_repository_test.dart
@@ -1461,6 +1461,37 @@ void main() {
 
       expect(earlierBookLateSegment, lessThan(laterBookFirstSegment));
     });
+
+    test('מזהה של ספר שאינו במפת הסדר נכנס ב-u64 וממוין אחרון', () {
+      final u64Max = (BigInt.one << 64) - BigInt.one;
+      final unknownBook = IndexingRepository.buildCatalogueDocumentId(
+        catalogueOrder: IndexingRepository.unknownCatalogueOrder,
+        ordinal: 0,
+      );
+
+      // חריגה מ-u64 נחתכת בגשר ל-Rust ומתגלגלת למזהה 1 — הספר היה קופץ
+      // לראש תוצאות החיפוש במקום להישאר אחרון.
+      expect(unknownBook, lessThanOrEqualTo(u64Max));
+      expect(
+        IndexingRepository.buildCatalogueDocumentId(
+          catalogueOrder: 100000,
+          ordinal: 0,
+        ),
+        lessThan(unknownBook),
+      );
+    });
+
+    test('מזהה של ספר לא ידוע נשאר בתוך u64 גם בשורות מאוחרות', () {
+      final u64Max = (BigInt.one << 64) - BigInt.one;
+
+      expect(
+        IndexingRepository.buildCatalogueDocumentId(
+          catalogueOrder: IndexingRepository.unknownCatalogueOrder,
+          ordinal: 1000000,
+        ),
+        lessThanOrEqualTo(u64Max),
+      );
+    });
   });
 
   group('IndexingRepository.catalogueOrderKey', () {

--- a/test/indexing/repository/indexing_repository_test.dart
+++ b/test/indexing/repository/indexing_repository_test.dart
@@ -671,6 +671,47 @@ void main() {
       expect(provider.indexedFilePaths, isEmpty);
     });
 
+    test('אחרי commit מוצלח מושלם חותם הסדר הקטלוגי שנכשל באתחול', () async {
+      // רגרסיה: חותם שלא נכתב באתחול הותיר את האינדקס המלא "ישן" בהפעלה
+      // הבאה, והמשתמש נדרש למחוק ולבנות הכול מחדש.
+      final engine = _RecordingSearchEngine();
+      final provider = _RecordingTantivyDataProvider(engine);
+      final library = Library(categories: []);
+      library.books.add(
+        PdfBook(title: 'שבת', path: r'C:ooks\שבת.pdf', id: 7),
+      );
+      final repository = IndexingRepository(provider);
+
+      await repository.indexAllBooks(
+        library,
+        includePdfBooks: false,
+        onProgress: (_, _) {},
+      );
+
+      expect(provider.ensureCatalogueOrderStampCount, 1);
+    });
+
+    test('commit שנכשל אינו נחתם — החותם מעיד על אינדקס שנשמר', () async {
+      final engine = _RecordingSearchEngine()..failCommit = true;
+      final provider = _RecordingTantivyDataProvider(engine);
+      final library = Library(categories: []);
+      library.books.add(
+        PdfBook(title: 'שבת', path: r'C:ooks\שבת.pdf', id: 7),
+      );
+      final repository = IndexingRepository(provider);
+
+      await expectLater(
+        repository.indexAllBooks(
+          library,
+          includePdfBooks: false,
+          onProgress: (_, _) {},
+        ),
+        throwsA(anything),
+      );
+
+      expect(provider.ensureCatalogueOrderStampCount, 0);
+    });
+
     test('fast path מחזיר מוקדם בלי להפעיל isolate ובלי callbacks', () async {
       final library = _buildLibrary(bavliBooks: const [('שבת', 1)]);
       final indexedFilePaths = library
@@ -1462,35 +1503,47 @@ void main() {
       expect(earlierBookLateSegment, lessThan(laterBookFirstSegment));
     });
 
-    test('מזהה של ספר שאינו במפת הסדר נכנס ב-u64 וממוין אחרון', () {
+    test('ספר שאינו בספרייה נכנס ב-u64 וממוין אחרי הספר האחרון', () {
       final u64Max = (BigInt.one << 64) - BigInt.one;
-      final unknownBook = IndexingRepository.buildCatalogueDocumentId(
-        catalogueOrder: IndexingRepository.unknownCatalogueOrder,
-        ordinal: 0,
+      final library = _buildLibrary(bavliBooks: const [('שבת', 1)]);
+      final resolver = IndexingRepository.buildCatalogueOrderResolver(library);
+      final lastKnown = resolver.orderFor(
+        IndexingRepository.catalogueOrderKey(library.getAllBooks().last),
       );
 
       // חריגה מ-u64 נחתכת בגשר ל-Rust ומתגלגלת למזהה 1 — הספר היה קופץ
       // לראש תוצאות החיפוש במקום להישאר אחרון.
+      final unknownBook = IndexingRepository.buildCatalogueDocumentId(
+        catalogueOrder: resolver.orderFor('uid:404'),
+        ordinal: 1000000,
+      );
+
       expect(unknownBook, lessThanOrEqualTo(u64Max));
       expect(
         IndexingRepository.buildCatalogueDocumentId(
-          catalogueOrder: 100000,
+          catalogueOrder: lastKnown,
           ordinal: 0,
         ),
         lessThan(unknownBook),
       );
     });
 
-    test('מזהה של ספר לא ידוע נשאר בתוך u64 גם בשורות מאוחרות', () {
-      final u64Max = (BigInt.one << 64) - BigInt.one;
+    test('שני ספרים שאינם בספרייה מקבלים מזהים שונים באותה שורה', () {
+      // רגרסיה: מזהה משותף הפר את חוזה המנוע — מחיקה לפי id בכתיבת ספר
+      // אחד מחקה את מסמכי האחר, והשניים חלקו גם sectionId.
+      final library = _buildLibrary(bavliBooks: const [('שבת', 1)]);
+      final resolver = IndexingRepository.buildCatalogueOrderResolver(library);
 
-      expect(
-        IndexingRepository.buildCatalogueDocumentId(
-          catalogueOrder: IndexingRepository.unknownCatalogueOrder,
-          ordinal: 1000000,
-        ),
-        lessThanOrEqualTo(u64Max),
+      final first = IndexingRepository.buildCatalogueDocumentId(
+        catalogueOrder: resolver.orderFor('uid:404'),
+        ordinal: 0,
       );
+      final second = IndexingRepository.buildCatalogueDocumentId(
+        catalogueOrder: resolver.orderFor('uid:405'),
+        ordinal: 0,
+      );
+
+      expect(first, isNot(second));
     });
   });
 
@@ -1715,6 +1768,16 @@ class _RecordingTantivyDataProvider implements TantivyDataProvider {
 
   @override
   bool get requiresManualReindex => false;
+
+  /// כמו האמיתי: משלים חותם סדר קטלוגי שכתיבתו נכשלה באתחול.
+  int ensureCatalogueOrderStampCount = 0;
+  bool catalogueOrderStampWriteSucceeds = true;
+
+  @override
+  bool ensureCatalogueOrderStamp() {
+    ensureCatalogueOrderStampCount++;
+    return catalogueOrderStampWriteSucceeds;
+  }
 
   @override
   Future<SearchEngine> get engine async => _engine;

--- a/test/indexing/repository/indexing_repository_test.dart
+++ b/test/indexing/repository/indexing_repository_test.dart
@@ -7,6 +7,7 @@ import 'dart:typed_data';
 import 'package:flutter/foundation.dart' show ValueNotifier;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:otzaria/data/data_providers/tantivy_data_provider.dart';
+import 'package:otzaria/indexing/models/catalogue_order_resolver.dart';
 import 'package:otzaria/indexing/models/indexing_run_result.dart';
 import 'package:otzaria/indexing/repository/indexing_repository.dart';
 import 'package:otzaria/indexing/utils/pdf_extraction_prefetcher.dart';
@@ -678,7 +679,7 @@ void main() {
       final provider = _RecordingTantivyDataProvider(engine);
       final library = Library(categories: []);
       library.books.add(
-        PdfBook(title: 'שבת', path: r'C:ooks\שבת.pdf', id: 7),
+        PdfBook(title: 'שבת', path: r'C:\books\שבת.pdf', id: 7),
       );
       final repository = IndexingRepository(provider);
 
@@ -696,7 +697,7 @@ void main() {
       final provider = _RecordingTantivyDataProvider(engine);
       final library = Library(categories: []);
       library.books.add(
-        PdfBook(title: 'שבת', path: r'C:ooks\שבת.pdf', id: 7),
+        PdfBook(title: 'שבת', path: r'C:\books\שבת.pdf', id: 7),
       );
       final repository = IndexingRepository(provider);
 
@@ -1503,65 +1504,22 @@ void main() {
       expect(earlierBookLateSegment, lessThan(laterBookFirstSegment));
     });
 
-    test('ספר חסר מקבל אותו מזהה בכל ריצה — יציב בין הפעלות', () {
-      // רגרסיה: סדר חלופי לפי מונה רץ השתנה בין ריצות, ולכן ריצה אחרת
-      // חילקה אותו סדר לספר חסר אחר — מזהי מסמך מתנגשים.
-      final small = _buildLibrary(bavliBooks: const [('שבת', 1)]);
-      final grown = _buildLibrary(
-        bavliBooks: const [('שבת', 1), ('עירובין', 2)],
-      );
-
-      expect(
-        IndexingRepository.buildCatalogueOrderResolver(
-          grown,
-        ).orderFor('id:404'),
-        IndexingRepository.buildCatalogueOrderResolver(
-          small,
-        ).orderFor('id:404'),
-      );
-    });
-
-    test('ספר שאינו בספרייה נכנס ב-u64 וממוין אחרי הספר האחרון', () {
+    test('הסדר המרבי החוקי יוצר מזהה שנכנס ב-u64', () {
       final u64Max = (BigInt.one << 64) - BigInt.one;
-      final library = _buildLibrary(bavliBooks: const [('שבת', 1)]);
-      final resolver = IndexingRepository.buildCatalogueOrderResolver(library);
-      final lastKnown = resolver.orderFor(
-        IndexingRepository.catalogueOrderKey(library.getAllBooks().last),
+      final documentId = IndexingRepository.buildCatalogueDocumentId(
+        catalogueOrder: CatalogueOrderResolver.maxCatalogueOrder,
+        ordinal: 0,
       );
 
-      // חריגה מ-u64 נחתכת בגשר ל-Rust ומתגלגלת למזהה 1 — הספר היה קופץ
-      // לראש תוצאות החיפוש במקום להישאר אחרון.
-      final unknownBook = IndexingRepository.buildCatalogueDocumentId(
-        catalogueOrder: resolver.orderFor('uid:404'),
-        ordinal: 1000000,
-      );
-
-      expect(unknownBook, lessThanOrEqualTo(u64Max));
-      expect(
-        IndexingRepository.buildCatalogueDocumentId(
-          catalogueOrder: lastKnown,
-          ordinal: 0,
-        ),
-        lessThan(unknownBook),
-      );
+      expect(documentId, u64Max - BigInt.from(0xFFFFFFFE));
+      expect(documentId, lessThanOrEqualTo(u64Max));
     });
 
-    test('שני ספרים שאינם בספרייה מקבלים מזהים שונים באותה שורה', () {
-      // רגרסיה: מזהה משותף הפר את חוזה המנוע — מחיקה לפי id בכתיבת ספר
-      // אחד מחקה את מסמכי האחר, והשניים חלקו גם sectionId.
+    test('ספר שאינו במפת הספרייה נדחה לפני יצירת מזהה מסמך', () {
       final library = _buildLibrary(bavliBooks: const [('שבת', 1)]);
       final resolver = IndexingRepository.buildCatalogueOrderResolver(library);
 
-      final first = IndexingRepository.buildCatalogueDocumentId(
-        catalogueOrder: resolver.orderFor('uid:404'),
-        ordinal: 0,
-      );
-      final second = IndexingRepository.buildCatalogueDocumentId(
-        catalogueOrder: resolver.orderFor('uid:405'),
-        ordinal: 0,
-      );
-
-      expect(first, isNot(second));
+      expect(() => resolver.orderFor('uid:404'), throwsStateError);
     });
   });
 

--- a/test/indexing/repository/indexing_repository_test.dart
+++ b/test/indexing/repository/indexing_repository_test.dart
@@ -1503,6 +1503,24 @@ void main() {
       expect(earlierBookLateSegment, lessThan(laterBookFirstSegment));
     });
 
+    test('ספר חסר מקבל אותו מזהה בכל ריצה — יציב בין הפעלות', () {
+      // רגרסיה: סדר חלופי לפי מונה רץ השתנה בין ריצות, ולכן ריצה אחרת
+      // חילקה אותו סדר לספר חסר אחר — מזהי מסמך מתנגשים.
+      final small = _buildLibrary(bavliBooks: const [('שבת', 1)]);
+      final grown = _buildLibrary(
+        bavliBooks: const [('שבת', 1), ('עירובין', 2)],
+      );
+
+      expect(
+        IndexingRepository.buildCatalogueOrderResolver(
+          grown,
+        ).orderFor('id:404'),
+        IndexingRepository.buildCatalogueOrderResolver(
+          small,
+        ).orderFor('id:404'),
+      );
+    });
+
     test('ספר שאינו בספרייה נכנס ב-u64 וממוין אחרי הספר האחרון', () {
       final u64Max = (BigInt.one << 64) - BigInt.one;
       final library = _buildLibrary(bavliBooks: const [('שבת', 1)]);

--- a/test/search/search_catalogue_order_helper_test.dart
+++ b/test/search/search_catalogue_order_helper_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/indexing/repository/indexing_repository.dart';
 import 'package:otzaria/library/models/library.dart';
 import 'package:otzaria/models/books.dart';
 import 'package:otzaria/search/utils/search_catalogue_order_helper.dart';
@@ -79,7 +80,151 @@ void main() {
 
       expect(sorted.map((result) => result.marker).toList(), [10, 20, 30]);
     });
+
+    test('ספרי הקטגוריה קודמים למפרשים שבתת-קטגוריה (issue #649)', () {
+      final library = _buildMidrashLibrary();
+
+      final ordered = SearchCatalogueOrderHelper.buildOrderedKeys<String>(
+        library,
+        keyOf: (book) => book.title as String,
+      );
+
+      expect(ordered, [
+        'ספרא',
+        'ספרי במדבר',
+        'ראבד על ספרא',
+        'בראשית רבה',
+        'שמות רבה',
+        'מתנות כהונה',
+      ]);
+    });
+
+    test('sortByLibraryOrder מציב את המדרש לפני מפרשיו (issue #649)', () {
+      final library = _buildMidrashLibrary();
+      final results = [
+        const _FakeResult('מתנות כהונה', 0),
+        const _FakeResult('ראבד על ספרא', 1),
+        const _FakeResult('בראשית רבה', 2),
+        const _FakeResult('ספרא', 3),
+      ];
+
+      final sorted = SearchCatalogueOrderHelper.sortByLibraryOrder(
+        results,
+        library,
+        titleOf: (result) => result.title,
+      );
+
+      expect(sorted.map((result) => result.title).toList(), [
+        'ספרא',
+        'ראבד על ספרא',
+        'בראשית רבה',
+        'מתנות כהונה',
+      ]);
+    });
+
+    test('מזהה המסמך באינדקס עולה מהמדרש למפרשיו (issue #649)', () {
+      final library = _buildMidrashLibrary();
+      final orderByTitle = SearchCatalogueOrderHelper.buildKeyOrderMap<String>(
+        library,
+        keyOf: (book) => book.title as String,
+      );
+
+      BigInt idFor(String title) => IndexingRepository.buildCatalogueDocumentId(
+        catalogueOrder: orderByTitle[title]!,
+        ordinal: 0,
+      );
+
+      expect(idFor('ספרא'), lessThan(idFor('ראבד על ספרא')));
+      expect(idFor('בראשית רבה'), lessThan(idFor('מתנות כהונה')));
+    });
   });
+}
+
+/// משחזר את מבנה קטגוריית "מדרש" בספרייה: בכל רמה יש ספרים לצד
+/// תת-קטגוריית "מפרשים".
+Library _buildMidrashLibrary() {
+  final library = Library(categories: []);
+
+  final midrash = Category(
+    title: 'מדרש',
+    description: '',
+    shortDescription: '',
+    order: 1,
+    subCategories: [],
+    books: [],
+    parent: library,
+  );
+  library.subCategories.add(midrash);
+
+  final halacha = Category(
+    title: 'הלכה',
+    description: '',
+    shortDescription: '',
+    order: 1,
+    subCategories: [],
+    books: [],
+    parent: midrash,
+  );
+  final aggada = Category(
+    title: 'אגדה',
+    description: '',
+    shortDescription: '',
+    order: 2,
+    subCategories: [],
+    books: [],
+    parent: midrash,
+  );
+  midrash.subCategories.addAll([halacha, aggada]);
+
+  halacha.books.addAll([
+    TextBook(title: 'ספרא', order: 1, category: halacha),
+    TextBook(title: 'ספרי במדבר', order: 2, category: halacha),
+  ]);
+
+  final halachaMefarshim = Category(
+    title: 'מפרשים',
+    description: '',
+    shortDescription: '',
+    order: 1,
+    subCategories: [],
+    books: [],
+    parent: halacha,
+  );
+  halacha.subCategories.add(halachaMefarshim);
+  halachaMefarshim.books.add(
+    TextBook(title: 'ראבד על ספרא', order: 1, category: halachaMefarshim),
+  );
+
+  final rabba = Category(
+    title: 'מדרש רבה',
+    description: '',
+    shortDescription: '',
+    order: 1,
+    subCategories: [],
+    books: [],
+    parent: aggada,
+  );
+  aggada.subCategories.add(rabba);
+  rabba.books.addAll([
+    TextBook(title: 'בראשית רבה', order: 1, category: rabba),
+    TextBook(title: 'שמות רבה', order: 2, category: rabba),
+  ]);
+
+  final rabbaMefarshim = Category(
+    title: 'מפרשים',
+    description: '',
+    shortDescription: '',
+    order: 1,
+    subCategories: [],
+    books: [],
+    parent: rabba,
+  );
+  rabba.subCategories.add(rabbaMefarshim);
+  rabbaMefarshim.books.add(
+    TextBook(title: 'מתנות כהונה', order: 1, category: rabbaMefarshim),
+  );
+
+  return library;
 }
 
 Library _buildLibrary() {


### PR DESCRIPTION
סוגר את #649.

## הבאג

במיון תוצאות החיפוש **"לפי סדר קטלוגי"**, מפרשי הספרא והספרי הוצגו לפני המדרשים עצמם, וכן במדרש רבה. במיון "לפי סדר הדורות" הסדר היה תקין.

## שורש הבעיה

`SearchCatalogueOrderHelper.buildOrderedKeys` סרק את הספרייה כך שהרקורסיה על תת־הקטגוריות רצה **לפני** הוספת ספרי הקטגוריה עצמה. בספרייה, "מפרשים" היא תת־קטגוריה של הספר שהיא מפרשת:

```
מדרש/הלכה/ספרא.txt
מדרש/הלכה/מפרשים/ראבד על ספרא.txt

מדרש/אגדה/מדרש רבה/בראשית רבה.txt
מדרש/אגדה/מדרש רבה/מפרשים/מתנות כהונה.txt
```

לכן ראב"ד על ספרא, מתנות כהונה ויפה תואר קיבלו סדר נמוך מספרא ומבראשית רבה.

התיקון מהפך את סדר שתי הלולאות, ובכך גם **מיישר את הפונקציה עם `Category.getAllBooks()`** ועם `_allBooks` בעץ הניווט, ששניהם כבר מציבים ספרים לפני תת־קטגוריות.

מדוע "סדר הדורות" היה תקין: הוא ממיין לפי דור הספר מ־`book_generation`, ומפרש נמצא בדור מאוחר מהמדרש.

## חובת בנייה מחדש של האינדקס

הסדר הקטלוגי **נצרב ל־`documentId`** בזמן האינדוקס (`buildCatalogueDocumentId`), לא מחושב בזמן החיפוש. לכן תיקון הקוד לבדו אינו משנה דבר אצל מי שכבר בנה אינדקס.

נוסף `CatalogueOrderRevision` — חותם `otzaria_catalogue_order.json` בתיקיית האינדקס, לצד `otzaria_index_meta.json` הקיים:

| מצב | תוצאה |
|---|---|
| אינדקס קיים, אין חותם (משתמש משדרג) | `requiresManualReindex` → הזרימה הקיימת מציגה "נדרש איפוס אינדקס" |
| התקנה נקייה / אינדקס שאופס | נחתם מיד, בלי הודעה מיותרת |
| אחרי בנייה מחדש | חותם עדכני, אין דרישה חוזרת |

לא נוצרה זרימת UI חדשה — המנגנון מתחבר ל־`requiresManualReindex` הקיים, ומשם ל־`decideStartupIndexing` והדיאלוג הקיים.

**החתימה נעשית רק על אינדקס ריק שמצבו ידוע.** כשל בקריאת `getIndexedFilePaths` או מנוע שנפל ל־fallback על אינדקס זמני משאירים רשימה ריקה בלי שהאינדקס שבדיסק ריק; חתימה במצב כזה הייתה מכריזה סדר ישן כתקין ומנטרלת את המנגנון לצמיתות, בלי שום סימן למשתמש. הכתיבה אטומית (קובץ זמני + rename) כדי שהפסקה באמצע לא תותיר חותם חצוי.

## תיקון שני: ספר לא מוכר קפץ לראש התוצאות

בזמן העבודה התגלה באג נוסף באותו מנגנון מזהים, **קיים מאז `4e90dfbab` ובלתי תלוי ב־#649**. תחילה רשמתי אותו כהערה בלבד; לאחר שאימתתי מה קורה בפועל, הוא נכלל כאן.

כשספר אינו נמצא ב־`catalogueOrderByBookKey`, הקוד נתן לו `0xFFFFFFFF` במטרה שיהיה **אחרון**. אבל `buildCatalogueDocumentId` מוסיף 1 לפני ההזזה:

```
(0xFFFFFFFF + 1) << 32  =  2^64  =  18,446,744,073,709,551,616
u64::MAX                          =  18,446,744,073,709,551,615
```

חריגה של צעד אחד משדה ה־`id` של המנוע. **הגשר ל־Rust אינו זורק על חריגה — הוא חותך:**

```dart
byteData.setUint64(offset, value.toSigned(64).toInt(), endian);
```

אימות בפועל של הערך שמגיע למנוע:

| | מזהה במנוע |
|---|---|
| הספר הראשון בקטלוג | 4,294,967,297 |
| ספר לא מוכר — **לפני** | **1** ← ראש הרשימה |
| ספר לא מוכר — **אחרי** | 18,446,744,069,414,584,321 ← אחרון |

הספר לא נדחף לסוף אלא **קפץ לראש**, לפני בראשית, בכל חיפוש ממוין בסדר קטלוגי. בשקט מוחלט, בלי שגיאה. שני ספרים כאלה באותו אינדקס אף היו מקבלים מזהים זהים (1, 2, 3).

הערך הוחלף בקבוע `unknownCatalogueOrder` (`0xFFFFFFFE`) בכל חמשת המקומות — קבוע אחד עם הסבר במקום מספר קסם חוזר, כדי שהמלכוד לא יחזור.

## בדיקות

22 בדיקות חדשות, כולן עוברות. `flutter analyze` נקי. `test/indexing/`, `test/search/`, `test/data_providers/` ו־`test/data/data_providers/` — **691 עוברים, אפס כשלים**.

- `test/search/search_catalogue_order_helper_test.dart` — מבנה "מדרש" אמיתי עם מפרשים בשתי רמות, כולל בדיקה ש־`documentId` באינדקס אכן עולה מהמדרש למפרשיו
- `test/data_providers/catalogue_order_revision_test.dart` — `shouldStamp` / `isStale` / קריאה־כתיבה, כולל שני מצבי ה"לא ידוע" ומצב המשתמש המשדרג
- `test/indexing/repository/indexing_repository_test.dart` — המזהה של ספר לא מוכר נכנס ב־u64 וממוין אחרון

## הערות למתחזק

1. **העלאת `kCatalogueOrderRevision` בעתיד תחייב גם בניית האינדקס המוכן־מראש** שמצורף לגרסה (`release_index_builder_cli.dart`) — אחרת הוא יימחק וייבנה מחדש אצל כל מי שיתקין אותו. מתועד ליד הקבוע.
2. **עץ הניווט של התוצאות** (`_flattenChildren`) עדיין מרנדר תת־קטגוריות מעל הספרים, כך ש"מפרשים" מופיעה כשורה מעל "ספרא". לא נגעתי — זו התנהגות עקבית של עץ היררכי (תיקיות לפני קבצים) ואינה מושפעת ממיון, בעוד התלונה ב־#649 מתייחסת לסדר התוצאות שכן משתנה בין המיונים. שווה החלטה נפרדת.
3. **חסימה שקטה**: משתמש שיבחר "אחר כך" בדיאלוג לא יקבל אינדוקס של ספרים חדשים, בלי הודעה. ההתנהגות קיימת מראש, אך עד היום הגייט נורה רק באי־תאימות סכמה נדירה — כעת הוא ייורה אצל כל המשדרגים, כך שכדאי לשקול הודעת `UiSnack`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
