### PR TITLE
ערכת צבעים "לבן": מסך עיון לבן מוחלט ורקע פסקה נבחרת בהיר

### DIFF
--- a/lib/settings/l10n/settings_catalogs.g.dart
+++ b/lib/settings/l10n/settings_catalogs.g.dart
@@ -467,6 +467,7 @@ const Map<String, Map<String, String>> kSettingsCatalogs = {
     'לא קיימת ספרייה לאינדוקס': 'There is no library to index',
     'לא תידרש עוד סיסמה לגישה להגדרות.': 'A password will no longer be needed to access the settings.',
     'לאחר טעינת הספרייה תוכל לחזור לסיור המלא מ: הגדרות ← מערכת ← הפעל סיור מחדש.': 'Once the library is loaded you can come back to the full tour from: Settings → System → Run the tour again.',
+    'לבן': 'White',
     'לוח שנה': 'Calendar',
     'לוח שנה ושמור וזכור': 'Calendar and Shamor VeZachor',
     'לוח שנה ראשי': 'Main Calendar',

--- a/lib/settings/l10n/settings_en.arb
+++ b/lib/settings/l10n/settings_en.arb
@@ -129,6 +129,7 @@
   "סגול": "Purple",
   "חום": "Brown",
   "פרגמנט / בז'": "Parchment / Beige",
+  "לבן": "White",
   "אפור": "Grey",
   "חום זהבהב": "Golden Brown",
   "שינוי צבע": "Change Color",

--- a/lib/text_book/view/combined_view/combined_book_screen.dart
+++ b/lib/text_book/view/combined_view/combined_book_screen.dart
@@ -1967,7 +1967,7 @@ class _CombinedViewState extends State<CombinedView> {
         return theme.colorScheme.secondaryContainer.withValues(alpha: 0.4);
       }
       if (isSelected) {
-        return theme.colorScheme.primary.withValues(alpha: 0.08);
+        return AppSurfaces.paragraphSelectionBackground(theme.colorScheme);
       }
       return null;
     }();
@@ -2434,7 +2434,7 @@ class _CombinedViewState extends State<CombinedView> {
       final backgroundColor = state.highlightedLine == lineIndex
           ? colorScheme.secondaryContainer.withValues(alpha: 0.4)
           : state.selectedIndices.contains(lineIndex)
-          ? colorScheme.primary.withValues(alpha: 0.08)
+          ? AppSurfaces.paragraphSelectionBackground(colorScheme)
           : null;
       final style = backgroundColor == null
           ? baseTextStyle

--- a/lib/text_book/view/page_shape/simple_text_viewer.dart
+++ b/lib/text_book/view/page_shape/simple_text_viewer.dart
@@ -2555,7 +2555,7 @@ class _SimpleTextViewerState extends State<SimpleTextViewer> {
       }
       if (isCommentaryHighlighted || isSelected) {
         // צבע הדגשה למפרש קשור - כמו השורה הנבחרת
-        return theme.colorScheme.primary.withAlpha((0.08 * 255).round());
+        return AppSurfaces.paragraphSelectionBackground(theme.colorScheme);
       }
       return null;
     }();
@@ -2954,7 +2954,7 @@ class _SimpleTextViewerState extends State<SimpleTextViewer> {
       final backgroundColor = state.highlightedLine == lineIndex
           ? colorScheme.secondaryContainer.withAlpha((0.4 * 255).round())
           : state.selectedIndices.contains(lineIndex)
-          ? colorScheme.primary.withAlpha((0.08 * 255).round())
+          ? AppSurfaces.paragraphSelectionBackground(colorScheme)
           : null;
       final style = backgroundColor == null
           ? baseTextStyle

--- a/lib/theme/app_seed_colors.dart
+++ b/lib/theme/app_seed_colors.dart
@@ -24,6 +24,7 @@ class AppSeedColors {
   // ── צבעים נייטרלים ————————————————————————————
   static const Color brown = Color(0xFF795548);
   static const Color parchment = Color(0xFFD7CCC8);
+  static const Color white = Color(0xFFFFFFFF);
   static const Color grey = Color(0xFF9E9E9E);
   static const Color darkBrown = Color(0xFF2C1B02);
 
@@ -40,6 +41,7 @@ class AppSeedColors {
     (color: purple, name: 'סגול'),
     (color: brown, name: 'חום'),
     (color: parchment, name: 'פרגמנט / בז\''),
+    (color: white, name: 'לבן'),
     (color: grey, name: 'אפור'),
     (color: darkBrown, name: 'חום זהבהב'),
   ];

--- a/lib/theme/app_surfaces.dart
+++ b/lib/theme/app_surfaces.dart
@@ -75,6 +75,16 @@ class AppSurfaces {
   static Color selectedItem(ColorScheme cs) =>
       cs.primaryContainer.withValues(alpha: 0.3);
 
+  /// רקע הפסקה הנבחרת במסך העיון — השורה הפעילה בספר.
+  ///
+  /// ברירת מחדל: 8% primary — רמז עדין של הצבע הראשי. בערכת "לבן"
+  /// (מצב בהיר, מזוהה ע"י surface לבן מוחלט שהוגדר ב-createColorScheme)
+  /// הרקע בהיר יותר — F8FAFC — כדי שהבחירה תהיה עדינה וקרובה ללבן.
+  static Color paragraphSelectionBackground(ColorScheme cs) =>
+      cs.surface == Colors.white
+      ? const Color(0xFFF8FAFC)
+      : cs.primary.withValues(alpha: 0.08);
+
   /// רקע הדגשה לשורה שמעליה מרחפים בגרירה (drag target).
   ///
   /// 8% primary — רמז עדין למקום השחרור מבלי להסתיר את תוכן השורה.

--- a/lib/theme/app_theme_data.dart
+++ b/lib/theme/app_theme_data.dart
@@ -3,6 +3,7 @@ import 'dart:ui' show lerpDouble;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:otzaria/theme/app_colors.dart';
+import 'package:otzaria/theme/app_seed_colors.dart';
 import 'package:otzaria/theme/app_tokens.dart';
 
 // ════════════════════════════════════════════════════════════════════════════
@@ -39,13 +40,20 @@ class AppThemeData {
   /// לתוספים, כדי שכולם יקבלו בדיוק אותם צבעים.
   static ColorScheme createColorScheme(Color seedColor, Brightness brightness) {
     final isNeutral = HSLColor.fromColor(seedColor).saturation < 0.1;
-    return ColorScheme.fromSeed(
+    final scheme = ColorScheme.fromSeed(
       seedColor: seedColor,
       brightness: brightness,
       dynamicSchemeVariant: isNeutral
           ? DynamicSchemeVariant.monochrome
           : DynamicSchemeVariant.tonalSpot,
     );
+    // ערכת "לבן": זרע לבן נותן מ-fromSeed surface אפור (F9F9F9) — מסך העיון
+    // צריך לבן מוחלט, ולכן ה-surface מוחלף במפורש במצב בהיר.
+    if (seedColor.toARGB32() == AppSeedColors.white.toARGB32() &&
+        brightness == Brightness.light) {
+      return scheme.copyWith(surface: Colors.white);
+    }
+    return scheme;
   }
 
   // ── Light Theme ──────────────────────────────────────────────────────────

--- a/test/theme/app_surfaces_test.dart
+++ b/test/theme/app_surfaces_test.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/theme/app_seed_colors.dart';
 import 'package:otzaria/theme/app_surfaces.dart';
+import 'package:otzaria/theme/app_theme_data.dart';
 
 void main() {
   group('AppSurfaces.selectedItem', () {
@@ -40,6 +42,52 @@ void main() {
     test('alpha קרוב ל-0.3 (סובלנות לעיגול float)', () {
       final selected = AppSurfaces.selectedItem(lightScheme);
       expect(selected.a, closeTo(0.3, 0.01));
+    });
+  });
+
+  group('AppSurfaces.paragraphSelectionBackground', () {
+    test('ערכת "לבן" במצב בהיר נותנת F8FAFC', () {
+      final cs = AppThemeData.createColorScheme(
+        AppSeedColors.white,
+        Brightness.light,
+      );
+      expect(
+        AppSurfaces.paragraphSelectionBackground(cs),
+        const Color(0xFFF8FAFC),
+      );
+    });
+
+    test('ערכת "לבן" במצב כהה נשארת 8% primary', () {
+      final cs = AppThemeData.createColorScheme(
+        AppSeedColors.white,
+        Brightness.dark,
+      );
+      expect(
+        AppSurfaces.paragraphSelectionBackground(cs),
+        cs.primary.withValues(alpha: 0.08),
+      );
+    });
+
+    test('ערכת ברירת מחדל נותנת 8% primary', () {
+      final cs = ColorScheme.fromSeed(
+        seedColor: Colors.blue,
+        brightness: Brightness.light,
+      );
+      expect(
+        AppSurfaces.paragraphSelectionBackground(cs),
+        cs.primary.withValues(alpha: 0.08),
+      );
+    });
+
+    test('פרגמנט נשאר 8% primary — לא F8FAFC', () {
+      final cs = AppThemeData.createColorScheme(
+        AppSeedColors.parchment,
+        Brightness.light,
+      );
+      expect(
+        AppSurfaces.paragraphSelectionBackground(cs),
+        isNot(const Color(0xFFF8FAFC)),
+      );
     });
   });
 }

--- a/test/theme/app_theme_data_test.dart
+++ b/test/theme/app_theme_data_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/theme/app_seed_colors.dart';
 import 'package:otzaria/theme/app_theme_data.dart';
 
 void main() {
@@ -18,4 +19,43 @@ void main() {
       expect(theme.tooltipTheme.textStyle?.color, colorScheme.onSurface);
     });
   }
+
+  group('ערכת צבע "לבן"', () {
+    test('במצב בהיר רקע מסך העיון לבן מוחלט', () {
+      final cs = AppThemeData.createColorScheme(
+        AppSeedColors.white,
+        Brightness.light,
+      );
+      expect(cs.surface, Colors.white);
+    });
+
+    test('במצב כהה הרקע נשאר כהה', () {
+      final cs = AppThemeData.createColorScheme(
+        AppSeedColors.white,
+        Brightness.dark,
+      );
+      expect(cs.surface, isNot(Colors.white));
+    });
+
+    test('פרגמנט נשאר FFF8F6 — הרקע של "לבן" שונה ממנו', () {
+      final cs = AppThemeData.createColorScheme(
+        AppSeedColors.parchment,
+        Brightness.light,
+      );
+      expect(cs.surface, const Color(0xFFFFF8F6));
+    });
+
+    test('שאר צבעי הבסיס אינם מקבלים surface לבן', () {
+      for (final option in AppSeedColors.options) {
+        if (option.color.toARGB32() == AppSeedColors.white.toARGB32()) {
+          continue;
+        }
+        final cs = AppThemeData.createColorScheme(
+          option.color,
+          Brightness.light,
+        );
+        expect(cs.surface, isNot(Colors.white), reason: option.name);
+      }
+    });
+  });
 }


### PR DESCRIPTION
## מה זה

ערכת צבע בסיס חדשה **"לבן"** בהגדרות (מראה → צבע בסיס):

- **מסך העיון** הופך ללבן מוחלט (`FFFFFF`).
- **רקע הפסקה הנבחרת** הופך ל-`F8FAFC` (בהיר, קרוב ללבן) במקום `EBEBEB`.
- שאר התמה מונוכרומטית נקייה בגווני לבן-אפור.

## למה

צבע בסיס לבן לבדו נותן מ-`ColorScheme.fromSeed` ערכת monochrome עם `surface` אפור (`F9F9F9`), ולכן נדרש override מפורש של `surface` ללבן מוחלט במצב בהיר. בנוסף, בערכת הלבן `primary` הוא שחור מוחלט — כך ש-8% `primary` על רקע לבן נתן רקע פסקה נבחרת אפור (`EBEBEB`); כעת הוא `F8FAFC`.

## שינויים

- `lib/theme/app_seed_colors.dart` — צבע בסיס "לבן"
- `lib/theme/app_theme_data.dart` — `createColorScheme`: `surface` לבן לערכת הלבן במצב בהיר
- `lib/theme/app_surfaces.dart` — `AppSurfaces.paragraphSelectionBackground`: `F8FAFC` לערכת "לבן", 8% `primary` לשאר
- `lib/text_book/...` — 4 נקודות השימוש ברקע הפסקה הנבחרת (שני מסכי הקריאה, שורות בודדות וקריאה רציפה)
- `lib/settings/l10n` — תרגום "לבן" / "White"
- `test/theme` — בדיקות לערכת הלבן ולרקע הפסקה הנבחרת

## בדיקות

- כל 82 בדיקות התמה עוברות
- `flutter analyze` נקי על הקבצים ששונו
