### PR TITLE
תפריט הקשר בספרי מפרש: שורת הספר המקורי שפותחת את המקור במיקום הנוכחי

### DIFF
--- a/lib/text_book/view/combined_view/combined_book_screen.dart
+++ b/lib/text_book/view/combined_view/combined_book_screen.dart
@@ -1212,7 +1212,7 @@ class _CombinedViewState extends State<CombinedView> {
           state.linksByLine,
           paragraphIndex + 1,
         );
-        final entry = _siblingController.buildEntry(
+        return _siblingController.buildEntries(
           lineIndex: paragraphIndex,
           sourceLink: sourceLink,
           removeNikud: state.commentaryRemoveNikud,
@@ -1223,9 +1223,6 @@ class _CombinedViewState extends State<CombinedView> {
             widget.openBookCallback(tab);
           },
         );
-        return entry == null
-            ? const <AppContextMenuEntry>[]
-            : <AppContextMenuEntry>[entry];
       }(),
       ...(() {
         final dictionaryText = (selectedText?.trim().isNotEmpty == true)

--- a/lib/text_book/view/page_shape/simple_text_viewer.dart
+++ b/lib/text_book/view/page_shape/simple_text_viewer.dart
@@ -1733,18 +1733,19 @@ class _SimpleTextViewerState extends State<SimpleTextViewer> {
         state.linksByLine,
         index + 1,
       );
-      final siblingEntry = _siblingController!.buildEntry(
-        lineIndex: index,
-        sourceLink: sourceLink,
-        removeNikud: state.commentaryRemoveNikud,
-        removePunctuation: state.commentaryRemovePunctuation,
-        onNavigate: (link) async {
-          final tab = await buildLinkTargetTab(link);
-          if (!mounted) return;
-          widget.openBookCallback(tab);
-        },
+      entries.addAll(
+        _siblingController!.buildEntries(
+          lineIndex: index,
+          sourceLink: sourceLink,
+          removeNikud: state.commentaryRemoveNikud,
+          removePunctuation: state.commentaryRemovePunctuation,
+          onNavigate: (link) async {
+            final tab = await buildLinkTargetTab(link);
+            if (!mounted) return;
+            widget.openBookCallback(tab);
+          },
+        ),
       );
-      if (siblingEntry != null) entries.add(siblingEntry);
     }
 
     final dictionaryText = (capturedText?.trim().isNotEmpty == true)

--- a/lib/text_book/view/sibling_commentaries_menu.dart
+++ b/lib/text_book/view/sibling_commentaries_menu.dart
@@ -9,7 +9,8 @@ import 'package:otzaria/utils/text/text_manipulation.dart' as utils;
 import 'package:otzaria/widgets/misc/app_popup_menu.dart';
 import 'package:otzaria/widgets/misc/link_context_menu_entry.dart';
 
-/// מנהל את תת-התפריט "מפרשים נוספים על …" בתפריט ההקשר של ספרי מפרש.
+/// מנהל את פריטי תפריט ההקשר של ספרי מפרש הקשורים לשורת המקור: תת-התפריט
+/// "מפרשים נוספים על …" ושורת הספר המקורי שפותחת את המקור במיקום הנוכחי.
 ///
 /// כשלומדים בתוך ספר מפרש (למשל רשב"א על ברכות), הקישור ההפוך (SOURCE) של כל
 /// שורה כבר נותן את שורת המקור בגמרא; מכאן נאספים שאר המפרשים על אותו קטע.
@@ -54,16 +55,43 @@ class SiblingCommentariesController {
     return best;
   }
 
-  /// בונה את פריט התפריט "מפרשים נוספים על <כתובת המקור>", או null כשאין מקור
-  /// (השורה אינה בספר מפרש).
-  AppContextMenuEntry? buildEntry({
+  /// בונה את פריטי התפריט של שורת מקור בספר מפרש: תת-התפריט
+  /// "מפרשים נוספים על <כתובת המקור>" ושורת הספר המקורי (שם הספר + הכתובת,
+  /// למשל "סנהדרין ב.") שפותחת את המקור במיקום הנוכחי. מחזיר רשימה ריקה
+  /// כשאין מקור (השורה אינה בספר מפרש).
+  List<AppContextMenuEntry> buildEntries({
     required int lineIndex,
     required Link? sourceLink,
     required void Function(Link link) onNavigate,
     bool? removeNikud,
     bool? removePunctuation,
   }) {
-    if (sourceLink == null) return null;
+    if (sourceLink == null) return const [];
+    return [
+      _buildSiblingsEntry(
+        lineIndex,
+        sourceLink,
+        onNavigate,
+        removeNikud: removeNikud,
+        removePunctuation: removePunctuation,
+      ),
+      _buildOriginalBookEntry(
+        sourceLink,
+        onNavigate,
+        removeNikud: removeNikud,
+        removePunctuation: removePunctuation,
+      ),
+    ];
+  }
+
+  /// פריט התפריט "מפרשים נוספים על <כתובת המקור>" — תת-תפריט שאר המפרשים.
+  AppContextMenuEntry _buildSiblingsEntry(
+    int lineIndex,
+    Link sourceLink,
+    void Function(Link link) onNavigate, {
+    bool? removeNikud,
+    bool? removePunctuation,
+  }) {
     // הכתובת המלאה (displayReference) מחושבת מה-TOC של המקור ולכן תואמת את
     // פורמט הכותרת ("ב."), בעוד fallbackDisplayReference מציג את ה-heRef הגולמי
     // ("ב א"). ה-fallback משמש עד שהחישוב האסינכרוני מסתיים.
@@ -87,6 +115,24 @@ class SiblingCommentariesController {
         removePunctuation: removePunctuation,
       ),
       childrenRefreshStream: _refresh.stream,
+    );
+  }
+
+  /// שורת הספר המקורי: שם הספר + הכתובת (למשל "סנהדרין ב.") שפותחת את ספר
+  /// המקור של המפרש במיקום הנוכחי. נבנית כמו קישור רגיל — כולל חלונית
+  /// תצוגה מקדימה צפה של הקטע ברפרוף.
+  AppContextMenuEntry _buildOriginalBookEntry(
+    Link sourceLink,
+    void Function(Link link) onNavigate, {
+    bool? removeNikud,
+    bool? removePunctuation,
+  }) {
+    return buildLinkContextMenuEntry(
+      link: sourceLink,
+      icon: FluentIcons.book_open_24_regular,
+      removeNikud: removeNikud,
+      removePunctuation: removePunctuation,
+      onTap: () => onNavigate(sourceLink),
     );
   }
 

--- a/lib/widgets/misc/link_context_menu_entry.dart
+++ b/lib/widgets/misc/link_context_menu_entry.dart
@@ -18,6 +18,7 @@ AppContextMenuEntry buildLinkContextMenuEntry({
   required VoidCallback onTap,
   bool? removeNikud,
   bool? removePunctuation,
+  IconData? icon,
 }) {
   return AppContextMenuEntry(
     label: link.fallbackDisplayReference,
@@ -29,6 +30,7 @@ AppContextMenuEntry buildLinkContextMenuEntry({
         overflow: TextOverflow.ellipsis,
       ),
     ),
+    icon: icon,
     onTap: onTap,
     hoverPreviewBuilder: (context) => LinkHoverPreviewContent(
       link: link,

--- a/test/text_book/sibling_commentaries_menu_test.dart
+++ b/test/text_book/sibling_commentaries_menu_test.dart
@@ -79,26 +79,50 @@ void main() {
       c.dispose();
     });
 
-    test('buildEntry מחזיר null כשאין קישור מקור', () {
+    test('buildEntries מחזיר רשימה ריקה כשאין קישור מקור', () {
       final c = SiblingCommentariesController(loadSiblings: (_) async => []);
       expect(
-        c.buildEntry(lineIndex: 1, sourceLink: null, onNavigate: (_) {}),
-        isNull,
+        c.buildEntries(lineIndex: 1, sourceLink: null, onNavigate: (_) {}),
+        isEmpty,
       );
       c.dispose();
     });
 
-    test('buildEntry בונה תווית "מפרשים נוספים על ..." עם תת-תפריט', () {
+    test('buildEntries בונה "מפרשים נוספים על ..." ושורת הספר המקורי', () {
       final c = SiblingCommentariesController(loadSiblings: (_) async => []);
-      final entry = c.buildEntry(
+      final entries = c.buildEntries(
         lineIndex: 1,
         sourceLink: _sourceLink(),
         onNavigate: (_) {},
       );
-      expect(entry, isNotNull);
-      expect(entry!.label, startsWith('מפרשים נוספים על'));
-      expect(entry.childrenBuilder, isNotNull);
-      expect(entry.childrenRefreshStream, isNotNull);
+      expect(entries.length, 2);
+
+      // הראשון: תת-התפריט "מפרשים נוספים על ..."
+      final siblings = entries[0];
+      expect(siblings.label, startsWith('מפרשים נוספים על'));
+      expect(siblings.childrenBuilder, isNotNull);
+      expect(siblings.childrenRefreshStream, isNotNull);
+
+      // השני: שורת הספר המקורי שפותחת את המקור במיקום הנוכחי.
+      final original = entries[1];
+      expect(original.label, contains('ברכות'));
+      expect(original.onTap, isNotNull);
+      c.dispose();
+    });
+
+    test('שורת הספר המקורי מנווטת לקישור המקור בעת לחיצה', () {
+      final c = SiblingCommentariesController(loadSiblings: (_) async => []);
+      Link? navigated;
+      final entries = c.buildEntries(
+        lineIndex: 1,
+        sourceLink: _sourceLink(),
+        onNavigate: (link) => navigated = link,
+      );
+      entries[1].onTap!();
+      expect(navigated, isNotNull);
+      expect(navigated!.connectionType, LinkTypes.source);
+      expect(navigated!.path2, 'ברכות');
+      expect(navigated!.index2, 10);
       c.dispose();
     });
 
@@ -112,11 +136,11 @@ void main() {
             return [_commentaryLink('ריטב"א'), _commentaryLink('רא"ש')];
           },
         );
-        final entry = c.buildEntry(
+        final entry = c.buildEntries(
           lineIndex: 1,
           sourceLink: _sourceLink(),
           onNavigate: (_) {},
-        )!;
+        )[0];
 
         final loading = entry.childrenBuilder!();
         expect(loading.length, 1);
@@ -133,11 +157,11 @@ void main() {
 
     test('childrenBuilder מציג "אין מפרשים נוספים" כשאין תוצאות', () async {
       final c = SiblingCommentariesController(loadSiblings: (_) async => []);
-      final entry = c.buildEntry(
+      final entry = c.buildEntries(
         lineIndex: 2,
         sourceLink: _sourceLink(),
         onNavigate: (_) {},
-      )!;
+      )[0];
 
       entry.childrenBuilder!();
       await Future<void>.delayed(const Duration(milliseconds: 10));
@@ -152,11 +176,11 @@ void main() {
     test('טעינה שהתחילה לפני clear() לא כותבת תוצאות ישנות למטמון', () async {
       final gate = Completer<List<Link>>();
       final c = SiblingCommentariesController(loadSiblings: (_) => gate.future);
-      final entry = c.buildEntry(
+      final entry = c.buildEntries(
         lineIndex: 1,
         sourceLink: _sourceLink(),
         onNavigate: (_) {},
-      )!;
+      )[0];
 
       entry.childrenBuilder!(); // מתחיל טעינה (Future תלוי)
       c.clear(); // מעבר ספר באמצע הטעינה
@@ -178,11 +202,11 @@ void main() {
           return [_commentaryLink('ריטב"א')];
         },
       );
-      final entry = c.buildEntry(
+      final entry = c.buildEntries(
         lineIndex: 1,
         sourceLink: _sourceLink(),
         onNavigate: (_) {},
-      )!;
+      )[0];
 
       entry.childrenBuilder!();
       await Future<void>.delayed(const Duration(milliseconds: 10));


### PR DESCRIPTION
כשלומדים בספר מפרש מוצגת תחת "מפרשים נוספים על …" שורה נוספת עם שם הספר המקורי והכתובת (למשל "סנהדרין ב.") שפותחת את המקור באותו מיקום — כך גם בספרים כמו שולחן ערוך, טור ומשנה תורה. SiblingCommentariesController בונה כעת רשימת פריטים (buildEntries) במקום פריט בודד, והשורה החדשה נבנית כקישור רגיל עם תצוגה מקדימה צפה ברפרוף. 
שימושי מאוד בזמן חיפוש, שנמצאה תוצאה בתוך מפרש ורוצים לראות על מה מוסבים דברי המפרש.

<img width="958" height="413" alt="image" src="https://github.com/user-attachments/assets/ed5051f7-cdf2-48b8-ad1e-3fac10712960" />
