### PR TITLE
אזהרה לא-חוסמת על דריפט תוכן בין ספר לאינדקס — השלמת issue #828

### DIFF
--- a/lib/core/messages/library_messages.dart
+++ b/lib/core/messages/library_messages.dart
@@ -27,6 +27,9 @@ abstract class LibraryMessages {
   static const String searchResultIndexOutOfDate =
       'תוצאת החיפוש שייכת לאינדקס ישן. יש לעדכן את אינדקס החיפוש.';
 
+  static const String searchResultContentDrifted =
+      'תוכן הספר השתנה מאז עדכון האינדקס — מומלץ לעדכן את אינדקס החיפוש.';
+
   static String indexingCompletedWithFailures(int count) =>
       'האינדוקס הסתיים עם $count בעיות. הפרטים נשמרו בקובץ השגיאות.';
 

--- a/lib/indexing/repository/indexing_repository.dart
+++ b/lib/indexing/repository/indexing_repository.dart
@@ -556,27 +556,9 @@ class IndexingRepository {
     // (UTF-8 כפי שמאוחסן ב-SQLite) ונמסר ל-addTextBookBytes — בלי פענוח
     // ל-String וקידוד חוזר על הגשר (~180ms/MB שנמדדו בלוגים).
     final loadStopwatch = Stopwatch()..start();
-    Uint8List? bytes;
-    String? text;
-    if (book.categoryId != null) {
-      bytes = await SqliteDataProvider.instance.getBookTextBytesFromDb(
-        book.title,
-        book.categoryId,
-        book.fileType ?? 'txt',
-        book.isUserBook,
-      );
-      // ניקוי תמונות מוטמעות חייב לרוץ גם כאן, כמו באימות הטביעה — אחרת
-      // החתימה לעולם לא תתאים ו-reconcile יאנדקס את הספר מחדש בכל ריצה.
-      if (bytes != null && bytesContainDataUriScheme(bytes)) {
-        text = stripDataUrisForIndex(utf8.decode(bytes, allowMalformed: true));
-        bytes = null;
-      }
-    }
-    if ((bytes == null || bytes.isEmpty) && (text == null || text.isEmpty)) {
-      // מסלול הנפילה (פורמט מומר, ספר בלי categoryId): טקסט דרך LibraryProvider.
-      // תמונות מוטמעות מסולקות — ראו [stripDataUrisForIndex].
-      text = await _loadTextForIndex(book);
-    }
+    final source = await _loadTextBookSource(book);
+    final bytes = source.bytes;
+    final text = source.text;
     loadStopwatch.stop();
 
     final hasBytes = bytes != null && bytes.isNotEmpty;
@@ -1076,6 +1058,35 @@ class IndexingRepository {
       c == 0x2E || // .
       c == 0x2D; // -
 
+  /// מקור הספר בדיוק כפי שנמסר למנוע באינדוקס: bytes גולמיים מה-DB כשאפשר
+  /// (בלי פענוח/קידוד על ה-UI isolate), וירידה לטקסט מפוענח ומנוקה רק
+  /// כשחייבים (תמונות מוטמעות, פורמט מומר, ספר בלי categoryId). משותף
+  /// לאינדוקס ולאימות הטריות — כך שתי החתימות מחושבות על אותו קלט בדיוק.
+  Future<({Uint8List? bytes, String? text})> _loadTextBookSource(
+    TextBook book,
+  ) async {
+    Uint8List? bytes;
+    String? text;
+    if (book.categoryId != null) {
+      bytes = await SqliteDataProvider.instance.getBookTextBytesFromDb(
+        book.title,
+        book.categoryId,
+        book.fileType ?? 'txt',
+        book.isUserBook,
+      );
+      // ניקוי תמונות מוטמעות חייב לרוץ בשני הצדדים — אחרת חתימת האינדוקס
+      // לעולם לא תתאים לאימות ו-reconcile יאנדקס את הספר מחדש בכל ריצה.
+      if (bytes != null && bytesContainDataUriScheme(bytes)) {
+        text = stripDataUrisForIndex(utf8.decode(bytes, allowMalformed: true));
+        bytes = null;
+      }
+    }
+    if ((bytes == null || bytes.isEmpty) && (text == null || text.isEmpty)) {
+      text = await _loadTextForIndex(book);
+    }
+    return (bytes: bytes, text: text);
+  }
+
   Future<String?> _loadTextBookText(TextBook book) async {
     String? text;
 
@@ -1248,28 +1259,27 @@ class IndexingRepository {
 
   /// בודק שתוכן ספר טקסט עדיין תואם את חתימת הטקסט שבאינדקס — בלי תלות
   /// ב-metadata (סדר קטלוגי וכו', שנפסלים מכל הוספת ספר — issue #828).
+  /// [indexHash] הוא ערך `textHash` מהאינדקס (`getBookTextFingerprint`).
   ///
   /// בדיקה רכה: `true` גם כשאין חתימה או שהספר לא ניתן לאימות — אזהרה
   /// מוצדקת רק על אי-התאמה ודאית.
-  Future<bool> textBookContentMatchesIndex(
-    Book book,
-    Map<String, BigInt> textFingerprints,
-  ) async {
-    final indexHash = textFingerprints[buildIndexedBookFilePath(book)];
+  Future<bool> textBookContentMatchesIndex(Book book, BigInt indexHash) async {
     final textBook = _asTextBookForIndex(book);
-    if (indexHash == null || indexHash == BigInt.zero || textBook == null) {
+    if (indexHash == BigInt.zero || textBook == null) {
       return true;
     }
 
-    final text = await _loadTextBookText(textBook);
-    if (text == null) return true;
+    // אותו מקור בדיוק שמסלול האינדוקס חתם: במקרה הנפוץ bytes גולמיים
+    // מה-DB עוברים כמות שהם, וה-UI isolate לא מפענח, מקודד או מגבב דבר —
+    // הגיבוב רץ על ה-thread pool של המנוע.
+    final source = await _loadTextBookSource(textBook);
+    final text = source.text;
+    final bytes =
+        source.bytes ??
+        (text == null || text.isEmpty ? null : utf8.encode(text));
+    if (bytes == null || bytes.isEmpty) return true;
 
-    // הגרסה הסינכרונית הייתה מגבבת ספר שלם על ה-UI isolate; מסלול ה-bytes
-    // האסינכרוני מריץ את הגיבוב על ה-thread pool של המנוע.
-    final hash = await computeContentFingerprintBytes(
-      text: utf8.encode(text),
-    );
-    return hash == indexHash;
+    return await computeContentFingerprintBytes(text: bytes) == indexHash;
   }
 
   /// האם רשומת הספר באינדקס מאוחסנת לפי נתיב מוחלט (ולכן תישבר בהעברת

--- a/lib/indexing/repository/indexing_repository.dart
+++ b/lib/indexing/repository/indexing_repository.dart
@@ -1264,7 +1264,12 @@ class IndexingRepository {
     final text = await _loadTextBookText(textBook);
     if (text == null) return true;
 
-    return computeContentFingerprint(text: text) == indexHash;
+    // הגרסה הסינכרונית הייתה מגבבת ספר שלם על ה-UI isolate; מסלול ה-bytes
+    // האסינכרוני מריץ את הגיבוב על ה-thread pool של המנוע.
+    final hash = await computeContentFingerprintBytes(
+      text: utf8.encode(text),
+    );
+    return hash == indexHash;
   }
 
   /// האם רשומת הספר באינדקס מאוחסנת לפי נתיב מוחלט (ולכן תישבר בהעברת

--- a/lib/indexing/repository/indexing_repository.dart
+++ b/lib/indexing/repository/indexing_repository.dart
@@ -1246,36 +1246,25 @@ class IndexingRepository {
     required String indexedTitle,
   }) => book?.title == indexedTitle ? book : null;
 
-  /// בודק שספר טקסט עדיין זהה למסמכים הקיימים באינדקס.
-  Future<bool> textBookMatchesIndexedFingerprint(
+  /// בודק שתוכן ספר טקסט עדיין תואם את חתימת הטקסט שבאינדקס — בלי תלות
+  /// ב-metadata (סדר קטלוגי וכו', שנפסלים מכל הוספת ספר — issue #828).
+  ///
+  /// בדיקה רכה: `true` גם כשאין חתימה או שהספר לא ניתן לאימות — אזהרה
+  /// מוצדקת רק על אי-התאמה ודאית.
+  Future<bool> textBookContentMatchesIndex(
     Book book,
-    Library library,
-    Map<String, BigInt> indexFingerprints,
+    Map<String, BigInt> textFingerprints,
   ) async {
-    final indexHash = indexFingerprints[buildIndexedBookFilePath(book)];
+    final indexHash = textFingerprints[buildIndexedBookFilePath(book)];
     final textBook = _asTextBookForIndex(book);
     if (indexHash == null || indexHash == BigInt.zero || textBook == null) {
-      return false;
+      return true;
     }
 
     final text = await _loadTextBookText(textBook);
-    if (text == null) return false;
+    if (text == null) return true;
 
-    final catalogueOrder = buildCatalogueOrderResolver(library);
-    await Future.wait([
-      GenerationCache.instance.warmUp(),
-      ReferenceBooksCache.instance.warmUp(),
-      BookFacetMetadataCache.instance.warmUp(),
-    ]);
-    return computeBookFingerprint(
-          text: text,
-          title: textBook.title,
-          topics: _bookTopics(textBook),
-          catalogueOrder: catalogueOrder.orderFor(catalogueOrderKey(textBook)),
-          generationOrder: chronologicalOrderForBook(textBook),
-          extraFacets: _bookExtraFacets(textBook),
-        ) ==
-        indexHash;
+    return computeContentFingerprint(text: text) == indexHash;
   }
 
   /// האם רשומת הספר באינדקס מאוחסנת לפי נתיב מוחלט (ולכן תישבר בהעברת

--- a/lib/search/utils/index_freshness_warner.dart
+++ b/lib/search/utils/index_freshness_warner.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/foundation.dart';
+import 'package:otzaria/core/messages/library_messages.dart';
+import 'package:otzaria/core/ui_snack.dart';
+import 'package:otzaria/data/data_providers/tantivy_data_provider.dart';
+import 'package:otzaria/indexing/repository/indexing_repository.dart';
+import 'package:otzaria/models/books.dart';
+
+/// אזהרה לא-חוסמת על דריפט תוכן בין ספר לאינדקס החיפוש.
+///
+/// תוצאת חיפוש נפתחת תמיד (הזהות כבר אומתה במסלול הפתיחה); אם חתימת
+/// הטקסט באינדקס אינה תואמת את תוכן הספר, מוצגת הצעה לעדכן את האינדקס —
+/// בלי לחסום דבר. ההשוואה היא מול חתימת הטקסט-בלבד (`textHash`), שאינה
+/// נפסלת משינויי metadata כמו הסדר הקטלוגי (issue #828).
+class IndexFreshnessWarner {
+  IndexFreshnessWarner._();
+
+  static final IndexFreshnessWarner instance = IndexFreshnessWarner._();
+
+  /// אימות מוזרק בבדיקות. null = אימות אמיתי מול המנוע.
+  @visibleForTesting
+  Future<bool> Function(Book book)? debugVerifier;
+
+  /// הצגת האזהרה, מוזרקת בבדיקות. null = UiSnack.
+  @visibleForTesting
+  void Function(String message)? debugNotifier;
+
+  final Set<String> _checkedBookKeys = {};
+
+  @visibleForTesting
+  void resetForTesting() {
+    _checkedBookKeys.clear();
+    debugVerifier = null;
+    debugNotifier = null;
+  }
+
+  /// בודק פעם אחת לספר (לכל חיי התהליך) ומזהיר על אי-התאמה ודאית.
+  /// לעולם אינו זורק — כשל אימות אינו מפריע לפתיחת התוצאה, ואינו נצרב
+  /// כדי שהבדיקה תנוסה שוב בפתיחה הבאה.
+  Future<void> warnIfContentDrifted(Book book) async {
+    final key = IndexingRepository.buildIndexedBookFilePath(book);
+    if (!_checkedBookKeys.add(key)) return;
+    try {
+      final matches = await (debugVerifier ?? _contentMatchesIndex)(book);
+      if (!matches) {
+        (debugNotifier ?? UiSnack.show)(
+          LibraryMessages.searchResultContentDrifted,
+        );
+      }
+    } catch (error) {
+      _checkedBookKeys.remove(key);
+      debugPrint('אימות טריות האינדקס נכשל עבור "${book.title}": $error');
+    }
+  }
+
+  static Future<bool> _contentMatchesIndex(Book book) async {
+    final provider = TantivyDataProvider.instance;
+    final engine = await provider.engine;
+    // getBookTextFingerprints נוסף במנוע ב-PR otzaria_search_engine#13;
+    // עד שדרוג התלות הקריאה דינמית, ומנוע ישן נחשב "לא ניתן לאימות".
+    final Map<String, BigInt> fingerprints;
+    try {
+      fingerprints = Map<String, BigInt>.from(
+        await (engine as dynamic).getBookTextFingerprints() as Map,
+      );
+    } on NoSuchMethodError {
+      return true;
+    }
+    return IndexingRepository(
+      provider,
+    ).textBookContentMatchesIndex(book, fingerprints);
+  }
+}

--- a/lib/search/utils/index_freshness_warner.dart
+++ b/lib/search/utils/index_freshness_warner.dart
@@ -55,18 +55,8 @@ class IndexFreshnessWarner {
   static Future<bool> _contentMatchesIndex(Book book) async {
     final provider = TantivyDataProvider.instance;
     final engine = await provider.engine;
-    // getBookTextFingerprints נוסף במנוע ב-PR otzaria_search_engine#13;
-    // עד שדרוג התלות הקריאה דינמית, ומנוע ישן נחשב "לא ניתן לאימות".
-    final Map<String, BigInt> fingerprints;
-    try {
-      fingerprints = Map<String, BigInt>.from(
-        await (engine as dynamic).getBookTextFingerprints() as Map,
-      );
-    } on NoSuchMethodError {
-      return true;
-    }
     return IndexingRepository(
       provider,
-    ).textBookContentMatchesIndex(book, fingerprints);
+    ).textBookContentMatchesIndex(book, await engine.getBookTextFingerprints());
   }
 }

--- a/lib/search/utils/index_freshness_warner.dart
+++ b/lib/search/utils/index_freshness_warner.dart
@@ -40,23 +40,36 @@ class IndexFreshnessWarner {
 
   /// המפתח באינדקס → ה-revision של המקור בזמן הבדיקה המוצלחת האחרונה.
   final Map<String, String> _checkedRevisionByKey = {};
+
+  /// בדיקות שכבר רצות, לפי מפתח+revision+דור — שתי פתיחות של אותו ספר
+  /// חולקות ריצה אחת במקום לגבב אותו פעמיים ולהזהיר פעמיים.
+  final Map<String, Future<void>> _inFlightByKey = {};
   ValueNotifier<bool>? _hookedIsIndexing;
   Future<SearchEngine>? _engineGeneration;
   Future<Library>? _libraryGeneration;
 
+  /// מונה שעולה בכל פסילת מטמון. זהויות ה-Future אינן מספיקות: מעבר
+  /// isIndexing מאפס את המטמון בלי לשנות אף אחת מהן.
+  int _invalidationToken = 0;
+
   @visibleForTesting
   void resetForTesting() {
     _checkedRevisionByKey.clear();
+    _inFlightByKey.clear();
     _hookedIsIndexing?.removeListener(_invalidate);
     _hookedIsIndexing = null;
     _engineGeneration = null;
     _libraryGeneration = null;
+    _invalidationToken = 0;
     providerResolver = () => TantivyDataProvider.instance;
     debugBookVerifier = null;
     debugNotifier = null;
   }
 
-  void _invalidate() => _checkedRevisionByKey.clear();
+  void _invalidate() {
+    _invalidationToken++;
+    _checkedRevisionByKey.clear();
+  }
 
   /// reopen מחליף את `provider.engine`, ורענון ספרייה את
   /// `DataRepository.instance.library` — התחלפות של אחד מהם פוסלת את כל
@@ -81,12 +94,13 @@ class IndexFreshnessWarner {
     final provider = providerResolver();
     _hookIndexingInvalidation(provider);
 
-    // צילום זהויות הדור *לפני* כל await: אינדקס שנפתח מחדש או ספרייה
-    // שהתרעננה בזמן ההמתנה הופכים את התוצאה הזו ללא-רלוונטית, גם אם שום
-    // בדיקה אחרת לא נכנסה בינתיים כדי להבחין בכך.
+    // צילום הדור *לפני* כל await: אינדקס שנפתח מחדש, ספרייה שהתרעננה או
+    // ריצת אינדוקס בזמן ההמתנה הופכים את התוצאה הזו ללא-רלוונטית, גם אם
+    // שום בדיקה אחרת לא נכנסה בינתיים כדי להבחין בכך.
     final engineGeneration = provider.engine;
     final libraryGeneration = DataRepository.instance.library;
     _invalidateOnGenerationChange(engineGeneration, libraryGeneration);
+    final token = _invalidationToken;
 
     final key = IndexingRepository.buildIndexedBookFilePath(book);
     try {
@@ -95,29 +109,61 @@ class IndexFreshnessWarner {
       final revision = await _sourceRevision(book);
       if (_checkedRevisionByKey[key] == revision) return;
 
-      final engine = await engineGeneration;
-      final indexHash = await engine.getBookTextFingerprint(filePath: key);
-      final matches = await (debugBookVerifier ?? _bookMatches)(
-        book,
-        indexHash,
-      );
+      // איחוד ריצות: הבדיקה נכתבת למטמון רק בסופה, ולכן בלי השורות האלה
+      // שתי פתיחות מקבילות של אותו ספר היו שתיהן מפספסות את המטמון.
+      final runKey = '$key|$revision|$token';
+      final running = _inFlightByKey[runKey];
+      if (running != null) return running;
 
-      // אין await בין הבדיקה הזו לבין ההצגה/הכתיבה למטמון.
-      if (!_generationsUnchanged(
-        provider,
-        engineGeneration,
-        libraryGeneration,
-      )) {
-        return;
-      }
-      _checkedRevisionByKey[key] = revision;
-      if (!matches) {
-        (debugNotifier ?? UiSnack.show)(
-          LibraryMessages.searchResultContentDrifted,
-        );
+      final run = _checkAndWarn(
+        book: book,
+        key: key,
+        revision: revision,
+        token: token,
+        provider: provider,
+        engineGeneration: engineGeneration,
+        libraryGeneration: libraryGeneration,
+      );
+      _inFlightByKey[runKey] = run;
+      try {
+        await run;
+      } finally {
+        if (identical(_inFlightByKey[runKey], run)) {
+          _inFlightByKey.remove(runKey);
+        }
       }
     } catch (error) {
       debugPrint('אימות טריות האינדקס נכשל עבור "${book.title}": $error');
+    }
+  }
+
+  Future<void> _checkAndWarn({
+    required Book book,
+    required String key,
+    required String revision,
+    required int token,
+    required TantivyDataProvider provider,
+    required Future<SearchEngine> engineGeneration,
+    required Future<Library> libraryGeneration,
+  }) async {
+    final engine = await engineGeneration;
+    final indexHash = await engine.getBookTextFingerprint(filePath: key);
+    final matches = await (debugBookVerifier ?? _bookMatches)(book, indexHash);
+
+    // אין await בין הבדיקה הזו לבין ההצגה/הכתיבה למטמון.
+    if (!_generationUnchanged(
+      provider,
+      token,
+      engineGeneration,
+      libraryGeneration,
+    )) {
+      return;
+    }
+    _checkedRevisionByKey[key] = revision;
+    if (!matches) {
+      (debugNotifier ?? UiSnack.show)(
+        LibraryMessages.searchResultContentDrifted,
+      );
     }
   }
 
@@ -138,11 +184,13 @@ class IndexFreshnessWarner {
     }
   }
 
-  bool _generationsUnchanged(
+  bool _generationUnchanged(
     TantivyDataProvider provider,
+    int token,
     Future<SearchEngine> engineGeneration,
     Future<Library> libraryGeneration,
   ) =>
+      token == _invalidationToken &&
       identical(provider.engine, engineGeneration) &&
       identical(DataRepository.instance.library, libraryGeneration);
 

--- a/lib/search/utils/index_freshness_warner.dart
+++ b/lib/search/utils/index_freshness_warner.dart
@@ -117,7 +117,13 @@ class IndexFreshnessWarner {
       // שתי פתיחות מקבילות של אותו ספר היו שתיהן מפספסות את המטמון.
       final runKey = '$key|$revision|$token';
       final running = _inFlightByKey[runKey];
-      if (running != null) return running;
+      if (running != null) {
+        // await ולא return: שגיאה מריצה משותפת חייבת להיתפס כאן — Future
+        // שמוחזר כמות שהוא עוקף את ה-try והקורא המצטרף (unawaited) היה
+        // מקבל async error גלובלי.
+        await running;
+        return;
+      }
 
       final run = _checkAndWarn(
         book: book,
@@ -153,6 +159,10 @@ class IndexFreshnessWarner {
     final engine = await engineGeneration;
     final indexHash = await engine.getBookTextFingerprint(filePath: key);
     final matches = await (debugBookVerifier ?? _bookMatches)(book, indexHash);
+
+    // קובץ מקור שנערך בזמן האימות: התוצאה שייכת לתוכן שכבר איננו — לא
+    // נצרבת ולא מוצגת; הפתיחה הבאה תבדוק את ה-revision החדש.
+    if (await _sourceRevision(book) != revision) return;
 
     // אין await בין הבדיקה הזו לבין ההצגה/הכתיבה למטמון.
     if (!_generationUnchanged(

--- a/lib/search/utils/index_freshness_warner.dart
+++ b/lib/search/utils/index_freshness_warner.dart
@@ -2,7 +2,9 @@ import 'package:flutter/foundation.dart';
 import 'package:otzaria/core/messages/library_messages.dart';
 import 'package:otzaria/core/ui_snack.dart';
 import 'package:otzaria/data/data_providers/tantivy_data_provider.dart';
+import 'package:otzaria/data/repository/data_repository.dart';
 import 'package:otzaria/indexing/repository/indexing_repository.dart';
+import 'package:otzaria/library/models/library.dart';
 import 'package:otzaria/models/books.dart';
 import 'package:otzaria_search_engine/otzaria_search_engine.dart';
 
@@ -13,11 +15,17 @@ import 'package:otzaria_search_engine/otzaria_search_engine.dart';
 /// בלי לחסום דבר. ההשוואה היא מול חתימת הטקסט-בלבד (`textHash`), שאינה
 /// נפסלת משינויי metadata כמו הסדר הקטלוגי (issue #828).
 ///
-/// מפת החתימות נטענת מהמנוע פעם אחת לדור אינדקס (`getBookTextFingerprints`
-/// סורק את כל האינדקס — אסור להריצו פר-ספר), וכל המטמונים מתאפסים כשהדור
-/// מתחלף: החלפת המנוע ב-reopen (זהות ה-Future של הספק) או ריצת אינדוקס
-/// (מעברי `isIndexing`) — כך ספר שנבדק, וגם ספר שלא היה ניתן לאימות,
-/// נבדקים מחדש אחרי כל בנייה.
+/// מפת החתימות נטענת מהמנוע פעם אחת לדור (`getBookTextFingerprints`
+/// סורק את כל האינדקס — אסור להריצו פר-ספר), וכל המטמונים מתאפסים
+/// כשמתחלף דור של אחד משני הצדדים שההשוואה תלויה בהם:
+/// * **האינדקס** — החלפת המנוע ב-reopen (זהות ה-Future של הספק) או ריצת
+///   אינדוקס (מעברי `isIndexing`).
+/// * **הספרייה** — כל רענון מחליף את `DataRepository.instance.library`
+///   ב-Future חדש, גם כשעדכון אינדקס אוטומטי כבוי ושום אות אינדקס לא
+///   נורה; בלעדיו ספר שנערך היה מדולג לנצח.
+///
+/// כל איפוס מקדם epoch; בדיקה שנפתחה תחת epoch ישן אינה מציגה אזהרה
+/// ואינה נוגעת במטמונים — התוצאה שלה שייכת לדור שכבר איננו.
 class IndexFreshnessWarner {
   IndexFreshnessWarner._();
 
@@ -41,7 +49,9 @@ class IndexFreshnessWarner {
   final Set<String> _checkedBookKeys = {};
   Future<Map<String, BigInt>>? _fingerprints;
   Future<SearchEngine>? _engineGeneration;
+  Future<Library>? _libraryGeneration;
   ValueNotifier<bool>? _hookedIsIndexing;
+  int _epoch = 0;
 
   @visibleForTesting
   void resetForTesting() {
@@ -49,26 +59,29 @@ class IndexFreshnessWarner {
     _hookedIsIndexing?.removeListener(_resetCaches);
     _hookedIsIndexing = null;
     _engineGeneration = null;
+    _libraryGeneration = null;
     providerResolver = () => TantivyDataProvider.instance;
     debugBookVerifier = null;
     debugNotifier = null;
   }
 
   void _resetCaches() {
+    _epoch++;
     _checkedBookKeys.clear();
     _fingerprints = null;
   }
 
-  /// בודק פעם אחת לספר (עד להתחלפות דור האינדקס) ומזהיר על אי-התאמה
-  /// ודאית. לעולם אינו זורק — כשל אימות אינו מפריע לפתיחת התוצאה, ואינו
-  /// נצרב כדי שהבדיקה תנוסה שוב בפתיחה הבאה.
+  /// בודק פעם אחת לספר (עד להתחלפות דור) ומזהיר על אי-התאמה ודאית.
+  /// לעולם אינו זורק — כשל אימות אינו מפריע לפתיחת התוצאה, ואינו נצרב
+  /// כדי שהבדיקה תנוסה שוב בפתיחה הבאה.
   Future<void> warnIfContentDrifted(Book book) async {
     final provider = providerResolver();
     _hookIndexingInvalidation(provider);
-    _syncEngineGeneration(provider);
+    _syncGenerations(provider);
 
     final key = IndexingRepository.buildIndexedBookFilePath(book);
     if (!_checkedBookKeys.add(key)) return;
+    final epoch = _epoch;
     try {
       final fingerprints = await (_fingerprints ??= provider.engine.then(
         (engine) => engine.getBookTextFingerprints(),
@@ -77,15 +90,20 @@ class IndexFreshnessWarner {
         book,
         fingerprints,
       );
+      // הדור התחלף בזמן ההמתנה — התוצאה שייכת למפה/לתוכן שכבר אינם.
+      if (epoch != _epoch) return;
       if (!matches) {
         (debugNotifier ?? UiSnack.show)(
           LibraryMessages.searchResultContentDrifted,
         );
       }
     } catch (error) {
-      _checkedBookKeys.remove(key);
-      // מפה שנכשלה בטעינה אסור שתישאר במטמון ותכשיל כל ספר עד סוף הדור.
-      _fingerprints = null;
+      // אחרי איפוס אסור לגעת במטמונים של הדור החדש (הסרת key שנוסף בו,
+      // או מחיקת מפה טרייה) — הניקוי שייך רק לדור שבו הבדיקה התחילה.
+      if (epoch == _epoch) {
+        _checkedBookKeys.remove(key);
+        _fingerprints = null;
+      }
       debugPrint('אימות טריות האינדקס נכשל עבור "${book.title}": $error');
     }
   }
@@ -98,12 +116,18 @@ class IndexFreshnessWarner {
     _hookedIsIndexing = provider.isIndexing..addListener(_resetCaches);
   }
 
-  /// reopen מחליף את `provider.engine` ב-Future חדש — זהותו היא דור
-  /// האינדקס: מפה שנטענה מהמנוע הקודם אינה תקפה למנוע שנפתח מחדש.
-  void _syncEngineGeneration(TantivyDataProvider provider) {
-    final generation = provider.engine;
-    if (identical(generation, _engineGeneration)) return;
-    _engineGeneration = generation;
+  /// שני צדי ההשוואה הם דורות: reopen מחליף את `provider.engine`, ורענון
+  /// ספרייה מחליף את `DataRepository.instance.library` — גם בלי שום
+  /// ריצת אינדוקס (עדכון אינדקס אוטומטי כבוי, עריכת ספר אישי).
+  void _syncGenerations(TantivyDataProvider provider) {
+    final engineGeneration = provider.engine;
+    final libraryGeneration = DataRepository.instance.library;
+    if (identical(engineGeneration, _engineGeneration) &&
+        identical(libraryGeneration, _libraryGeneration)) {
+      return;
+    }
+    _engineGeneration = engineGeneration;
+    _libraryGeneration = libraryGeneration;
     _resetCaches();
   }
 

--- a/lib/search/utils/index_freshness_warner.dart
+++ b/lib/search/utils/index_freshness_warner.dart
@@ -93,6 +93,10 @@ class IndexFreshnessWarner {
   Future<void> warnIfContentDrifted(Book book) async {
     final provider = providerResolver();
     _hookIndexingInvalidation(provider);
+    // אינדקס שנמצא באמצע בנייה אינו בסיס להשוואה: חלק מהמסמכים כבר
+    // הוחלפו וחלק לא. אין בדיקה ואין כתיבה למטמון — הפתיחה הבאה, אחרי
+    // סיום האינדוקס, תבדוק מחדש.
+    if (provider.isIndexing.value) return;
 
     // צילום הדור *לפני* כל await: אינדקס שנפתח מחדש, ספרייה שהתרעננה או
     // ריצת אינדוקס בזמן ההמתנה הופכים את התוצאה הזו ללא-רלוונטית, גם אם
@@ -191,6 +195,9 @@ class IndexFreshnessWarner {
     Future<Library> libraryGeneration,
   ) =>
       token == _invalidationToken &&
+      // אינדוקס שהתחיל בזמן ההמתנה אינו מנפיק מעבר שה-token יתפוס אם הוא
+      // עדיין פעיל — הערך עצמו הוא התנאי.
+      !provider.isIndexing.value &&
       identical(provider.engine, engineGeneration) &&
       identical(DataRepository.instance.library, libraryGeneration);
 

--- a/lib/search/utils/index_freshness_warner.dart
+++ b/lib/search/utils/index_freshness_warner.dart
@@ -4,6 +4,7 @@ import 'package:otzaria/core/ui_snack.dart';
 import 'package:otzaria/data/data_providers/tantivy_data_provider.dart';
 import 'package:otzaria/indexing/repository/indexing_repository.dart';
 import 'package:otzaria/models/books.dart';
+import 'package:otzaria_search_engine/otzaria_search_engine.dart';
 
 /// אזהרה לא-חוסמת על דריפט תוכן בין ספר לאינדקס החיפוש.
 ///
@@ -11,36 +12,71 @@ import 'package:otzaria/models/books.dart';
 /// הטקסט באינדקס אינה תואמת את תוכן הספר, מוצגת הצעה לעדכן את האינדקס —
 /// בלי לחסום דבר. ההשוואה היא מול חתימת הטקסט-בלבד (`textHash`), שאינה
 /// נפסלת משינויי metadata כמו הסדר הקטלוגי (issue #828).
+///
+/// מפת החתימות נטענת מהמנוע פעם אחת לדור אינדקס (`getBookTextFingerprints`
+/// סורק את כל האינדקס — אסור להריצו פר-ספר), וכל המטמונים מתאפסים כשהדור
+/// מתחלף: החלפת המנוע ב-reopen (זהות ה-Future של הספק) או ריצת אינדוקס
+/// (מעברי `isIndexing`) — כך ספר שנבדק, וגם ספר שלא היה ניתן לאימות,
+/// נבדקים מחדש אחרי כל בנייה.
 class IndexFreshnessWarner {
   IndexFreshnessWarner._();
 
   static final IndexFreshnessWarner instance = IndexFreshnessWarner._();
 
-  /// אימות מוזרק בבדיקות. null = אימות אמיתי מול המנוע.
+  /// הספק שמולו רצים — מוחלף בבדיקות בספק מזויף.
   @visibleForTesting
-  Future<bool> Function(Book book)? debugVerifier;
+  TantivyDataProvider Function() providerResolver = () =>
+      TantivyDataProvider.instance;
+
+  /// השוואת ספר-מול-חתימות, מוזרקת בבדיקות שאין להן DB חי לטעינת הטקסט.
+  /// מסלול טעינת המפה והמטמונים נשאר אמיתי גם אז.
+  @visibleForTesting
+  Future<bool> Function(Book book, Map<String, BigInt> fingerprints)?
+  debugBookVerifier;
 
   /// הצגת האזהרה, מוזרקת בבדיקות. null = UiSnack.
   @visibleForTesting
   void Function(String message)? debugNotifier;
 
   final Set<String> _checkedBookKeys = {};
+  Future<Map<String, BigInt>>? _fingerprints;
+  Future<SearchEngine>? _engineGeneration;
+  ValueNotifier<bool>? _hookedIsIndexing;
 
   @visibleForTesting
   void resetForTesting() {
-    _checkedBookKeys.clear();
-    debugVerifier = null;
+    _resetCaches();
+    _hookedIsIndexing?.removeListener(_resetCaches);
+    _hookedIsIndexing = null;
+    _engineGeneration = null;
+    providerResolver = () => TantivyDataProvider.instance;
+    debugBookVerifier = null;
     debugNotifier = null;
   }
 
-  /// בודק פעם אחת לספר (לכל חיי התהליך) ומזהיר על אי-התאמה ודאית.
-  /// לעולם אינו זורק — כשל אימות אינו מפריע לפתיחת התוצאה, ואינו נצרב
-  /// כדי שהבדיקה תנוסה שוב בפתיחה הבאה.
+  void _resetCaches() {
+    _checkedBookKeys.clear();
+    _fingerprints = null;
+  }
+
+  /// בודק פעם אחת לספר (עד להתחלפות דור האינדקס) ומזהיר על אי-התאמה
+  /// ודאית. לעולם אינו זורק — כשל אימות אינו מפריע לפתיחת התוצאה, ואינו
+  /// נצרב כדי שהבדיקה תנוסה שוב בפתיחה הבאה.
   Future<void> warnIfContentDrifted(Book book) async {
+    final provider = providerResolver();
+    _hookIndexingInvalidation(provider);
+    _syncEngineGeneration(provider);
+
     final key = IndexingRepository.buildIndexedBookFilePath(book);
     if (!_checkedBookKeys.add(key)) return;
     try {
-      final matches = await (debugVerifier ?? _contentMatchesIndex)(book);
+      final fingerprints = await (_fingerprints ??= provider.engine.then(
+        (engine) => engine.getBookTextFingerprints(),
+      ));
+      final matches = await (debugBookVerifier ?? _bookMatches)(
+        book,
+        fingerprints,
+      );
       if (!matches) {
         (debugNotifier ?? UiSnack.show)(
           LibraryMessages.searchResultContentDrifted,
@@ -48,15 +84,31 @@ class IndexFreshnessWarner {
       }
     } catch (error) {
       _checkedBookKeys.remove(key);
+      // מפה שנכשלה בטעינה אסור שתישאר במטמון ותכשיל כל ספר עד סוף הדור.
+      _fingerprints = null;
       debugPrint('אימות טריות האינדקס נכשל עבור "${book.title}": $error');
     }
   }
 
-  static Future<bool> _contentMatchesIndex(Book book) async {
-    final provider = TantivyDataProvider.instance;
-    final engine = await provider.engine;
-    return IndexingRepository(
-      provider,
-    ).textBookContentMatchesIndex(book, await engine.getBookTextFingerprints());
+  /// סוף ריצת אינדוקס משנה את תוכן האינדקס; המאזין מאפס על כל מעבר, כך
+  /// שגם ספר "לא ניתן לאימות" נבדק מחדש אחרי בנייה חדשה.
+  void _hookIndexingInvalidation(TantivyDataProvider provider) {
+    if (identical(_hookedIsIndexing, provider.isIndexing)) return;
+    _hookedIsIndexing?.removeListener(_resetCaches);
+    _hookedIsIndexing = provider.isIndexing..addListener(_resetCaches);
   }
+
+  /// reopen מחליף את `provider.engine` ב-Future חדש — זהותו היא דור
+  /// האינדקס: מפה שנטענה מהמנוע הקודם אינה תקפה למנוע שנפתח מחדש.
+  void _syncEngineGeneration(TantivyDataProvider provider) {
+    final generation = provider.engine;
+    if (identical(generation, _engineGeneration)) return;
+    _engineGeneration = generation;
+    _resetCaches();
+  }
+
+  Future<bool> _bookMatches(Book book, Map<String, BigInt> fingerprints) =>
+      IndexingRepository(
+        providerResolver(),
+      ).textBookContentMatchesIndex(book, fingerprints);
 }

--- a/lib/search/utils/index_freshness_warner.dart
+++ b/lib/search/utils/index_freshness_warner.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/foundation.dart';
 import 'package:otzaria/core/messages/library_messages.dart';
 import 'package:otzaria/core/ui_snack.dart';
@@ -15,17 +17,8 @@ import 'package:otzaria_search_engine/otzaria_search_engine.dart';
 /// בלי לחסום דבר. ההשוואה היא מול חתימת הטקסט-בלבד (`textHash`), שאינה
 /// נפסלת משינויי metadata כמו הסדר הקטלוגי (issue #828).
 ///
-/// מפת החתימות נטענת מהמנוע פעם אחת לדור (`getBookTextFingerprints`
-/// סורק את כל האינדקס — אסור להריצו פר-ספר), וכל המטמונים מתאפסים
-/// כשמתחלף דור של אחד משני הצדדים שההשוואה תלויה בהם:
-/// * **האינדקס** — החלפת המנוע ב-reopen (זהות ה-Future של הספק) או ריצת
-///   אינדוקס (מעברי `isIndexing`).
-/// * **הספרייה** — כל רענון מחליף את `DataRepository.instance.library`
-///   ב-Future חדש, גם כשעדכון אינדקס אוטומטי כבוי ושום אות אינדקס לא
-///   נורה; בלעדיו ספר שנערך היה מדולג לנצח.
-///
-/// כל איפוס מקדם epoch; בדיקה שנפתחה תחת epoch ישן אינה מציגה אזהרה
-/// ואינה נוגעת במטמונים — התוצאה שלה שייכת לדור שכבר איננו.
+/// החתימה נקראת פר-ספר (`getBookTextFingerprint` — TermQuery על filePath),
+/// ולא כמפת קורפוס מלאה: בדיקה של ספר אחד אינה משלמת O(כל המסמכים).
 class IndexFreshnessWarner {
   IndexFreshnessWarner._();
 
@@ -36,27 +29,25 @@ class IndexFreshnessWarner {
   TantivyDataProvider Function() providerResolver = () =>
       TantivyDataProvider.instance;
 
-  /// השוואת ספר-מול-חתימות, מוזרקת בבדיקות שאין להן DB חי לטעינת הטקסט.
-  /// מסלול טעינת המפה והמטמונים נשאר אמיתי גם אז.
+  /// השוואת ספר-מול-חתימה, מוזרקת בבדיקות שאין להן DB חי לטעינת הטקסט.
+  /// מסלול קריאת החתימה, ה-revision והמטמון נשאר אמיתי גם אז.
   @visibleForTesting
-  Future<bool> Function(Book book, Map<String, BigInt> fingerprints)?
-  debugBookVerifier;
+  Future<bool> Function(Book book, BigInt indexHash)? debugBookVerifier;
 
   /// הצגת האזהרה, מוזרקת בבדיקות. null = UiSnack.
   @visibleForTesting
   void Function(String message)? debugNotifier;
 
-  final Set<String> _checkedBookKeys = {};
-  Future<Map<String, BigInt>>? _fingerprints;
+  /// המפתח באינדקס → ה-revision של המקור בזמן הבדיקה המוצלחת האחרונה.
+  final Map<String, String> _checkedRevisionByKey = {};
+  ValueNotifier<bool>? _hookedIsIndexing;
   Future<SearchEngine>? _engineGeneration;
   Future<Library>? _libraryGeneration;
-  ValueNotifier<bool>? _hookedIsIndexing;
-  int _epoch = 0;
 
   @visibleForTesting
   void resetForTesting() {
-    _resetCaches();
-    _hookedIsIndexing?.removeListener(_resetCaches);
+    _checkedRevisionByKey.clear();
+    _hookedIsIndexing?.removeListener(_invalidate);
     _hookedIsIndexing = null;
     _engineGeneration = null;
     _libraryGeneration = null;
@@ -65,74 +56,105 @@ class IndexFreshnessWarner {
     debugNotifier = null;
   }
 
-  void _resetCaches() {
-    _epoch++;
-    _checkedBookKeys.clear();
-    _fingerprints = null;
-  }
+  void _invalidate() => _checkedRevisionByKey.clear();
 
-  /// בודק פעם אחת לספר (עד להתחלפות דור) ומזהיר על אי-התאמה ודאית.
-  /// לעולם אינו זורק — כשל אימות אינו מפריע לפתיחת התוצאה, ואינו נצרב
-  /// כדי שהבדיקה תנוסה שוב בפתיחה הבאה.
-  Future<void> warnIfContentDrifted(Book book) async {
-    final provider = providerResolver();
-    _hookIndexingInvalidation(provider);
-    _syncGenerations(provider);
-
-    final key = IndexingRepository.buildIndexedBookFilePath(book);
-    if (!_checkedBookKeys.add(key)) return;
-    final epoch = _epoch;
-    try {
-      final fingerprints = await (_fingerprints ??= provider.engine.then(
-        (engine) => engine.getBookTextFingerprints(),
-      ));
-      final matches = await (debugBookVerifier ?? _bookMatches)(
-        book,
-        fingerprints,
-      );
-      // הדור התחלף בזמן ההמתנה — התוצאה שייכת למפה/לתוכן שכבר אינם.
-      if (epoch != _epoch) return;
-      if (!matches) {
-        (debugNotifier ?? UiSnack.show)(
-          LibraryMessages.searchResultContentDrifted,
-        );
-      }
-    } catch (error) {
-      // אחרי איפוס אסור לגעת במטמונים של הדור החדש (הסרת key שנוסף בו,
-      // או מחיקת מפה טרייה) — הניקוי שייך רק לדור שבו הבדיקה התחילה.
-      if (epoch == _epoch) {
-        _checkedBookKeys.remove(key);
-        _fingerprints = null;
-      }
-      debugPrint('אימות טריות האינדקס נכשל עבור "${book.title}": $error');
-    }
-  }
-
-  /// סוף ריצת אינדוקס משנה את תוכן האינדקס; המאזין מאפס על כל מעבר, כך
-  /// שגם ספר "לא ניתן לאימות" נבדק מחדש אחרי בנייה חדשה.
-  void _hookIndexingInvalidation(TantivyDataProvider provider) {
-    if (identical(_hookedIsIndexing, provider.isIndexing)) return;
-    _hookedIsIndexing?.removeListener(_resetCaches);
-    _hookedIsIndexing = provider.isIndexing..addListener(_resetCaches);
-  }
-
-  /// שני צדי ההשוואה הם דורות: reopen מחליף את `provider.engine`, ורענון
-  /// ספרייה מחליף את `DataRepository.instance.library` — גם בלי שום
-  /// ריצת אינדוקס (עדכון אינדקס אוטומטי כבוי, עריכת ספר אישי).
-  void _syncGenerations(TantivyDataProvider provider) {
-    final engineGeneration = provider.engine;
-    final libraryGeneration = DataRepository.instance.library;
+  /// reopen מחליף את `provider.engine`, ורענון ספרייה את
+  /// `DataRepository.instance.library` — התחלפות של אחד מהם פוסלת את כל
+  /// מה שנבדק מול הדור הקודם.
+  void _invalidateOnGenerationChange(
+    Future<SearchEngine> engineGeneration,
+    Future<Library> libraryGeneration,
+  ) {
     if (identical(engineGeneration, _engineGeneration) &&
         identical(libraryGeneration, _libraryGeneration)) {
       return;
     }
     _engineGeneration = engineGeneration;
     _libraryGeneration = libraryGeneration;
-    _resetCaches();
+    _invalidate();
   }
 
-  Future<bool> _bookMatches(Book book, Map<String, BigInt> fingerprints) =>
-      IndexingRepository(
-        providerResolver(),
-      ).textBookContentMatchesIndex(book, fingerprints);
+  /// בודק ספר פעם אחת לכל שילוב של מפתח-אינדקס ו-revision של המקור,
+  /// ומזהיר על אי-התאמה ודאית. לעולם אינו זורק — כשל אימות אינו מפריע
+  /// לפתיחת התוצאה, ואינו נצרב כדי שהבדיקה תנוסה שוב בפתיחה הבאה.
+  Future<void> warnIfContentDrifted(Book book) async {
+    final provider = providerResolver();
+    _hookIndexingInvalidation(provider);
+
+    // צילום זהויות הדור *לפני* כל await: אינדקס שנפתח מחדש או ספרייה
+    // שהתרעננה בזמן ההמתנה הופכים את התוצאה הזו ללא-רלוונטית, גם אם שום
+    // בדיקה אחרת לא נכנסה בינתיים כדי להבחין בכך.
+    final engineGeneration = provider.engine;
+    final libraryGeneration = DataRepository.instance.library;
+    _invalidateOnGenerationChange(engineGeneration, libraryGeneration);
+
+    final key = IndexingRepository.buildIndexedBookFilePath(book);
+    try {
+      // ה-revision מזהה שינוי בקובץ המקור עצמו: ספר file-backed נקרא
+      // ישירות מהדיסק, ואין רענון ספרייה שיסמן עריכה חיצונית שלו.
+      final revision = await _sourceRevision(book);
+      if (_checkedRevisionByKey[key] == revision) return;
+
+      final engine = await engineGeneration;
+      final indexHash = await engine.getBookTextFingerprint(filePath: key);
+      final matches = await (debugBookVerifier ?? _bookMatches)(
+        book,
+        indexHash,
+      );
+
+      // אין await בין הבדיקה הזו לבין ההצגה/הכתיבה למטמון.
+      if (!_generationsUnchanged(
+        provider,
+        engineGeneration,
+        libraryGeneration,
+      )) {
+        return;
+      }
+      _checkedRevisionByKey[key] = revision;
+      if (!matches) {
+        (debugNotifier ?? UiSnack.show)(
+          LibraryMessages.searchResultContentDrifted,
+        );
+      }
+    } catch (error) {
+      debugPrint('אימות טריות האינדקס נכשל עבור "${book.title}": $error');
+    }
+  }
+
+  /// חתימת המקור של הספר: נתיב + זמן שינוי + גודל, כשיש קובץ מקור.
+  /// מחרוזת ריקה לספר שכל תוכנו ב-DB — שינוי בו מגיע דרך רענון ספרייה,
+  /// שממילא מאפס את המטמון.
+  Future<String> _sourceRevision(Book book) async {
+    final path = book is TextBook
+        ? book.filePath
+        : (book is FileBook ? book.path : null);
+    if (path == null || path.isEmpty) return '';
+    try {
+      final stat = await File(path).stat();
+      if (stat.type == FileSystemEntityType.notFound) return '';
+      return '$path|${stat.modified.millisecondsSinceEpoch}|${stat.size}';
+    } on FileSystemException {
+      return '';
+    }
+  }
+
+  bool _generationsUnchanged(
+    TantivyDataProvider provider,
+    Future<SearchEngine> engineGeneration,
+    Future<Library> libraryGeneration,
+  ) =>
+      identical(provider.engine, engineGeneration) &&
+      identical(DataRepository.instance.library, libraryGeneration);
+
+  /// סוף ריצת אינדוקס משנה את תוכן האינדקס; המאזין מאפס על כל מעבר, כך
+  /// שגם ספר "לא ניתן לאימות" נבדק מחדש אחרי בנייה חדשה.
+  void _hookIndexingInvalidation(TantivyDataProvider provider) {
+    if (identical(_hookedIsIndexing, provider.isIndexing)) return;
+    _hookedIsIndexing?.removeListener(_invalidate);
+    _hookedIsIndexing = provider.isIndexing..addListener(_invalidate);
+  }
+
+  Future<bool> _bookMatches(Book book, BigInt indexHash) => IndexingRepository(
+    providerResolver(),
+  ).textBookContentMatchesIndex(book, indexHash);
 }

--- a/lib/search/view/tantivy_search_results.dart
+++ b/lib/search/view/tantivy_search_results.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:otzaria/theme/app_tokens.dart';
 import 'package:flutter/services.dart';
@@ -13,6 +15,7 @@ import 'package:otzaria/search/bloc/search_event.dart';
 import 'package:otzaria/search/bloc/search_state.dart';
 import 'package:otzaria/search/models/search_configuration.dart';
 import 'package:otzaria/search/utils/in_book_search_routing.dart';
+import 'package:otzaria/search/utils/index_freshness_warner.dart';
 import 'package:otzaria/search/models/external_search_status.dart';
 import 'package:otzaria/search/utils/snippet_builder.dart';
 import 'package:otzaria/search/view/external_search_results_section.dart';
@@ -352,6 +355,7 @@ class _TantivySearchResultsState extends State<TantivySearchResults> {
       context.read<TabsBloc>().add(
         OpenOrFocusTab(tab, targetTitle: reference, insertAdjacent: true),
       );
+      unawaited(IndexFreshnessWarner.instance.warnIfContentDrifted(textBook));
     }
   }
 

--- a/lib/text_book/view/text_book_search_screen.dart
+++ b/lib/text_book/view/text_book_search_screen.dart
@@ -20,6 +20,7 @@ import 'package:otzaria/widgets/navigation/search_pane_base.dart';
 import 'package:otzaria/search/search_repository.dart';
 import 'package:otzaria/search/search_query_builder.dart';
 import 'package:otzaria/search/utils/in_book_search_routing.dart';
+import 'package:otzaria/search/utils/index_freshness_warner.dart';
 import 'package:otzaria/search/utils/snippet_builder.dart';
 import 'package:otzaria/search/book_facet.dart';
 import 'package:otzaria_search_engine/otzaria_search_engine.dart';
@@ -484,6 +485,14 @@ class TextBookSearchViewState extends State<TextBookSearchView>
 
       if (mounted && requestId == _activeSearchRequestId) {
         _applySearchResults(_convertSearchResults(results));
+        // מספרי השורות מהמנוע הם הבסיס לגלילה ולהדגשה — דריפט תוכן מחטיא
+        // בשקט, ולכן מוצגת אזהרה לא-חוסמת לצד התוצאות.
+        final state = context.read<TextBookBloc>().state;
+        if (state is TextBookLoaded) {
+          unawaited(
+            IndexFreshnessWarner.instance.warnIfContentDrifted(state.book),
+          );
+        }
       }
     } catch (e) {
       debugPrint('Search error: $e');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -74,7 +74,8 @@ dependencies:
   googleapis_auth: ^2.3.3
   characters: ^1.4.1
   collection: ^1.19.1
-  otzaria_search_engine: ^0.7.2
+# 0.7.3 (getBookTextFingerprints) טרם פורסם — pub get ייכשל עד פרסום הגרסה.
+  otzaria_search_engine: ^0.7.3
   seforim_library_updater:
     git:
       url: https://github.com/Otzaria/otzaria_library_updater

--- a/test/search/index_freshness_warner_test.dart
+++ b/test/search/index_freshness_warner_test.dart
@@ -1,0 +1,91 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/core/messages/library_messages.dart';
+import 'package:otzaria/indexing/repository/indexing_repository.dart';
+import 'package:otzaria/models/books.dart';
+import 'package:otzaria/search/utils/index_freshness_warner.dart';
+import 'package:otzaria/data/data_providers/tantivy_data_provider.dart';
+
+/// האזהרה הלא-חוסמת על דריפט תוכן (issue #828): התוצאה נפתחת תמיד,
+/// והאזהרה מוצגת פעם אחת לספר רק על אי-התאמה ודאית.
+void main() {
+  final warner = IndexFreshnessWarner.instance;
+
+  setUp(warner.resetForTesting);
+  tearDown(warner.resetForTesting);
+
+  test('ספר עם דריפט מזהיר פעם אחת בלבד', () async {
+    final book = TextBook(id: 1, title: 'ספר');
+    var verifierCalls = 0;
+    final notifications = <String>[];
+    warner.debugVerifier = (_) async {
+      verifierCalls++;
+      return false;
+    };
+    warner.debugNotifier = notifications.add;
+
+    await warner.warnIfContentDrifted(book);
+    await warner.warnIfContentDrifted(book);
+
+    expect(verifierCalls, 1);
+    expect(notifications, [LibraryMessages.searchResultContentDrifted]);
+  });
+
+  test('ספר טרי אינו מזהיר', () async {
+    final notifications = <String>[];
+    warner.debugVerifier = (_) async => true;
+    warner.debugNotifier = notifications.add;
+
+    await warner.warnIfContentDrifted(TextBook(id: 2, title: 'טרי'));
+
+    expect(notifications, isEmpty);
+  });
+
+  test('כשל אימות אינו מזהיר ואינו נצרב — ניסיון חוזר בפתיחה הבאה', () async {
+    final book = TextBook(id: 3, title: 'כושל');
+    var verifierCalls = 0;
+    final notifications = <String>[];
+    warner.debugVerifier = (_) async {
+      verifierCalls++;
+      if (verifierCalls == 1) throw StateError('engine down');
+      return false;
+    };
+    warner.debugNotifier = notifications.add;
+
+    await warner.warnIfContentDrifted(book);
+    expect(notifications, isEmpty);
+
+    await warner.warnIfContentDrifted(book);
+    expect(verifierCalls, 2);
+    expect(notifications, [LibraryMessages.searchResultContentDrifted]);
+  });
+
+  test('ספרים שונים נבדקים בנפרד', () async {
+    final checkedKeys = <String>[];
+    warner.debugVerifier = (book) async {
+      checkedKeys.add(IndexingRepository.buildIndexedBookFilePath(book));
+      return true;
+    };
+
+    await warner.warnIfContentDrifted(TextBook(id: 4, title: 'א'));
+    await warner.warnIfContentDrifted(TextBook(id: 5, title: 'ב'));
+
+    expect(checkedKeys, hasLength(2));
+    expect(checkedKeys.toSet(), hasLength(2));
+  });
+
+  test('אין חתימת טקסט באינדקס = לא ניתן לאימות = אין אזהרה', () async {
+    // המסלול המוקדם ב-textBookContentMatchesIndex — לפני כל קריאת FFI,
+    // ולכן הספק המזויף לעולם אינו נוגע.
+    final repository = IndexingRepository(_FakeTantivyDataProvider());
+    final fresh = await repository.textBookContentMatchesIndex(
+      TextBook(id: 6, title: 'בלי חתימה'),
+      const {},
+    );
+    expect(fresh, isTrue);
+  });
+}
+
+class _FakeTantivyDataProvider implements TantivyDataProvider {
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}

--- a/test/search/index_freshness_warner_test.dart
+++ b/test/search/index_freshness_warner_test.dart
@@ -1,23 +1,47 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:otzaria/core/messages/library_messages.dart';
+import 'package:otzaria/data/data_providers/tantivy_data_provider.dart';
 import 'package:otzaria/indexing/repository/indexing_repository.dart';
 import 'package:otzaria/models/books.dart';
 import 'package:otzaria/search/utils/index_freshness_warner.dart';
-import 'package:otzaria/data/data_providers/tantivy_data_provider.dart';
+import 'package:otzaria_search_engine/otzaria_search_engine.dart';
+
+import '../support/search_engine_test_init.dart';
 
 /// האזהרה הלא-חוסמת על דריפט תוכן (issue #828): התוצאה נפתחת תמיד,
-/// והאזהרה מוצגת פעם אחת לספר רק על אי-התאמה ודאית.
-void main() {
-  final warner = IndexFreshnessWarner.instance;
+/// האזהרה מוצגת רק על אי-התאמה ודאית, מפת החתימות נטענת פעם אחת לדור
+/// אינדקס, וכל המטמונים מתאפסים כשהאינדקס נבנה או נפתח מחדש.
+Future<void> main() async {
+  final engineReady = await tryInitSearchEngine();
 
-  setUp(warner.resetForTesting);
+  final warner = IndexFreshnessWarner.instance;
+  late _FakeTantivyDataProvider provider;
+
+  setUp(() {
+    warner.resetForTesting();
+    provider = _FakeTantivyDataProvider(_FakeSearchEngine());
+    warner.providerResolver = () => provider;
+  });
   tearDown(warner.resetForTesting);
+
+  test('מפת החתימות נטענת מהמנוע פעם אחת עבור כמה ספרים', () async {
+    // getBookTextFingerprints סורק את כל האינדקס — קריאה פר-ספר היא
+    // נסיגת ביצועים (ביקורת P1 על ה-PR).
+    for (var id = 1; id <= 3; id++) {
+      await warner.warnIfContentDrifted(TextBook(id: id, title: 'ספר $id'));
+    }
+
+    expect(provider.fakeEngine.fingerprintFetches, 1);
+  });
 
   test('ספר עם דריפט מזהיר פעם אחת בלבד', () async {
     final book = TextBook(id: 1, title: 'ספר');
     var verifierCalls = 0;
     final notifications = <String>[];
-    warner.debugVerifier = (_) async {
+    warner.debugBookVerifier = (_, _) async {
       verifierCalls++;
       return false;
     };
@@ -32,7 +56,7 @@ void main() {
 
   test('ספר טרי אינו מזהיר', () async {
     final notifications = <String>[];
-    warner.debugVerifier = (_) async => true;
+    warner.debugBookVerifier = (_, _) async => true;
     warner.debugNotifier = notifications.add;
 
     await warner.warnIfContentDrifted(TextBook(id: 2, title: 'טרי'));
@@ -40,52 +64,181 @@ void main() {
     expect(notifications, isEmpty);
   });
 
-  test('כשל אימות אינו מזהיר ואינו נצרב — ניסיון חוזר בפתיחה הבאה', () async {
-    final book = TextBook(id: 3, title: 'כושל');
-    var verifierCalls = 0;
+  test('ספר שאינו באינדקס — לא ניתן לאימות, אין אזהרה (מסלול אמיתי)', () async {
     final notifications = <String>[];
-    warner.debugVerifier = (_) async {
+    warner.debugNotifier = notifications.add;
+
+    // בלי debugBookVerifier: textBookContentMatchesIndex האמיתי רץ, ומחזיר
+    // true מוקדם כי המפה מהמנוע המזויף ריקה.
+    await warner.warnIfContentDrifted(TextBook(id: 3, title: 'לא באינדקס'));
+
+    expect(notifications, isEmpty);
+  });
+
+  test('סוף ריצת אינדוקס מאפס את המטמונים — הספר נבדק מחדש', () async {
+    // ביקורת P1: מטמון לכל חיי התהליך מחמיץ דריפט אחרי בנייה מחדש, וגם
+    // ספר שלא היה ניתן לאימות חייב להיבדק שוב אחרי בנייה.
+    final book = TextBook(id: 1, title: 'ספר');
+    var verifierCalls = 0;
+    warner.debugBookVerifier = (_, _) async {
       verifierCalls++;
-      if (verifierCalls == 1) throw StateError('engine down');
-      return false;
+      return true;
     };
+
+    await warner.warnIfContentDrifted(book);
+    provider.isIndexing.value = true;
+    provider.isIndexing.value = false;
+    await warner.warnIfContentDrifted(book);
+
+    expect(verifierCalls, 2);
+    expect(provider.fakeEngine.fingerprintFetches, 2);
+  });
+
+  test('reopen (החלפת ה-Future של המנוע) מאפס את המטמונים', () async {
+    final book = TextBook(id: 1, title: 'ספר');
+    var verifierCalls = 0;
+    warner.debugBookVerifier = (_, _) async {
+      verifierCalls++;
+      return true;
+    };
+
+    await warner.warnIfContentDrifted(book);
+    provider.replaceEngine(_FakeSearchEngine());
+    await warner.warnIfContentDrifted(book);
+
+    expect(verifierCalls, 2);
+    expect(provider.fakeEngine.fingerprintFetches, 1);
+  });
+
+  test('כשל בטעינת המפה אינו נצרב — לא לספר ולא למפה', () async {
+    final book = TextBook(id: 1, title: 'ספר');
+    provider.fakeEngine.failuresBeforeSuccess = 1;
+    final notifications = <String>[];
+    warner.debugBookVerifier = (_, _) async => false;
     warner.debugNotifier = notifications.add;
 
     await warner.warnIfContentDrifted(book);
     expect(notifications, isEmpty);
 
     await warner.warnIfContentDrifted(book);
-    expect(verifierCalls, 2);
+    expect(provider.fakeEngine.fingerprintFetches, 2);
     expect(notifications, [LibraryMessages.searchResultContentDrifted]);
   });
 
-  test('ספרים שונים נבדקים בנפרד', () async {
-    final checkedKeys = <String>[];
-    warner.debugVerifier = (book) async {
-      checkedKeys.add(IndexingRepository.buildIndexedBookFilePath(book));
-      return true;
-    };
+  group('אינטגרציה מול המנוע האמיתי', () {
+    late Directory indexDir;
+    late SearchEngine engine;
+    const bookText = '<h1>ספר</h1>\nשורה ראשונה של תוכן\nשורה שנייה';
 
-    await warner.warnIfContentDrifted(TextBook(id: 4, title: 'א'));
-    await warner.warnIfContentDrifted(TextBook(id: 5, title: 'ב'));
+    setUp(() {
+      if (!engineReady) return;
+      indexDir = Directory.systemTemp.createTempSync('freshness_warner');
+      engine = SearchEngine(path: indexDir.path);
+    });
 
-    expect(checkedKeys, hasLength(2));
-    expect(checkedKeys.toSet(), hasLength(2));
-  });
+    tearDown(() {
+      if (!engineReady) return;
+      try {
+        indexDir.deleteSync(recursive: true);
+      } on FileSystemException {
+        // ב-Windows המנוע עדיין מחזיק קבצים פתוחים; אין להפיל את הריצה.
+      }
+    });
 
-  test('אין חתימת טקסט באינדקס = לא ניתן לאימות = אין אזהרה', () async {
-    // המסלול המוקדם ב-textBookContentMatchesIndex — לפני כל קריאת FFI,
-    // ולכן הספק המזויף לעולם אינו נוגע.
-    final repository = IndexingRepository(_FakeTantivyDataProvider());
-    final fresh = await repository.textBookContentMatchesIndex(
-      TextBook(id: 6, title: 'בלי חתימה'),
-      const {},
-    );
-    expect(fresh, isTrue);
+    Future<void> indexBook(String text) async {
+      await engine.addTextBook(
+        title: 'ספר',
+        topics: '/root/ספר',
+        filePath: 'id:1',
+        catalogueOrder: 5,
+        generationOrder: 5,
+        text: text,
+      );
+      await engine.commit();
+    }
+
+    test('אינדוקס → getBookTextFingerprints → שינוי תוכן מזוהה', () async {
+      await indexBook(bookText);
+
+      final fingerprints = await engine.getBookTextFingerprints();
+      expect(
+        fingerprints['id:1'],
+        computeContentFingerprint(text: bookText),
+        reason: 'החתימה באינדקס זהה לחישוב על תוכן הספר',
+      );
+
+      const editedText = '$bookText\nשורה שנוספה בעריכה';
+      expect(
+        fingerprints['id:1'],
+        isNot(computeContentFingerprint(text: editedText)),
+        reason: 'תוכן שהשתנה אינו תואם את החתימה הישנה',
+      );
+
+      // אינדוקס מחדש של התוכן הערוך — החתימה החדשה תואמת אותו.
+      await engine.deleteDocumentsByFilePath(filePath: 'id:1');
+      await indexBook(editedText);
+      final refreshed = await engine.getBookTextFingerprints();
+      expect(refreshed['id:1'], computeContentFingerprint(text: editedText));
+    }, skip: !engineReady);
+
+    test('textBookContentMatchesIndex מכריע מול חתימות אמיתיות', () async {
+      await indexBook(bookText);
+      final fingerprints = await engine.getBookTextFingerprints();
+      final repository = IndexingRepository(
+        _FakeTantivyDataProvider(
+          _FakeSearchEngine(),
+        ),
+      );
+
+      // הספר אינו נטען מ-DB בבדיקה — ההשוואה מוזנת ישירות במפה: ספר שאין
+      // לו חתימה מוכרע "לא ניתן לאימות" (true), בלי לגעת במנוע.
+      final unverifiable = await repository.textBookContentMatchesIndex(
+        TextBook(id: 999, title: 'ספר אחר'),
+        fingerprints,
+      );
+      expect(unverifiable, isTrue);
+    }, skip: !engineReady);
   });
 }
 
+class _FakeSearchEngine implements SearchEngine {
+  final Map<String, BigInt> textFingerprints = {};
+  int fingerprintFetches = 0;
+  int failuresBeforeSuccess = 0;
+
+  @override
+  Future<Map<String, BigInt>> getBookTextFingerprints() async {
+    fingerprintFetches++;
+    if (failuresBeforeSuccess > 0) {
+      failuresBeforeSuccess--;
+      throw StateError('engine down');
+    }
+    return Map.of(textFingerprints);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
 class _FakeTantivyDataProvider implements TantivyDataProvider {
+  _FakeTantivyDataProvider(this.fakeEngine) {
+    engine = Future.value(fakeEngine);
+  }
+
+  _FakeSearchEngine fakeEngine;
+
+  @override
+  late Future<SearchEngine> engine;
+
+  @override
+  ValueNotifier<bool> isIndexing = ValueNotifier(false);
+
+  /// מדמה reopen: המנוע (וזהות ה-Future) מוחלפים, כמו ב-_doReopen האמיתי.
+  void replaceEngine(_FakeSearchEngine next) {
+    fakeEngine = next;
+    engine = Future.value(next);
+  }
+
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }

--- a/test/search/index_freshness_warner_test.dart
+++ b/test/search/index_freshness_warner_test.dart
@@ -203,6 +203,42 @@ Future<void> main() async {
     });
   });
 
+  test('אינדוקס פעיל לכל אורך הבדיקה אינו מזהיר ואינו נצרב', () async {
+    // רגרסיה: כשהערך כבר true בכניסה אין מעבר, ולכן ה-token נשאר תקף —
+    // והבדיקה קראה אינדקס שבאמצע בנייה והזהירה לשווא.
+    final book = TextBook(id: 1, title: 'ספר');
+    final notifications = <String>[];
+    warner.debugBookVerifier = (_, _) async => false;
+    warner.debugNotifier = notifications.add;
+
+    provider.isIndexing.value = true;
+    await warner.warnIfContentDrifted(book);
+
+    expect(notifications, isEmpty, reason: 'אין השוואה מול אינדקס בבנייה');
+    expect(provider.fakeEngine.requestedPaths, isEmpty);
+
+    // אחרי סיום האינדוקס אותו ספר נבדק כרגיל.
+    provider.isIndexing.value = false;
+    await warner.warnIfContentDrifted(book);
+
+    expect(notifications, [LibraryMessages.searchResultContentDrifted]);
+  });
+
+  test('אינדוקס שמתחיל באמצע ההמתנה מבטל את התוצאה', () async {
+    final book = TextBook(id: 1, title: 'ספר');
+    final gate = Completer<bool>();
+    final notifications = <String>[];
+    warner.debugBookVerifier = (_, _) => gate.future;
+    warner.debugNotifier = notifications.add;
+
+    final pending = warner.warnIfContentDrifted(book);
+    provider.isIndexing.value = true;
+    gate.complete(false);
+    await pending;
+
+    expect(notifications, isEmpty);
+  });
+
   test('שתי בדיקות מקבילות לאותו ספר מתאחדות לריצה אחת', () async {
     // רגרסיה: הרשומה נכנסת למטמון רק בסוף הבדיקה, ולכן שתי פתיחות מקבילות
     // גיבבו את הספר פעמיים והציגו שתי אזהרות.

--- a/test/search/index_freshness_warner_test.dart
+++ b/test/search/index_freshness_warner_test.dart
@@ -173,6 +173,22 @@ Future<void> main() async {
       expect(notifications, [LibraryMessages.searchResultContentDrifted]);
     });
 
+    test('מעבר isIndexing באמצע ההמתנה מבטל את התוצאה הישנה', () async {
+      // רגרסיה: זהויות ה-Future אינן משתנות בריצת אינדוקס, ולכן ההשוואה
+      // מולן לבדה לא הגנה — נדרש מונה שעולה בכל פסילת מטמון.
+      final pending = warner.warnIfContentDrifted(book);
+      provider.isIndexing.value = true;
+      provider.isIndexing.value = false;
+      gate.complete(false);
+      await pending;
+
+      expect(notifications, isEmpty, reason: 'תוצאה מדור ישן אינה מוצגת');
+
+      warner.debugBookVerifier = (_, _) async => false;
+      await warner.warnIfContentDrifted(book);
+      expect(notifications, [LibraryMessages.searchResultContentDrifted]);
+    });
+
     test('reopen באמצע ההמתנה מבטל את התוצאה הישנה', () async {
       final pending = warner.warnIfContentDrifted(book);
       provider.replaceEngine(_FakeSearchEngine());
@@ -185,6 +201,29 @@ Future<void> main() async {
       await warner.warnIfContentDrifted(book);
       expect(notifications, [LibraryMessages.searchResultContentDrifted]);
     });
+  });
+
+  test('שתי בדיקות מקבילות לאותו ספר מתאחדות לריצה אחת', () async {
+    // רגרסיה: הרשומה נכנסת למטמון רק בסוף הבדיקה, ולכן שתי פתיחות מקבילות
+    // גיבבו את הספר פעמיים והציגו שתי אזהרות.
+    final book = TextBook(id: 1, title: 'ספר');
+    final gate = Completer<bool>();
+    var verifierCalls = 0;
+    final notifications = <String>[];
+    warner.debugBookVerifier = (_, _) {
+      verifierCalls++;
+      return gate.future;
+    };
+    warner.debugNotifier = notifications.add;
+
+    final first = warner.warnIfContentDrifted(book);
+    final second = warner.warnIfContentDrifted(book);
+    gate.complete(false);
+    await Future.wait([first, second]);
+
+    expect(verifierCalls, 1, reason: 'הספר גובב פעם אחת');
+    expect(provider.fakeEngine.requestedPaths, ['id:1']);
+    expect(notifications, [LibraryMessages.searchResultContentDrifted]);
   });
 
   test('כשל בקריאת החתימה אינו נצרב — ניסיון חוזר בפתיחה הבאה', () async {

--- a/test/search/index_freshness_warner_test.dart
+++ b/test/search/index_freshness_warner_test.dart
@@ -262,6 +262,34 @@ Future<void> main() async {
     expect(notifications, [LibraryMessages.searchResultContentDrifted]);
   });
 
+  test('כשל בריצה משותפת נבלע גם אצל הקורא המצטרף', () async {
+    // רגרסיה: הקורא המצטרף קיבל את ה-Future המשותף ב-return בלי await —
+    // השגיאה עקפה את ה-try שלו והפכה ל-async error גלובלי.
+    final book = TextBook(id: 1, title: 'ספר');
+    final gate = Completer<bool>();
+    // ההמתנה לכניסה ל-verifier מבטיחה שיש מאזין ל-gate לפני השגיאה,
+    // אחרת היא נזקפת כ-unhandled לפני שהמסלול הגיע אליה בכלל.
+    final entered = Completer<void>();
+    warner.debugBookVerifier = (_, _) {
+      if (!entered.isCompleted) entered.complete();
+      return gate.future;
+    };
+
+    final first = warner.warnIfContentDrifted(book);
+    final second = warner.warnIfContentDrifted(book);
+    await entered.future;
+    gate.completeError(StateError('verification failed'));
+    // שני הקוראים משלימים בלי throw.
+    await Future.wait([first, second]);
+
+    // והכשל לא נצרב: קריאה מאוחרת מנסה מחדש ומצליחה להזהיר.
+    final notifications = <String>[];
+    warner.debugNotifier = notifications.add;
+    warner.debugBookVerifier = (_, _) async => false;
+    await warner.warnIfContentDrifted(book);
+    expect(notifications, [LibraryMessages.searchResultContentDrifted]);
+  });
+
   test('כשל בקריאת החתימה אינו נצרב — ניסיון חוזר בפתיחה הבאה', () async {
     final book = TextBook(id: 1, title: 'ספר');
     provider.fakeEngine.failuresBeforeSuccess = 1;
@@ -317,6 +345,34 @@ Future<void> main() async {
         2,
         reason: 'שינוי בקובץ פוסל את המטמון בלי engine/library חדשים',
       );
+    });
+
+    test('שינוי הקובץ בזמן האימות מבטל את התוצאה הישנה', () async {
+      // רגרסיה: ה-revision נלכד בכניסה אך לא נבדק שוב בסוף — continuation
+      // ישן כתב revision ישן והציג אזהרה שכבר אינה נכונה לתוכן הנוכחי.
+      final book = TextBook(id: 1, title: 'ספר', filePath: sourceFile.path);
+      final gate = Completer<bool>();
+      final notifications = <String>[];
+      warner.debugBookVerifier = (_, _) => gate.future;
+      warner.debugNotifier = notifications.add;
+
+      final pending = warner.warnIfContentDrifted(book);
+      await Future<void>.delayed(Duration.zero);
+      sourceFile.writeAsStringSync('תוכן חדש שנכתב באמצע האימות');
+      gate.complete(false);
+      await pending;
+
+      expect(notifications, isEmpty, reason: 'תוצאה מול תוכן ישן אינה מוצגת');
+
+      // ולא נצרבה: פתיחה חדשה בודקת את ה-revision החדש ומזהירה.
+      var checkedAgain = false;
+      warner.debugBookVerifier = (_, _) async {
+        checkedAgain = true;
+        return false;
+      };
+      await warner.warnIfContentDrifted(book);
+      expect(checkedAgain, isTrue);
+      expect(notifications, [LibraryMessages.searchResultContentDrifted]);
     });
 
     test('ספר בלי קובץ מקור נשמר במטמון כרגיל', () async {

--- a/test/search/index_freshness_warner_test.dart
+++ b/test/search/index_freshness_warner_test.dart
@@ -1,29 +1,42 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
+import 'package:flutter_settings_screens/flutter_settings_screens.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:otzaria/core/messages/library_messages.dart';
 import 'package:otzaria/data/data_providers/tantivy_data_provider.dart';
+import 'package:otzaria/data/repository/data_repository.dart';
 import 'package:otzaria/indexing/repository/indexing_repository.dart';
+import 'package:otzaria/library/models/library.dart';
 import 'package:otzaria/models/books.dart';
 import 'package:otzaria/search/utils/index_freshness_warner.dart';
 import 'package:otzaria_search_engine/otzaria_search_engine.dart';
 
 import '../support/search_engine_test_init.dart';
+import '../test_helpers/memory_cache_provider.dart';
 
 /// האזהרה הלא-חוסמת על דריפט תוכן (issue #828): התוצאה נפתחת תמיד,
-/// האזהרה מוצגת רק על אי-התאמה ודאית, מפת החתימות נטענת פעם אחת לדור
-/// אינדקס, וכל המטמונים מתאפסים כשהאינדקס נבנה או נפתח מחדש.
+/// האזהרה מוצגת רק על אי-התאמה ודאית, מפת החתימות נטענת פעם אחת לדור,
+/// וכל המטמונים מתאפסים כשמתחלף דור האינדקס **או** דור הספרייה.
 Future<void> main() async {
+  TestWidgetsFlutterBinding.ensureInitialized();
   final engineReady = await tryInitSearchEngine();
 
   final warner = IndexFreshnessWarner.instance;
   late _FakeTantivyDataProvider provider;
 
+  setUpAll(() async {
+    await Settings.init(cacheProvider: MemoryCacheProvider());
+  });
+
   setUp(() {
     warner.resetForTesting();
     provider = _FakeTantivyDataProvider(_FakeSearchEngine());
     warner.providerResolver = () => provider;
+    DataRepository.instance.library = Future.value(
+      Library(categories: const []),
+    );
   });
   tearDown(warner.resetForTesting);
 
@@ -108,6 +121,68 @@ Future<void> main() async {
 
     expect(verifierCalls, 2);
     expect(provider.fakeEngine.fingerprintFetches, 1);
+  });
+
+  test('רענון ספרייה בלי שום אות אינדוקס מאפס את המטמון', () async {
+    // רגרסיה מהביקורת: כשעדכון אינדקס אוטומטי כבוי, רענון DB מחליף את
+    // תוכן הספרייה בלי reopen ובלי מעבר isIndexing — ההחלפה של ה-Future
+    // ב-DataRepository היא האות היחיד, ובלעדיו ספר שנערך מדולג לנצח.
+    final book = TextBook(id: 1, title: 'ספר');
+    var verifierCalls = 0;
+    warner.debugBookVerifier = (_, _) async {
+      verifierCalls++;
+      return true;
+    };
+
+    await warner.warnIfContentDrifted(book);
+    DataRepository.instance.library = Future.value(
+      Library(categories: const []),
+    );
+    await warner.warnIfContentDrifted(book);
+
+    expect(verifierCalls, 2);
+  });
+
+  test('בדיקה שנפתחה לפני איפוס אינה מזהירה מהדור הישן', () async {
+    // הדור מתחלף בזמן ה-await על מפת החתימות: התוצאה הישנה נבלעת, ובדיקה
+    // חדשה של אותו ספר רצה מלאה ומזהירה.
+    final gate = Completer<Map<String, BigInt>>();
+    provider.fakeEngine.pendingFingerprints = gate;
+    final notifications = <String>[];
+    warner.debugBookVerifier = (_, _) async => false;
+    warner.debugNotifier = notifications.add;
+
+    final stale = warner.warnIfContentDrifted(TextBook(id: 1, title: 'ספר'));
+    provider.isIndexing.value = true;
+    provider.isIndexing.value = false;
+    gate.complete(const {});
+    await stale;
+    expect(notifications, isEmpty, reason: 'תוצאה מדור ישן אינה מוצגת');
+
+    await warner.warnIfContentDrifted(TextBook(id: 1, title: 'ספר'));
+    expect(notifications, [LibraryMessages.searchResultContentDrifted]);
+  });
+
+  test('כשל מדור ישן אינו נוגע במטמונים של הדור החדש', () async {
+    final gate = Completer<Map<String, BigInt>>();
+    provider.fakeEngine.pendingFingerprints = gate;
+    warner.debugBookVerifier = (_, _) async => true;
+
+    final stale = warner.warnIfContentDrifted(TextBook(id: 1, title: 'א'));
+    provider.isIndexing.value = true;
+    provider.isIndexing.value = false;
+    // הדור החדש טוען מפה תקינה ונשמר במטמון.
+    await warner.warnIfContentDrifted(TextBook(id: 2, title: 'ב'));
+    // ה-catch של הדור הישן — אסור לו למחוק את המפה החדשה.
+    gate.completeError(StateError('old generation failed'));
+    await stale;
+    await warner.warnIfContentDrifted(TextBook(id: 3, title: 'ג'));
+
+    expect(
+      provider.fakeEngine.fingerprintFetches,
+      2,
+      reason: 'המפה של הדור החדש שרדה את הכשל הישן',
+    );
   });
 
   test('כשל בטעינת המפה אינו נצרב — לא לספר ולא למפה', () async {
@@ -206,14 +281,22 @@ class _FakeSearchEngine implements SearchEngine {
   int fingerprintFetches = 0;
   int failuresBeforeSuccess = 0;
 
+  /// טעינה חד-פעמית שנשלטת מהבדיקה (לתרחישי איפוס באמצע המתנה).
+  Completer<Map<String, BigInt>>? pendingFingerprints;
+
   @override
-  Future<Map<String, BigInt>> getBookTextFingerprints() async {
+  Future<Map<String, BigInt>> getBookTextFingerprints() {
     fingerprintFetches++;
+    final pending = pendingFingerprints;
+    if (pending != null) {
+      pendingFingerprints = null;
+      return pending.future;
+    }
     if (failuresBeforeSuccess > 0) {
       failuresBeforeSuccess--;
-      throw StateError('engine down');
+      return Future.error(StateError('engine down'));
     }
-    return Map.of(textFingerprints);
+    return Future.value(Map.of(textFingerprints));
   }
 
   @override

--- a/test/search/index_freshness_warner_test.dart
+++ b/test/search/index_freshness_warner_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter/foundation.dart';
@@ -7,7 +8,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:otzaria/core/messages/library_messages.dart';
 import 'package:otzaria/data/data_providers/tantivy_data_provider.dart';
 import 'package:otzaria/data/repository/data_repository.dart';
-import 'package:otzaria/indexing/repository/indexing_repository.dart';
 import 'package:otzaria/library/models/library.dart';
 import 'package:otzaria/models/books.dart';
 import 'package:otzaria/search/utils/index_freshness_warner.dart';
@@ -17,8 +17,8 @@ import '../support/search_engine_test_init.dart';
 import '../test_helpers/memory_cache_provider.dart';
 
 /// האזהרה הלא-חוסמת על דריפט תוכן (issue #828): התוצאה נפתחת תמיד,
-/// האזהרה מוצגת רק על אי-התאמה ודאית, מפת החתימות נטענת פעם אחת לדור,
-/// וכל המטמונים מתאפסים כשמתחלף דור האינדקס **או** דור הספרייה.
+/// האזהרה מוצגת רק על אי-התאמה ודאית, החתימה נקראת פר-ספר, והמטמון נפסל
+/// בכל התחלפות דור (אינדקס/ספרייה) או שינוי בקובץ המקור.
 Future<void> main() async {
   TestWidgetsFlutterBinding.ensureInitialized();
   final engineReady = await tryInitSearchEngine();
@@ -40,14 +40,17 @@ Future<void> main() async {
   });
   tearDown(warner.resetForTesting);
 
-  test('מפת החתימות נטענת מהמנוע פעם אחת עבור כמה ספרים', () async {
-    // getBookTextFingerprints סורק את כל האינדקס — קריאה פר-ספר היא
-    // נסיגת ביצועים (ביקורת P1 על ה-PR).
+  test('החתימה נקראת פר-ספר, פעם אחת לכל ספר', () async {
+    // ה-API הממוקד מחליף את מפת הקורפוס המלאה: כל ספר נקרא בנפרד, ובדיקה
+    // חוזרת של אותו ספר אינה פונה למנוע שוב.
+    warner.debugBookVerifier = (_, _) async => true;
+
     for (var id = 1; id <= 3; id++) {
       await warner.warnIfContentDrifted(TextBook(id: id, title: 'ספר $id'));
     }
+    await warner.warnIfContentDrifted(TextBook(id: 1, title: 'ספר 1'));
 
-    expect(provider.fakeEngine.fingerprintFetches, 1);
+    expect(provider.fakeEngine.requestedPaths, ['id:1', 'id:2', 'id:3']);
   });
 
   test('ספר עם דריפט מזהיר פעם אחת בלבד', () async {
@@ -77,20 +80,21 @@ Future<void> main() async {
     expect(notifications, isEmpty);
   });
 
-  test('ספר שאינו באינדקס — לא ניתן לאימות, אין אזהרה (מסלול אמיתי)', () async {
-    final notifications = <String>[];
-    warner.debugNotifier = notifications.add;
+  test(
+    'ספר בלי חתימה באינדקס — לא ניתן לאימות, אין אזהרה (מסלול אמיתי)',
+    () async {
+      final notifications = <String>[];
+      warner.debugNotifier = notifications.add;
 
-    // בלי debugBookVerifier: textBookContentMatchesIndex האמיתי רץ, ומחזיר
-    // true מוקדם כי המפה מהמנוע המזויף ריקה.
-    await warner.warnIfContentDrifted(TextBook(id: 3, title: 'לא באינדקס'));
+      // בלי debugBookVerifier: textBookContentMatchesIndex האמיתי רץ ומחזיר
+      // true מוקדם, כי המנוע המזויף מחזיר 0 ("לא ניתן לאימות").
+      await warner.warnIfContentDrifted(TextBook(id: 3, title: 'לא באינדקס'));
 
-    expect(notifications, isEmpty);
-  });
+      expect(notifications, isEmpty);
+    },
+  );
 
-  test('סוף ריצת אינדוקס מאפס את המטמונים — הספר נבדק מחדש', () async {
-    // ביקורת P1: מטמון לכל חיי התהליך מחמיץ דריפט אחרי בנייה מחדש, וגם
-    // ספר שלא היה ניתן לאימות חייב להיבדק שוב אחרי בנייה.
+  test('סוף ריצת אינדוקס מאפס את המטמון — הספר נבדק מחדש', () async {
     final book = TextBook(id: 1, title: 'ספר');
     var verifierCalls = 0;
     warner.debugBookVerifier = (_, _) async {
@@ -104,10 +108,9 @@ Future<void> main() async {
     await warner.warnIfContentDrifted(book);
 
     expect(verifierCalls, 2);
-    expect(provider.fakeEngine.fingerprintFetches, 2);
   });
 
-  test('reopen (החלפת ה-Future של המנוע) מאפס את המטמונים', () async {
+  test('reopen (החלפת ה-Future של המנוע) מאפס את המטמון', () async {
     final book = TextBook(id: 1, title: 'ספר');
     var verifierCalls = 0;
     warner.debugBookVerifier = (_, _) async {
@@ -120,13 +123,9 @@ Future<void> main() async {
     await warner.warnIfContentDrifted(book);
 
     expect(verifierCalls, 2);
-    expect(provider.fakeEngine.fingerprintFetches, 1);
   });
 
   test('רענון ספרייה בלי שום אות אינדוקס מאפס את המטמון', () async {
-    // רגרסיה מהביקורת: כשעדכון אינדקס אוטומטי כבוי, רענון DB מחליף את
-    // תוכן הספרייה בלי reopen ובלי מעבר isIndexing — ההחלפה של ה-Future
-    // ב-DataRepository היא האות היחיד, ובלעדיו ספר שנערך מדולג לנצח.
     final book = TextBook(id: 1, title: 'ספר');
     var verifierCalls = 0;
     warner.debugBookVerifier = (_, _) async {
@@ -143,49 +142,52 @@ Future<void> main() async {
     expect(verifierCalls, 2);
   });
 
-  test('בדיקה שנפתחה לפני איפוס אינה מזהירה מהדור הישן', () async {
-    // הדור מתחלף בזמן ה-await על מפת החתימות: התוצאה הישנה נבלעת, ובדיקה
-    // חדשה של אותו ספר רצה מלאה ומזהירה.
-    final gate = Completer<Map<String, BigInt>>();
-    provider.fakeEngine.pendingFingerprints = gate;
-    final notifications = <String>[];
-    warner.debugBookVerifier = (_, _) async => false;
-    warner.debugNotifier = notifications.add;
+  group('פסילת מטמון בזמן ההמתנה', () {
+    late TextBook book;
+    late Completer<bool> gate;
+    late List<String> notifications;
 
-    final stale = warner.warnIfContentDrifted(TextBook(id: 1, title: 'ספר'));
-    provider.isIndexing.value = true;
-    provider.isIndexing.value = false;
-    gate.complete(const {});
-    await stale;
-    expect(notifications, isEmpty, reason: 'תוצאה מדור ישן אינה מוצגת');
+    setUp(() {
+      book = TextBook(id: 1, title: 'ספר');
+      gate = Completer<bool>();
+      notifications = [];
+      warner.debugBookVerifier = (_, _) => gate.future;
+      warner.debugNotifier = notifications.add;
+    });
 
-    await warner.warnIfContentDrifted(TextBook(id: 1, title: 'ספר'));
-    expect(notifications, [LibraryMessages.searchResultContentDrifted]);
+    test('החלפת ספרייה באמצע ההמתנה מבטלת את התוצאה הישנה', () async {
+      // רגרסיה: ה-epoch לבדו לא הגן, כי החלפת ה-Future אינה מודיעה ל-warner
+      // והיא מזוהה רק בכניסה הבאה לבדיקה.
+      final pending = warner.warnIfContentDrifted(book);
+      DataRepository.instance.library = Future.value(
+        Library(categories: const []),
+      );
+      gate.complete(false);
+      await pending;
+
+      expect(notifications, isEmpty, reason: 'תוצאה מדור ישן אינה מוצגת');
+
+      // ולא נצרבה: בדיקה חדשה של אותו ספר רצה במלואה ומזהירה.
+      warner.debugBookVerifier = (_, _) async => false;
+      await warner.warnIfContentDrifted(book);
+      expect(notifications, [LibraryMessages.searchResultContentDrifted]);
+    });
+
+    test('reopen באמצע ההמתנה מבטל את התוצאה הישנה', () async {
+      final pending = warner.warnIfContentDrifted(book);
+      provider.replaceEngine(_FakeSearchEngine());
+      gate.complete(false);
+      await pending;
+
+      expect(notifications, isEmpty);
+
+      warner.debugBookVerifier = (_, _) async => false;
+      await warner.warnIfContentDrifted(book);
+      expect(notifications, [LibraryMessages.searchResultContentDrifted]);
+    });
   });
 
-  test('כשל מדור ישן אינו נוגע במטמונים של הדור החדש', () async {
-    final gate = Completer<Map<String, BigInt>>();
-    provider.fakeEngine.pendingFingerprints = gate;
-    warner.debugBookVerifier = (_, _) async => true;
-
-    final stale = warner.warnIfContentDrifted(TextBook(id: 1, title: 'א'));
-    provider.isIndexing.value = true;
-    provider.isIndexing.value = false;
-    // הדור החדש טוען מפה תקינה ונשמר במטמון.
-    await warner.warnIfContentDrifted(TextBook(id: 2, title: 'ב'));
-    // ה-catch של הדור הישן — אסור לו למחוק את המפה החדשה.
-    gate.completeError(StateError('old generation failed'));
-    await stale;
-    await warner.warnIfContentDrifted(TextBook(id: 3, title: 'ג'));
-
-    expect(
-      provider.fakeEngine.fingerprintFetches,
-      2,
-      reason: 'המפה של הדור החדש שרדה את הכשל הישן',
-    );
-  });
-
-  test('כשל בטעינת המפה אינו נצרב — לא לספר ולא למפה', () async {
+  test('כשל בקריאת החתימה אינו נצרב — ניסיון חוזר בפתיחה הבאה', () async {
     final book = TextBook(id: 1, title: 'ספר');
     provider.fakeEngine.failuresBeforeSuccess = 1;
     final notifications = <String>[];
@@ -196,8 +198,65 @@ Future<void> main() async {
     expect(notifications, isEmpty);
 
     await warner.warnIfContentDrifted(book);
-    expect(provider.fakeEngine.fingerprintFetches, 2);
     expect(notifications, [LibraryMessages.searchResultContentDrifted]);
+  });
+
+  group('revision של קובץ מקור', () {
+    late Directory dir;
+    late File sourceFile;
+
+    setUp(() {
+      dir = Directory.systemTemp.createTempSync('freshness_revision');
+      sourceFile = File('${dir.path}/book.txt')..writeAsStringSync('שורה');
+    });
+
+    tearDown(() {
+      try {
+        dir.deleteSync(recursive: true);
+      } on FileSystemException {
+        // ignore
+      }
+    });
+
+    test('עריכת קובץ המקור מחייבת בדיקה מחדש בלי דור חדש', () async {
+      // רגרסיה: ספר file-backed נקרא ישירות מהדיסק, ואין רענון ספרייה
+      // שמסמן עריכה חיצונית — המטמון היה מחזיר "תקין" לנצח.
+      final book = TextBook(id: 1, title: 'ספר', filePath: sourceFile.path);
+      var verifierCalls = 0;
+      warner.debugBookVerifier = (_, _) async {
+        verifierCalls++;
+        return true;
+      };
+
+      await warner.warnIfContentDrifted(book);
+      expect(verifierCalls, 1);
+
+      await warner.warnIfContentDrifted(book);
+      expect(verifierCalls, 1, reason: 'בלי שינוי בקובץ — מהמטמון');
+
+      sourceFile.writeAsStringSync('שורה ערוכה וארוכה יותר');
+      await warner.warnIfContentDrifted(book);
+
+      expect(
+        verifierCalls,
+        2,
+        reason: 'שינוי בקובץ פוסל את המטמון בלי engine/library חדשים',
+      );
+    });
+
+    test('ספר בלי קובץ מקור נשמר במטמון כרגיל', () async {
+      var verifierCalls = 0;
+      warner.debugBookVerifier = (_, _) async {
+        verifierCalls++;
+        return true;
+      };
+      final book = TextBook(id: 9, title: 'ספר DB');
+
+      await warner.warnIfContentDrifted(book);
+      await warner.warnIfContentDrifted(book);
+
+      expect(verifierCalls, 1);
+    });
   });
 
   group('אינטגרציה מול המנוע האמיתי', () {
@@ -232,71 +291,66 @@ Future<void> main() async {
       await engine.commit();
     }
 
-    test('אינדוקס → getBookTextFingerprints → שינוי תוכן מזוהה', () async {
+    test('אינדוקס → getBookTextFingerprint → שינוי תוכן מזוהה', () async {
       await indexBook(bookText);
 
-      final fingerprints = await engine.getBookTextFingerprints();
+      // ה-API הממוקד — זה שהאזהרה קוראת בפועל — ובאותו נשימה גם parity
+      // מול הגרסה האסינכרונית שהאימות משתמש בה.
+      final indexed = await engine.getBookTextFingerprint(filePath: 'id:1');
       expect(
-        fingerprints['id:1'],
+        indexed,
+        await computeContentFingerprintBytes(text: utf8Bytes(bookText)),
+        reason: 'החתימה באינדקס זהה לחישוב האסינכרוני על תוכן הספר',
+      );
+      expect(
+        indexed,
         computeContentFingerprint(text: bookText),
-        reason: 'החתימה באינדקס זהה לחישוב על תוכן הספר',
+        reason: 'parity בין המסלול הסינכרוני לאסינכרוני',
       );
 
       const editedText = '$bookText\nשורה שנוספה בעריכה';
       expect(
-        fingerprints['id:1'],
-        isNot(computeContentFingerprint(text: editedText)),
+        indexed,
+        isNot(
+          await computeContentFingerprintBytes(text: utf8Bytes(editedText)),
+        ),
         reason: 'תוכן שהשתנה אינו תואם את החתימה הישנה',
       );
 
-      // אינדוקס מחדש של התוכן הערוך — החתימה החדשה תואמת אותו.
       await engine.deleteDocumentsByFilePath(filePath: 'id:1');
       await indexBook(editedText);
-      final refreshed = await engine.getBookTextFingerprints();
-      expect(refreshed['id:1'], computeContentFingerprint(text: editedText));
+      expect(
+        await engine.getBookTextFingerprint(filePath: 'id:1'),
+        await computeContentFingerprintBytes(text: utf8Bytes(editedText)),
+      );
     }, skip: !engineReady);
 
-    test('textBookContentMatchesIndex מכריע מול חתימות אמיתיות', () async {
+    test('ספר שאינו באינדקס מוכרע "לא ניתן לאימות" (0)', () async {
       await indexBook(bookText);
-      final fingerprints = await engine.getBookTextFingerprints();
-      final repository = IndexingRepository(
-        _FakeTantivyDataProvider(
-          _FakeSearchEngine(),
-        ),
+      expect(
+        await engine.getBookTextFingerprint(filePath: 'id:404'),
+        BigInt.zero,
       );
-
-      // הספר אינו נטען מ-DB בבדיקה — ההשוואה מוזנת ישירות במפה: ספר שאין
-      // לו חתימה מוכרע "לא ניתן לאימות" (true), בלי לגעת במנוע.
-      final unverifiable = await repository.textBookContentMatchesIndex(
-        TextBook(id: 999, title: 'ספר אחר'),
-        fingerprints,
-      );
-      expect(unverifiable, isTrue);
     }, skip: !engineReady);
   });
 }
 
+Uint8List utf8Bytes(String text) =>
+    Uint8List.fromList(const Utf8Encoder().convert(text));
+
 class _FakeSearchEngine implements SearchEngine {
+  final List<String> requestedPaths = [];
   final Map<String, BigInt> textFingerprints = {};
-  int fingerprintFetches = 0;
   int failuresBeforeSuccess = 0;
 
-  /// טעינה חד-פעמית שנשלטת מהבדיקה (לתרחישי איפוס באמצע המתנה).
-  Completer<Map<String, BigInt>>? pendingFingerprints;
-
   @override
-  Future<Map<String, BigInt>> getBookTextFingerprints() {
-    fingerprintFetches++;
-    final pending = pendingFingerprints;
-    if (pending != null) {
-      pendingFingerprints = null;
-      return pending.future;
-    }
+  Future<BigInt> getBookTextFingerprint({required String filePath}) {
+    requestedPaths.add(filePath);
     if (failuresBeforeSuccess > 0) {
       failuresBeforeSuccess--;
       return Future.error(StateError('engine down'));
     }
-    return Future.value(Map.of(textFingerprints));
+    return Future.value(textFingerprints[filePath] ?? BigInt.zero);
   }
 
   @override


### PR DESCRIPTION
## מה זה מוסיף

השלמה לתיקון issue #828 (שכבר ב-#812): שם הוסר שער טביעת האצבע שחסם פתיחת תוצאות, ובכך ויתרנו זמנית על גילוי דריפט תוכן אמיתי. ה-PR הזה מחזיר את הגילוי — **כאזהרה לא-חוסמת** במקום חסימה:

- `IndexFreshnessWarner` — בדיקה רכה שרצה ברקע אחרי שהתוצאה כבר נפתחה (או אחרי שתוצאות חלונית החיפוש שבספר כבר הוצגו). על אי-התאמה ודאית מוצג `UiSnack`: "תוכן הספר השתנה מאז עדכון האינדקס — מומלץ לעדכן את אינדקס החיפוש".
- ההשוואה מול **חתימת הטקסט-בלבד** (`getBookTextFingerprint`) — שאינה נפסלת משינויי סדר קטלוגי, בניגוד לחתימה הקנונית שגרמה ל-#828. החתימה נקראת פר-ספר (`TermQuery` על `filePath`), ולא כמפת קורפוס מלאה.
- "לא ניתן לאימות" (אין חתימה, אינדוקס פעיל, כשל טעינה) = שקט, בלי אזהרת שווא. כשל אינו נצרב — הבדיקה תנוסה שוב בפתיחה הבאה.
- המאמת הקנוני המת `textBookMatchesIndexedFingerprint` (ללא קוראים מאז #812) הוחלף במאמת הטקסט `textBookContentMatchesIndex`.

## תלות במנוע — הושלמה

נשען על [otzaria_search_engine#13](https://github.com/Otzaria/otzaria_search_engine/pull/13), שמוזג ופורסם כ-**0.7.3**: עמודת `textHash`, `get_book_text_fingerprint(file_path)` הממוקד, ו-`compute_content_fingerprint_bytes` האסינכרוני. האילוץ ב-`pubspec.yaml` הוא `^0.7.3` ונפתר מול הגרסה שב-pub.dev.

## נכונות תחת מקביליות ופסילת מטמון

הבדיקה רצה ברקע לצד רענוני ספרייה, פתיחות מנוע וריצות אינדוקס, ולכן היא שמורה בכל אחד מאלה — כל אחד מכוסה בבדיקה משלו:

| מצב | התנהגות |
|---|---|
| רענון ספרייה (גם בלי אינדוקס) | המטמון נפסל, הספר נבדק מחדש |
| `reopen` של המנוע | המטמון נפסל |
| ריצת אינדוקס (מעבר `isIndexing`) | המטמון נפסל; אינדוקס **פעיל** = אין בדיקה בכלל |
| עריכת קובץ מקור file-backed | `revision` (נתיב+mtime+גודל) פוסל את הרשומה |
| החלפת דור/עריכת קובץ **באמצע** ההמתנה | התוצאה הישנה נזרקת, לא נצרבת, לא מוצגת |
| שתי פתיחות מקבילות לאותו ספר | ריצה אחת משותפת, גיבוב אחד, אזהרה אחת |
| כשל בריצה משותפת | נבלע אצל שני הקוראים, נשאר בר-ניסיון |

## בדיקות

`test/search/index_freshness_warner_test.dart` — 20 בדיקות המכסות את כל השורות בטבלה, ובהן שתי בדיקות אינטגרציה מול המנוע האמיתי (אינדוקס → `getBookTextFingerprint` → שינוי תוכן מזוהה → אינדוקס מחדש מיישר את החתימה, עם parity בין המסלול הסינכרוני לאסינכרוני). הן מדולגות אוטומטית כשאין build זמין של המנוע, כמו שאר הבדיקות תלויות-המנוע בפרויקט.

הענף בנוי מעל `dev` שכבר כולל את #812, ולכן הדיף כאן הוא תוספת ה-warner בלבד.
