### PR TITLE
שינויי אייקונים חלק ב

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,59 +116,119 @@ lib/
 
 ## MANDATORY UI Components
 
-### 1. Icons - ONLY from `fluentui_system_icons`
+### 1. Icons - `otzaria_icons` FIRST, `fluentui_system_icons` for the rest
 ```dart
+import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
 import 'package:otzaria/widgets/misc/rtl_icon.dart';
 
-// Regular icon (symmetric, no RTL flipping needed):
-Icon(FluentIcons.search_24_regular)
-Icon(FluentIcons.settings_24_regular)
+// First choice — the app's own set. ALWAYS plain Icon(), never RtlIcon:
+Icon(OtzariaIcons.book_pdf_24_regular)
+Icon(OtzariaIcons.otzaria_icon_2_page_24_regular)
+Icon(OtzariaIcons.calendar_24_regular)
 
-// RtlIcon — ONLY for icons registered in lib/widgets/misc/rtl_icon.dart:
-RtlIcon(FluentIcons.book_24_filled)              // in _flippableIcons
-RtlIcon(FluentIcons.arrow_left_24_regular)        // in _fluentMirrorMap — auto-mirrors to arrow_right in RTL
+// Fallback — Fluent, only for what otzaria_icons does not have:
+Icon(FluentIcons.settings_24_regular)
 RtlIcon(FluentIcons.chevron_right_24_regular)     // in _fluentMirrorMap
+RtlIcon(FluentIcons.arrow_left_24_regular)        // in _fluentMirrorMap — auto-mirrors to arrow_right in RTL
 ```
+
+**What `otzaria_icons` is for.** It is not a general-purpose set and does not try to cover Fluent. It exists for exactly four cases:
+
+1. An icon that **breaks when mirrored** for RTL — a geometric flip mangles it.
+2. An icon that is **always shown in an RTL context**, so it should simply be drawn that way.
+3. An icon **Fluent does not have** (`stander`, `torah_scroll`, `yoma_deilula`, the `alef_*`/`beit_*`/`tet_*` families).
+4. An icon Fluent has but whose form is **less suitable** for a seforim library (`book_pdf` over a generic document).
+
+Anything outside those four — generic UI chrome like `dismiss`, `delete`, `copy`, `folder`, `settings`, `add`, `edit` — stays on Fluent. Redrawing chrome buys nothing and costs consistency.
+
+**Which library — in this order:**
+
+| Does `otzaria_icons` have an icon for it? | Use |
+|---|---|
+| Yes | `Icon(OtzariaIcons....)` — always plain `Icon` |
+| No | `fluentui_system_icons`, per the `RtlIcon` rule below |
+| Neither, but Material does | Draw it in `otzaria_icons` — **never** import Material |
+
+`otzaria_icons` is purpose-built for a Hebrew seforim library, so prefer it even when Fluent has *something* close: `book_pdf` for a PDF book rather than a generic document, `search_in_the_book` / `search_in_the_library` / `search_in_the_settings` for scoped search, the `alef_*` / `beit_*` / `tet_*` families for nikud, punctuation and font settings, `stander` / `torah_scroll` / `yoma_deilula` where nothing in Fluent applies.
+
+**Deliberate exceptions — these stay on Fluent:**
+
+| Case | Icon | Why |
+|---|---|---|
+| The seforim library itself | `FluentIcons.library_24_regular/filled` | The Fluent library is the app's established symbol for it |
+| In-book search action (toolbar button, side-panel tab, context-menu `חיפוש`) in `text_book/` and `pdf_book/` | `FluentIcons.search_24_regular/filled` | Recognized as *the* search affordance in the reading screen |
+| Search icon inside a **labeled** button (`ActionButton`, `FilledButton.icon` — e.g. `פתח חיפוש טקסט`, `חפש`) | `FluentIcons.search_24_regular` | Beside a label the Fluent glyph reads cleaner. Icon-only buttons and field prefixes are not affected |
+| A **direct link** to a book or a section (`קישור ישיר`, deep links, inserting a hyperlink) | `FluentIcons.link_24_regular` | Distinct from links *between* books |
+| The private-book badge on a library card (8px) | `FluentIcons.person_24_regular` | The Otzaria person is drawn for legible sizes; at 8px it turns to mush. `OtzariaIcons.person_24_regular` stays everywhere it renders at 16px+ |
+
+**Links between books** — the `קישורים` panel tab, the `קישורים` context-menu entry, `דורות וקישורים` — use `OtzariaIcons.link_24_regular`. The rule in practice: singular `קישור` / `קישור ישיר` is Fluent, plural `קישורים` is Otzaria. Two similar icons for the two meanings would be confusing, so keep the split.
+
+**Scoped search — pick the icon that names *what* is being searched.** A generic magnifier says nothing; these do. None of the scoped icons has a `filled` twin, so a selected/unselected pair reuses the same glyph and lets color carry the state.
+
+| Where | Icon |
+|---|---|
+| Library screen search, `סינון מפרשים`, `חפש בתוך המפרשים המוצגים`, שמור וזכור search | `search_in_the_library_24_regular` |
+| Notes search, calendar `חפש גם בתיאור` | `search_in_the_document_24_regular` |
+| Calendar `חפש רק בכותרת` | `search_in_the_text_24_regular` |
+| `הוסף ספרים למעקב` dialog | `search_in_the_book_24_regular` |
+| Settings search | `search_in_the_settings_24_regular` |
+| `איתור כותרת` boxes (TOC, alt-TOC), bookmarks search, `חפש בתוך הקישורים המוצגים` | `search_in_titles_24_regular` |
+| Gematria search | `search_in_numbered_list_24_regular` |
+
+The **navigation rail's `חיפוש`** item is the exception: it keeps plain `OtzariaIcons.search_24_regular` / `search_24_filled`, because it is the app-wide search entry point and not scoped to anything.
+
+Three shared widgets take an `icon:` / `searchIcon:` parameter for exactly this — `OtzariaSearchField`, `ItemsListView`, and any field's `prefixIcon`. Pass the scoped icon rather than wrapping the prefix in a `leading:` widget, which would drop `OtzariaSearchField`'s focus-color and sizing behaviour.
+
+**Finding an icon:** 135 icons, listed in `OtzariaIcons.values` and in the package's `index.html` catalog. The names follow the Fluent convention (`<name>_24_<regular|filled>`), so a Fluent name is usually the right thing to look up first. `otzaria_icons` is pinned by commit in `pubspec.lock`, and **`pubspec.lock` is gitignored** — if an icon in the catalog is undefined in your checkout, run `flutter pub upgrade otzaria_icons`.
+
+**Sizes:** every icon is drawn on a 24px grid, and the `_24_` in the name is the grid, not a size limit — pass `size:` freely. But the `book_open_*` family is drawn at different weights for different display sizes; `otzaria_icon_2_page_24_regular/filled` is the general-purpose "open book" and the only one of them with a `filled` twin, so it is what a nav rail or any regular/filled pair needs.
+
+**`OtzariaIcons` NEVER goes through `RtlIcon`.** Every icon in the set is drawn right-to-left already — `RtlIcon` would flip an icon that already faces the correct way. `test/widgets/rtl_icon_registered_usage_test.dart` fails the build on any `RtlIcon(OtzariaIcons....)`.
 
 **When to use `RtlIcon` vs `Icon`:**
 
-| Icon is registered in `rtl_icon.dart`? | Use |
+| Icon | Use |
 |---|---|
-| Yes (in `_fluentMirrorMap`, `_materialMirrorMap`, or `_flippableIcons`) | `RtlIcon(...)` |
-| No | `Icon(...)` — plain, no wrapper |
+| Any `OtzariaIcons.…` | `Icon(...)` — always |
+| Fluent icon registered in `rtl_icon.dart` (`_fluentMirrorMap`, `_flippableIcons`) | `RtlIcon(...)` |
+| Any other Fluent icon | `Icon(...)` — plain, no wrapper |
 
 **Icons currently registered in `lib/widgets/misc/rtl_icon.dart`:**
 
 *`_fluentMirrorMap` (swaps to opposite-direction variant in RTL):*
 - `chevron_right/left_24/20/16_regular`
 - `arrow_right/left_24_regular`, `arrow_right/left_24_filled`
+- `arrow_previous/next_24_regular`
+- `calendar_24_regular/filled` → `calendar_rtl_*`
 - `panel_left/right_24_regular`, `panel_left/right_24_filled`
 - `text_align_right/left_24_regular`
 
-*`_materialMirrorMap` (Material icons, swaps in RTL):*
-- `arrow_forward/back`, `arrow_forward/back_ios`
-- `arrow_right/left`, `chevron_right/left`
-- `navigate_next/before`, `keyboard_arrow_right/left`
-- `first_page/last_page`, `skip_next/previous`
-
-*`_flippableIcons` (geometrically flipped in RTL — no opposite-direction variant in library):*
+*`_flippableIcons` (geometrically flipped in RTL — no opposite-direction variant in Fluent):*
 - `book_24_regular`, `book_24_filled`
 - `book_information_24_regular`
 - `text_align_distributed_24_regular`
 - `list_24_regular`
+- `calendar_week_start_24_regular/filled`, `calendar_month_24_regular/filled`
 
-**If you need to flip an icon that is NOT yet registered:**
-Add it to the appropriate set/map in `lib/widgets/misc/rtl_icon.dart`, then use `RtlIcon`. Do NOT add manual `Transform.flip`/`Transform.scale` in feature files.
+`_flippableIcons` is a **stopgap, not a destination.** A geometric flip mirrors the whole glyph, including asymmetric detail that was never meant to mirror. When an icon looks wrong flipped, the fix is to draw it right-to-left in `otzaria_icons` and drop it from this set — that is what `book_star_24_regular` did. The remaining six are the open candidates.
+
+There is no `_materialMirrorMap` any more: `lib/` contains **zero** Material icons, and nothing can feed one to `RtlIcon` (plugins declare icons by *Fluent* name through `fluentIconFromName`), so the map was dead code.
+
+Some Fluent entries here have no call site left in `lib/` — the app moved to the `OtzariaIcons` equivalent. **Do not delete those:** a plugin can still name a Fluent icon through `fluentIconFromName` in `lib/plugins/utils/fluent_icon_resolver.dart`, and it reaches `RtlIcon` as a variable.
+
+**If you need to flip a Fluent icon that is NOT yet registered:**
+Prefer drawing it in `otzaria_icons` — that is exactly what the package is for. Registering it in `_flippableIcons` is the fallback when you cannot. Either way, do NOT add manual `Transform.flip`/`Transform.scale` in feature files.
 
 **Never use:**
-- Material Icons (unless in `_materialMirrorMap` above)
+- Material Icons — no exceptions. `lib/` is Material-free; if Material has something Fluent lacks, draw it in `otzaria_icons`
 - Cupertino Icons
-- Custom icon fonts
-- Random icon packages
+- Any icon font other than `otzaria_icons` and `fluentui_system_icons`
+- `RtlIcon` with an `OtzariaIcons` icon — it is already RTL
 - `mirrorIcon` parameter on any widget — **FORBIDDEN**, removed in commit 3b4d357
-- Manual `Transform.scale(scaleX: -1, ...)` or `Transform.flip(flipX: true, ...)` around icons — register in `rtl_icon.dart` instead
+- Manual `Transform.scale(scaleX: -1, ...)` or `Transform.flip(flipX: true, ...)` around icons — register in `rtl_icon.dart` instead. **On an `OtzariaIcons` icon this silently points it the wrong way**, and neither the analyzer nor `rtl_icon_registered_usage_test.dart` catches it — when replacing a Fluent icon, check the call site for a hand-rolled flip first
 - Comments explaining why `RtlIcon` or `Icon(...)` was chosen — the decision rule is documented here; do NOT repeat it inline in code
+- Editing `lib/plugins/utils/fluent_icon_resolver.dart` to point at `otzaria_icons` — it is the generated Fluent-name contract for plugins
 
 ### 2. User Messages - ONLY via `UiSnack`
 ```dart
@@ -872,7 +932,7 @@ if (Platform.isAndroid || Platform.isIOS) {
 1. **No progression with errors** - Fix ALL analyzer errors before next step
 2. **Run `flutter analyze` after EVERY file change** - Don't accumulate errors
 3. **RTL text fields** - Use `RtlTextField` exclusively, never `TextField`
-4. **Icons** - Only `fluentui_system_icons`. Use `RtlIcon` **only** for icons registered in `lib/widgets/misc/rtl_icon.dart` (`_fluentMirrorMap`, `_materialMirrorMap`, `_flippableIcons`). All other icons: plain `Icon(...)`. Never add manual `Transform` on icons — register in `rtl_icon.dart` instead.
+4. **Icons** - `otzaria_icons` first, `fluentui_system_icons` only for what it lacks, **Material never**. `OtzariaIcons` always uses plain `Icon(...)` — never `RtlIcon`, it is already RTL. `RtlIcon` is for Fluent icons registered in `lib/widgets/misc/rtl_icon.dart` (`_fluentMirrorMap`, `_flippableIcons`); all others: plain `Icon(...)`. Never add manual `Transform` on icons.
 5. **User messages** - Only through `UiSnack`, never direct SnackBar
 6. **Dialogs** - Only through `custom_ui_components` (SingleActionDialog, TwoActionsDialog, WarningDialog)
 7. **Action buttons** - Only `ActionButton.recommended` / `.neutral` / `.ghost` from `widgets_exports.dart`
@@ -896,9 +956,11 @@ if (Platform.isAndroid || Platform.isIOS) {
 - Asking multiple separate questions instead of batching all open questions into one message
 - Writing a large diff to fix what should be a small bug
 - Using `TextField` instead of `RtlTextField`
-- Using Material/Cupertino icons instead of FluentUI (unless Material icon is in `_materialMirrorMap` in `rtl_icon.dart`)
-- Using `RtlIcon` for icons **not** registered in `lib/widgets/misc/rtl_icon.dart` — check first; if not registered, use plain `Icon(...)`
-- Forgetting to use `RtlIcon` for icons that **are** registered in `lib/widgets/misc/rtl_icon.dart`
+- Reaching for a Fluent icon when `otzaria_icons` already has one for it — check `OtzariaIcons` first
+- Using a Material or Cupertino icon at all — `lib/` is Material-free and must stay that way
+- Wrapping an `OtzariaIcons` icon in `RtlIcon` — it is drawn RTL already, and `rtl_icon_registered_usage_test.dart` fails on it
+- Using `RtlIcon` for Fluent icons **not** registered in `lib/widgets/misc/rtl_icon.dart` — check first; if not registered, use plain `Icon(...)`
+- Forgetting to use `RtlIcon` for Fluent icons that **are** registered in `lib/widgets/misc/rtl_icon.dart`
 - Adding `mirrorIcon` parameter to any widget — FORBIDDEN (removed in commit 3b4d357)
 - Manual `Transform.scale(scaleX: -1)` or `Transform.flip` on icons — register the icon in `rtl_icon.dart` instead
 - Adding inline comments that explain why `RtlIcon` or `Icon(...)` was chosen — the decision rule lives in CLAUDE.md, not in code

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,59 +116,119 @@ lib/
 
 ## MANDATORY UI Components
 
-### 1. Icons - ONLY from `fluentui_system_icons`
+### 1. Icons - `otzaria_icons` FIRST, `fluentui_system_icons` for the rest
 ```dart
+import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
 import 'package:otzaria/widgets/misc/rtl_icon.dart';
 
-// Regular icon (symmetric, no RTL flipping needed):
-Icon(FluentIcons.search_24_regular)
-Icon(FluentIcons.settings_24_regular)
+// First choice — the app's own set. ALWAYS plain Icon(), never RtlIcon:
+Icon(OtzariaIcons.book_pdf_24_regular)
+Icon(OtzariaIcons.otzaria_icon_2_page_24_regular)
+Icon(OtzariaIcons.calendar_24_regular)
 
-// RtlIcon — ONLY for icons registered in lib/widgets/misc/rtl_icon.dart:
-RtlIcon(FluentIcons.book_24_filled)              // in _flippableIcons
-RtlIcon(FluentIcons.arrow_left_24_regular)        // in _fluentMirrorMap — auto-mirrors to arrow_right in RTL
+// Fallback — Fluent, only for what otzaria_icons does not have:
+Icon(FluentIcons.settings_24_regular)
 RtlIcon(FluentIcons.chevron_right_24_regular)     // in _fluentMirrorMap
+RtlIcon(FluentIcons.arrow_left_24_regular)        // in _fluentMirrorMap — auto-mirrors to arrow_right in RTL
 ```
+
+**What `otzaria_icons` is for.** It is not a general-purpose set and does not try to cover Fluent. It exists for exactly four cases:
+
+1. An icon that **breaks when mirrored** for RTL — a geometric flip mangles it.
+2. An icon that is **always shown in an RTL context**, so it should simply be drawn that way.
+3. An icon **Fluent does not have** (`stander`, `torah_scroll`, `yoma_deilula`, the `alef_*`/`beit_*`/`tet_*` families).
+4. An icon Fluent has but whose form is **less suitable** for a seforim library (`book_pdf` over a generic document).
+
+Anything outside those four — generic UI chrome like `dismiss`, `delete`, `copy`, `folder`, `settings`, `add`, `edit` — stays on Fluent. Redrawing chrome buys nothing and costs consistency.
+
+**Which library — in this order:**
+
+| Does `otzaria_icons` have an icon for it? | Use |
+|---|---|
+| Yes | `Icon(OtzariaIcons....)` — always plain `Icon` |
+| No | `fluentui_system_icons`, per the `RtlIcon` rule below |
+| Neither, but Material does | Draw it in `otzaria_icons` — **never** import Material |
+
+`otzaria_icons` is purpose-built for a Hebrew seforim library, so prefer it even when Fluent has *something* close: `book_pdf` for a PDF book rather than a generic document, `search_in_the_book` / `search_in_the_library` / `search_in_the_settings` for scoped search, the `alef_*` / `beit_*` / `tet_*` families for nikud, punctuation and font settings, `stander` / `torah_scroll` / `yoma_deilula` where nothing in Fluent applies.
+
+**Deliberate exceptions — these stay on Fluent:**
+
+| Case | Icon | Why |
+|---|---|---|
+| The seforim library itself | `FluentIcons.library_24_regular/filled` | The Fluent library is the app's established symbol for it |
+| In-book search action (toolbar button, side-panel tab, context-menu `חיפוש`) in `text_book/` and `pdf_book/` | `FluentIcons.search_24_regular/filled` | Recognized as *the* search affordance in the reading screen |
+| Search icon inside a **labeled** button (`ActionButton`, `FilledButton.icon` — e.g. `פתח חיפוש טקסט`, `חפש`) | `FluentIcons.search_24_regular` | Beside a label the Fluent glyph reads cleaner. Icon-only buttons and field prefixes are not affected |
+| A **direct link** to a book or a section (`קישור ישיר`, deep links, inserting a hyperlink) | `FluentIcons.link_24_regular` | Distinct from links *between* books |
+| The private-book badge on a library card (8px) | `FluentIcons.person_24_regular` | The Otzaria person is drawn for legible sizes; at 8px it turns to mush. `OtzariaIcons.person_24_regular` stays everywhere it renders at 16px+ |
+
+**Links between books** — the `קישורים` panel tab, the `קישורים` context-menu entry, `דורות וקישורים` — use `OtzariaIcons.link_24_regular`. The rule in practice: singular `קישור` / `קישור ישיר` is Fluent, plural `קישורים` is Otzaria. Two similar icons for the two meanings would be confusing, so keep the split.
+
+**Scoped search — pick the icon that names *what* is being searched.** A generic magnifier says nothing; these do. None of the scoped icons has a `filled` twin, so a selected/unselected pair reuses the same glyph and lets color carry the state.
+
+| Where | Icon |
+|---|---|
+| Library screen search, `סינון מפרשים`, `חפש בתוך המפרשים המוצגים`, שמור וזכור search | `search_in_the_library_24_regular` |
+| Notes search, calendar `חפש גם בתיאור` | `search_in_the_document_24_regular` |
+| Calendar `חפש רק בכותרת` | `search_in_the_text_24_regular` |
+| `הוסף ספרים למעקב` dialog | `search_in_the_book_24_regular` |
+| Settings search | `search_in_the_settings_24_regular` |
+| `איתור כותרת` boxes (TOC, alt-TOC), bookmarks search, `חפש בתוך הקישורים המוצגים` | `search_in_titles_24_regular` |
+| Gematria search | `search_in_numbered_list_24_regular` |
+
+The **navigation rail's `חיפוש`** item is the exception: it keeps plain `OtzariaIcons.search_24_regular` / `search_24_filled`, because it is the app-wide search entry point and not scoped to anything.
+
+Three shared widgets take an `icon:` / `searchIcon:` parameter for exactly this — `OtzariaSearchField`, `ItemsListView`, and any field's `prefixIcon`. Pass the scoped icon rather than wrapping the prefix in a `leading:` widget, which would drop `OtzariaSearchField`'s focus-color and sizing behaviour.
+
+**Finding an icon:** 135 icons, listed in `OtzariaIcons.values` and in the package's `index.html` catalog. The names follow the Fluent convention (`<name>_24_<regular|filled>`), so a Fluent name is usually the right thing to look up first. `otzaria_icons` is pinned by commit in `pubspec.lock`, and **`pubspec.lock` is gitignored** — if an icon in the catalog is undefined in your checkout, run `flutter pub upgrade otzaria_icons`.
+
+**Sizes:** every icon is drawn on a 24px grid, and the `_24_` in the name is the grid, not a size limit — pass `size:` freely. But the `book_open_*` family is drawn at different weights for different display sizes; `otzaria_icon_2_page_24_regular/filled` is the general-purpose "open book" and the only one of them with a `filled` twin, so it is what a nav rail or any regular/filled pair needs.
+
+**`OtzariaIcons` NEVER goes through `RtlIcon`.** Every icon in the set is drawn right-to-left already — `RtlIcon` would flip an icon that already faces the correct way. `test/widgets/rtl_icon_registered_usage_test.dart` fails the build on any `RtlIcon(OtzariaIcons....)`.
 
 **When to use `RtlIcon` vs `Icon`:**
 
-| Icon is registered in `rtl_icon.dart`? | Use |
+| Icon | Use |
 |---|---|
-| Yes (in `_fluentMirrorMap`, `_materialMirrorMap`, or `_flippableIcons`) | `RtlIcon(...)` |
-| No | `Icon(...)` — plain, no wrapper |
+| Any `OtzariaIcons.…` | `Icon(...)` — always |
+| Fluent icon registered in `rtl_icon.dart` (`_fluentMirrorMap`, `_flippableIcons`) | `RtlIcon(...)` |
+| Any other Fluent icon | `Icon(...)` — plain, no wrapper |
 
 **Icons currently registered in `lib/widgets/misc/rtl_icon.dart`:**
 
 *`_fluentMirrorMap` (swaps to opposite-direction variant in RTL):*
 - `chevron_right/left_24/20/16_regular`
 - `arrow_right/left_24_regular`, `arrow_right/left_24_filled`
+- `arrow_previous/next_24_regular`
+- `calendar_24_regular/filled` → `calendar_rtl_*`
 - `panel_left/right_24_regular`, `panel_left/right_24_filled`
 - `text_align_right/left_24_regular`
 
-*`_materialMirrorMap` (Material icons, swaps in RTL):*
-- `arrow_forward/back`, `arrow_forward/back_ios`
-- `arrow_right/left`, `chevron_right/left`
-- `navigate_next/before`, `keyboard_arrow_right/left`
-- `first_page/last_page`, `skip_next/previous`
-
-*`_flippableIcons` (geometrically flipped in RTL — no opposite-direction variant in library):*
+*`_flippableIcons` (geometrically flipped in RTL — no opposite-direction variant in Fluent):*
 - `book_24_regular`, `book_24_filled`
 - `book_information_24_regular`
 - `text_align_distributed_24_regular`
 - `list_24_regular`
+- `calendar_week_start_24_regular/filled`, `calendar_month_24_regular/filled`
 
-**If you need to flip an icon that is NOT yet registered:**
-Add it to the appropriate set/map in `lib/widgets/misc/rtl_icon.dart`, then use `RtlIcon`. Do NOT add manual `Transform.flip`/`Transform.scale` in feature files.
+`_flippableIcons` is a **stopgap, not a destination.** A geometric flip mirrors the whole glyph, including asymmetric detail that was never meant to mirror. When an icon looks wrong flipped, the fix is to draw it right-to-left in `otzaria_icons` and drop it from this set — that is what `book_star_24_regular` did. The remaining six are the open candidates.
+
+There is no `_materialMirrorMap` any more: `lib/` contains **zero** Material icons, and nothing can feed one to `RtlIcon` (plugins declare icons by *Fluent* name through `fluentIconFromName`), so the map was dead code.
+
+Some Fluent entries here have no call site left in `lib/` — the app moved to the `OtzariaIcons` equivalent. **Do not delete those:** a plugin can still name a Fluent icon through `fluentIconFromName` in `lib/plugins/utils/fluent_icon_resolver.dart`, and it reaches `RtlIcon` as a variable.
+
+**If you need to flip a Fluent icon that is NOT yet registered:**
+Prefer drawing it in `otzaria_icons` — that is exactly what the package is for. Registering it in `_flippableIcons` is the fallback when you cannot. Either way, do NOT add manual `Transform.flip`/`Transform.scale` in feature files.
 
 **Never use:**
-- Material Icons (unless in `_materialMirrorMap` above)
+- Material Icons — no exceptions. `lib/` is Material-free; if Material has something Fluent lacks, draw it in `otzaria_icons`
 - Cupertino Icons
-- Custom icon fonts
-- Random icon packages
+- Any icon font other than `otzaria_icons` and `fluentui_system_icons`
+- `RtlIcon` with an `OtzariaIcons` icon — it is already RTL
 - `mirrorIcon` parameter on any widget — **FORBIDDEN**, removed in commit 3b4d357
-- Manual `Transform.scale(scaleX: -1, ...)` or `Transform.flip(flipX: true, ...)` around icons — register in `rtl_icon.dart` instead
+- Manual `Transform.scale(scaleX: -1, ...)` or `Transform.flip(flipX: true, ...)` around icons — register in `rtl_icon.dart` instead. **On an `OtzariaIcons` icon this silently points it the wrong way**, and neither the analyzer nor `rtl_icon_registered_usage_test.dart` catches it — when replacing a Fluent icon, check the call site for a hand-rolled flip first
 - Comments explaining why `RtlIcon` or `Icon(...)` was chosen — the decision rule is documented here; do NOT repeat it inline in code
+- Editing `lib/plugins/utils/fluent_icon_resolver.dart` to point at `otzaria_icons` — it is the generated Fluent-name contract for plugins
 
 ### 2. User Messages - ONLY via `UiSnack`
 ```dart
@@ -937,7 +997,7 @@ if (Platform.isAndroid || Platform.isIOS) {
 1. **No progression with errors** - Fix ALL analyzer errors before next step
 2. **Run `flutter analyze` after EVERY file change** - Don't accumulate errors
 3. **RTL text fields** - Use `RtlTextField` exclusively, never `TextField`
-4. **Icons** - Only `fluentui_system_icons`. Use `RtlIcon` **only** for icons registered in `lib/widgets/misc/rtl_icon.dart` (`_fluentMirrorMap`, `_materialMirrorMap`, `_flippableIcons`). All other icons: plain `Icon(...)`. Never add manual `Transform` on icons — register in `rtl_icon.dart` instead.
+4. **Icons** - `otzaria_icons` first, `fluentui_system_icons` only for what it lacks, **Material never**. `OtzariaIcons` always uses plain `Icon(...)` — never `RtlIcon`, it is already RTL. `RtlIcon` is for Fluent icons registered in `lib/widgets/misc/rtl_icon.dart` (`_fluentMirrorMap`, `_flippableIcons`); all others: plain `Icon(...)`. Never add manual `Transform` on icons.
 5. **User messages** - Only through `UiSnack`, never direct SnackBar
 6. **Dialogs** - Only through `custom_ui_components` (SingleActionDialog, TwoActionsDialog, WarningDialog)
 7. **Action buttons** - Only `ActionButton.recommended` / `.neutral` / `.ghost` from `widgets_exports.dart`
@@ -962,9 +1022,11 @@ if (Platform.isAndroid || Platform.isIOS) {
 - Asking multiple separate questions instead of batching all open questions into one message
 - Writing a large diff to fix what should be a small bug
 - Using `TextField` instead of `RtlTextField`
-- Using Material/Cupertino icons instead of FluentUI (unless Material icon is in `_materialMirrorMap` in `rtl_icon.dart`)
-- Using `RtlIcon` for icons **not** registered in `lib/widgets/misc/rtl_icon.dart` — check first; if not registered, use plain `Icon(...)`
-- Forgetting to use `RtlIcon` for icons that **are** registered in `lib/widgets/misc/rtl_icon.dart`
+- Reaching for a Fluent icon when `otzaria_icons` already has one for it — check `OtzariaIcons` first
+- Using a Material or Cupertino icon at all — `lib/` is Material-free and must stay that way
+- Wrapping an `OtzariaIcons` icon in `RtlIcon` — it is drawn RTL already, and `rtl_icon_registered_usage_test.dart` fails on it
+- Using `RtlIcon` for Fluent icons **not** registered in `lib/widgets/misc/rtl_icon.dart` — check first; if not registered, use plain `Icon(...)`
+- Forgetting to use `RtlIcon` for Fluent icons that **are** registered in `lib/widgets/misc/rtl_icon.dart`
 - Adding `mirrorIcon` parameter to any widget — FORBIDDEN (removed in commit 3b4d357)
 - Manual `Transform.scale(scaleX: -1)` or `Transform.flip` on icons — register the icon in `rtl_icon.dart` instead
 - Adding inline comments that explain why `RtlIcon` or `Icon(...)` was chosen — the decision rule lives in CLAUDE.md, not in code

--- a/lib/bookmarks/view/bookmark_screen.dart
+++ b/lib/bookmarks/view/bookmark_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:otzaria/widgets/dialogs/reusable_items_dialog.dart';
 import 'package:otzaria/bookmarks/bloc/bookmark_bloc.dart';
@@ -298,13 +299,14 @@ class _BookmarkViewState extends State<BookmarkView> {
             }
           },
           hintText: 'חפש בסימניות...',
+          searchIcon: OtzariaIcons.search_in_titles_24_regular,
           emptyText: bookFilter == null ? 'אין סימניות' : 'אין סימניות בספר זה',
           notFoundText: 'לא נמצאו תוצאות',
           clearAllText: bookFilter == null
               ? 'מחק את כל הסימניות'
               : 'מחק סימניות הספר',
           leadingIconBuilder: (item) => item.book is PdfBook
-              ? const Icon(FluentIcons.document_pdf_24_regular)
+              ? const Icon(OtzariaIcons.book_pdf_24_regular)
               : null,
           subtitleBuilder: (item) {
             final label = (item as Bookmark).label?.trim();

--- a/lib/find_ref/view/find_ref_dialog.dart
+++ b/lib/find_ref/view/find_ref_dialog.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:otzaria/theme/app_tokens.dart';
 import 'package:flutter/services.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_settings_screens/flutter_settings_screens.dart';
 import 'package:otzaria/find_ref/bloc/find_ref_bloc.dart';
@@ -872,7 +873,7 @@ class _FindRefDialogState extends State<FindRefDialog> {
                                   : null,
                               leading: ref.isPdf
                                   ? const Icon(
-                                      FluentIcons.document_pdf_24_regular,
+                                      OtzariaIcons.book_pdf_24_regular,
                                     )
                                   : null,
                               title: Text(

--- a/lib/history/view/history_screen.dart
+++ b/lib/history/view/history_screen.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:otzaria/search/search_query_builder.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:otzaria/bookmarks/models/bookmark.dart';
@@ -214,7 +214,7 @@ class _HistoryViewState extends State<HistoryView> {
 
   Widget? _getLeadingIcon(Book book, bool isSearch) {
     if (isSearch) {
-      return const Icon(FluentIcons.search_24_regular);
+      return const Icon(OtzariaIcons.search_24_regular);
     }
     if (book is! PdfBook && book is! TextBook) return null;
     return Icon(bookFormatIcon(book));

--- a/lib/library/view/book_versions_dialog.dart
+++ b/lib/library/view/book_versions_dialog.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:flutter_widget_from_html/flutter_widget_from_html.dart';
 import 'package:otzaria/data/data_providers/database_library_provider.dart';
 import 'package:otzaria/models/book_version.dart';
@@ -205,8 +205,8 @@ class BookVersionTile extends StatelessWidget {
       enabled: openable,
       leading: Icon(
         isDisplayedText
-            ? FluentIcons.book_open_24_regular
-            : FluentIcons.stack_24_regular,
+            ? OtzariaIcons.otzaria_icon_2_page_24_regular
+            : OtzariaIcons.books_stacked_high_24_regular,
         color: openable ? theme.colorScheme.primary : null,
       ),
       title: Text(version.displayTitle),

--- a/lib/library/view/grid_items.dart
+++ b/lib/library/view/grid_items.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:otzaria/library/models/library.dart';
 import 'package:otzaria/models/books.dart';
 import 'package:otzaria/data/data_providers/file_system_data_provider.dart';
@@ -716,7 +717,7 @@ class _BookGridActionColumn extends StatelessWidget {
                       const AppMenuEntry<String>(
                         value: 'versions',
                         label: 'גרסאות',
-                        icon: FluentIcons.stack_24_regular,
+                        icon: OtzariaIcons.books_stacked_high_24_regular,
                       ),
                     if (canDelete)
                       const AppMenuEntry<String>(

--- a/lib/library/view/library_browser.dart
+++ b/lib/library/view/library_browser.dart
@@ -4,6 +4,7 @@ import 'dart:math';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:otzaria/core/focus_repository.dart';
 import 'package:otzaria/empty_library/empty_library_screen.dart';
@@ -824,6 +825,7 @@ class _LibraryBrowserState extends State<LibraryBrowser>
           child: KeyedSubtree(
             key: _tourLibrarySearchKey,
             child: OtzariaSearchField(
+              icon: OtzariaIcons.search_in_the_library_24_regular,
               controller: focusRepository.librarySearchController,
               focusNode: focusRepository.librarySearchFocusNode,
               autofocus: true,

--- a/lib/library/view/library_daf_yomi.dart
+++ b/lib/library/view/library_daf_yomi.dart
@@ -1,4 +1,4 @@
-import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:kosher_dart/kosher_dart.dart';
@@ -55,7 +55,7 @@ class _LibraryDafYomiState extends State<LibraryDafYomi> {
           message: 'פתח לוח שנה',
           child: BarButton.text(
             text: dateText,
-            icon: FluentIcons.calendar_24_regular,
+            icon: OtzariaIcons.calendar_24_regular,
             onPressed: _openCalendar,
           ),
         ),
@@ -63,7 +63,7 @@ class _LibraryDafYomiState extends State<LibraryDafYomi> {
           message: 'פתח דף יומי: $dafText',
           child: BarButton.text(
             text: dafText,
-            icon: FluentIcons.book_24_regular,
+            icon: OtzariaIcons.book_24_regular,
             onPressed: widget.dafEnabled
                 ? () => widget.onDafYomiTap(tractate, formatAmud(dafAmud))
                 : null,

--- a/lib/library/view/otzar_book_dialog.dart
+++ b/lib/library/view/otzar_book_dialog.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:otzaria/theme/app_tokens.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:otzaria/widgets/misc/rtl_icon.dart';
 import '../../models/books.dart';
 import '../../utils/navigation/otzar_utils.dart';
@@ -70,7 +71,7 @@ class OtzarBookDialog extends StatelessWidget {
                     ),
                     _buildInfoRow(
                       context,
-                      FluentIcons.person_24_regular,
+                      OtzariaIcons.person_24_regular,
                       'מחבר',
                       book.author ?? 'לא ידוע',
                     ),
@@ -82,7 +83,7 @@ class OtzarBookDialog extends StatelessWidget {
                     ),
                     _buildInfoRow(
                       context,
-                      FluentIcons.calendar_24_regular,
+                      OtzariaIcons.calendar_24_regular,
                       'שנת הדפסה',
                       book.pubDate ?? 'לא ידוע',
                     ),

--- a/lib/navigation/view/custom_title_bar.dart
+++ b/lib/navigation/view/custom_title_bar.dart
@@ -8,6 +8,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:flutter_settings_screens/flutter_settings_screens.dart';
 import 'package:window_manager/window_manager.dart';
 import 'package:otzaria/navigation/bloc/navigation_bloc.dart';
@@ -1079,7 +1080,7 @@ class _CustomTitleBarState extends State<CustomTitleBar> {
                             Padding(
                               padding: const EdgeInsetsDirectional.only(end: 4),
                               child: Icon(
-                                FluentIcons.document_pdf_16_regular,
+                                OtzariaIcons.book_pdf_24_regular,
                                 size: 14,
                                 color: colorScheme.onSurface,
                               ),

--- a/lib/navigation/view/main_window_screen.dart
+++ b/lib/navigation/view/main_window_screen.dart
@@ -382,8 +382,8 @@ class MainWindowScreenState extends State<MainWindowScreen>
     ),
     (
       screen: Screen.reading,
-      icon: OtzariaIcons.book_open_large_24_regular,
-      iconFilled: OtzariaIcons.book_open_large_24_filled,
+      icon: OtzariaIcons.otzaria_icon_2_page_24_regular,
+      iconFilled: OtzariaIcons.otzaria_icon_2_page_24_filled,
       label: 'עיון',
       shortcutKey: 'key-shortcut-open-reading-screen',
     ),

--- a/lib/pdf_book/view/pdf_book_screen.dart
+++ b/lib/pdf_book/view/pdf_book_screen.dart
@@ -285,7 +285,7 @@ AppContextMenuEntry buildPdfLinksContextMenuEntry({
 
   return AppContextMenuEntry(
     label: 'קישורים',
-    icon: FluentIcons.link_24_regular,
+    icon: OtzariaIcons.link_24_regular,
     enabled: relevantLinks.isNotEmpty,
     childrenBuilder: buildLinkChildren,
   );
@@ -1159,13 +1159,13 @@ class _PdfBookScreenState extends State<PdfBookScreen>
       ),
       AppContextMenuEntry(
         label: 'חפש מקבילות',
-        icon: FluentIcons.book_search_24_regular,
+        icon: OtzariaIcons.book_search_24_regular,
         enabled: _hasPdfTextSelection(),
         onTap: _searchParallelsFromSelection,
       ),
       AppContextMenuEntry(
         label: 'מפרשים',
-        icon: FluentIcons.book_24_regular,
+        icon: OtzariaIcons.book_24_regular,
         // התת-תפריט פעיל אם יש בדף מפרשים זמינים, או אם ניתן לפתוח את
         // חלונית בחירת המפרשים (כדי לאפשר בחירה התחלתית גם בדף ללא מפרשים).
         enabled: relevantCommentators.isNotEmpty || shouldShowSelectEntry,
@@ -4946,7 +4946,7 @@ class _PdfBookScreenState extends State<PdfBookScreen>
         (
           80,
           ActionButtonData.simple(
-            icon: FluentIcons.book_information_24_regular,
+            icon: OtzariaIcons.book_information_24_regular,
             tooltip: 'אודות הספר',
             onPressed: () => showBookDetailsDialog(context, widget.tab.book),
             compact: isCompact,
@@ -4976,7 +4976,7 @@ class _PdfBookScreenState extends State<PdfBookScreen>
               ),
               ActionButtonData(
                 widget: const SizedBox.shrink(),
-                icon: FluentIcons.book_information_24_regular,
+                icon: OtzariaIcons.book_information_24_regular,
                 tooltip: 'אודות הספר',
                 onPressed: () =>
                     showBookDetailsDialog(context, widget.tab.book),
@@ -5101,7 +5101,7 @@ class _PdfBookScreenState extends State<PdfBookScreen>
             widget: const SizedBox.shrink(),
             icon: edition.isCompanion
                 ? OtzariaIcons.document_column_24_regular
-                : FluentIcons.book_24_regular,
+                : OtzariaIcons.book_24_regular,
             tooltip: edition.isCompanion
                 ? '${edition.book.title} — מהדורת טקסט (אוצריא)'
                 : edition.book.title,
@@ -5330,14 +5330,12 @@ class _PdfBookScreenState extends State<PdfBookScreen>
     final isBookViewMode = state.layoutMode.isBookView;
     final iconData = isBookViewMode
         ? OtzariaIcons.book_open_small_24_regular
-        : FluentIcons.book_24_regular;
+        : OtzariaIcons.book_24_regular;
 
     return AppPopupMenuButton<PdfLayoutMode>(
       tooltip: 'בחר מצב תצוגה',
       iconData: iconData,
-      icon: isBookViewMode
-          ? Icon(iconData)
-          : Transform.scale(scaleX: -1.0, child: Icon(iconData)),
+      icon: Icon(iconData),
       position: PopupMenuPosition.under,
       onSelected: (selectedMode) {
         // בחירת "תצוגת ספר" כשכבר בתצוגת ספר משמרת את כיוון הזוגות
@@ -5370,15 +5368,7 @@ class _PdfBookScreenState extends State<PdfBookScreen>
             value: value,
             child: Row(
               children: [
-                value == PdfLayoutMode.bookView
-                    ? Icon(icon, color: isSelected ? primaryColor : null)
-                    : Transform.scale(
-                        scaleX: -1.0,
-                        child: Icon(
-                          icon,
-                          color: isSelected ? primaryColor : null,
-                        ),
-                      ),
+                Icon(icon, color: isSelected ? primaryColor : null),
                 const SizedBox(width: 12),
                 Text(text, style: style),
                 if (isSelected) ...[
@@ -5398,7 +5388,7 @@ class _PdfBookScreenState extends State<PdfBookScreen>
           buildItem(
             value: PdfLayoutMode.regularView,
             text: 'תצוגה רגילה',
-            icon: FluentIcons.book_24_regular,
+            icon: OtzariaIcons.book_24_regular,
             isSelected: !isBookViewMode,
           ),
           buildItem(

--- a/lib/pdf_book/view/pdf_commentary_panel.dart
+++ b/lib/pdf_book/view/pdf_commentary_panel.dart
@@ -4,6 +4,7 @@ import 'package:otzaria/theme/app_fonts.dart';
 import 'package:flutter/material.dart';
 import 'package:pdfrx/pdfrx.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:otzaria/widgets/misc/commentators_filter_button.dart';
 import 'package:otzaria/widgets/layout/commentators_filter_screen.dart';
@@ -1005,11 +1006,11 @@ class PdfCommentaryPanelState extends State<PdfCommentaryPanel>
           },
           tabs: const [
             PanelTab(
-              icon: FluentIcons.book_24_regular,
+              icon: OtzariaIcons.book_24_regular,
               label: 'מפרשים',
             ),
             PanelTab(
-              icon: FluentIcons.link_24_regular,
+              icon: OtzariaIcons.link_24_regular,
               label: 'קישורים',
             ),
             PanelTab(
@@ -1147,7 +1148,7 @@ class PdfCommentaryPanelState extends State<PdfCommentaryPanel>
         const SizedBox(width: gap),
         // 4. הפעלת שדה החיפוש
         IconButton(
-          icon: const Icon(FluentIcons.search_24_regular),
+          icon: const Icon(OtzariaIcons.search_24_regular),
           tooltip: 'חיפוש',
           onPressed: _openInlineSearch,
         ),
@@ -1194,7 +1195,7 @@ class PdfCommentaryPanelState extends State<PdfCommentaryPanel>
       controller: _searchController,
       decoration: InputDecoration(
         hintText: 'חפש בתוך המפרשים המוצגים...',
-        prefixIcon: const Icon(FluentIcons.search_24_regular),
+        prefixIcon: const Icon(OtzariaIcons.search_in_the_library_24_regular),
         suffixIcon: Row(
           mainAxisSize: MainAxisSize.min,
           children: [
@@ -1353,7 +1354,7 @@ class PdfCommentaryPanelState extends State<PdfCommentaryPanel>
                       widget.onSelectCommentatorsRequested?.call();
                     }
                   },
-                  icon: const Icon(FluentIcons.apps_list_24_regular),
+                  icon: const Icon(OtzariaIcons.apps_list_24_regular),
                   label: const Text('בחר מפרשים'),
                   style: ElevatedButton.styleFrom(
                     padding: const EdgeInsets.symmetric(

--- a/lib/pdf_book/view/pdf_commentators_tab_screen.dart
+++ b/lib/pdf_book/view/pdf_commentators_tab_screen.dart
@@ -870,11 +870,11 @@ class _PdfCommentatorsTabScreenState extends State<PdfCommentatorsTabScreen>
               ActionButtonData(
                 widget: BarButton.icon(
                   tooltip: 'חיפוש',
-                  icon: FluentIcons.search_24_regular,
+                  icon: OtzariaIcons.search_24_regular,
                   compact: isCompact,
                   onPressed: _openSearchPanel,
                 ),
-                icon: FluentIcons.search_24_regular,
+                icon: OtzariaIcons.search_24_regular,
                 tooltip: 'חיפוש',
                 onPressed: _openSearchPanel,
               ),
@@ -974,13 +974,13 @@ class _PdfCommentatorsTabScreenState extends State<PdfCommentatorsTabScreen>
               label: 'ניווט',
             ),
             (
-              icon: FluentIcons.apps_list_24_regular,
-              iconFilled: FluentIcons.apps_list_24_filled,
+              icon: OtzariaIcons.apps_list_24_regular,
+              iconFilled: OtzariaIcons.apps_list_24_filled,
               label: 'מפרשים',
             ),
             (
-              icon: FluentIcons.search_24_regular,
-              iconFilled: FluentIcons.search_24_filled,
+              icon: OtzariaIcons.search_24_regular,
+              iconFilled: OtzariaIcons.search_24_filled,
               label: 'חיפוש',
             ),
           ],
@@ -1246,7 +1246,7 @@ class _PdfCommentatorsTabScreenState extends State<PdfCommentatorsTabScreen>
       title: text,
       level: 1,
       isSelected: isSelected,
-      icon: FluentIcons.text_bullet_list_24_regular,
+      icon: OtzariaIcons.text_bullet_list_24_regular,
       onTap: onTap,
     );
   }

--- a/lib/pdf_book/view/pdf_external_matches_bar.dart
+++ b/lib/pdf_book/view/pdf_external_matches_bar.dart
@@ -1,4 +1,5 @@
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:flutter/material.dart';
 import 'package:otzaria/tabs/models/external_book_matches.dart';
 import 'package:otzaria/tabs/models/pdf_tab.dart';
@@ -111,7 +112,7 @@ class _PdfExternalMatchesBarState extends State<PdfExternalMatchesBar> {
             child: Row(
               children: [
                 Icon(
-                  FluentIcons.book_search_24_regular,
+                  OtzariaIcons.book_search_24_regular,
                   size: 18,
                   color: theme.colorScheme.onSurfaceVariant,
                 ),
@@ -141,7 +142,7 @@ class _PdfExternalMatchesBarState extends State<PdfExternalMatchesBar> {
                               )
                             : IconButton(
                                 icon: const Icon(
-                                  FluentIcons.search_24_regular,
+                                  OtzariaIcons.search_24_regular,
                                   size: 16,
                                 ),
                                 tooltip: 'חפש',

--- a/lib/pdf_book/view/pdf_outlines_screen.dart
+++ b/lib/pdf_book/view/pdf_outlines_screen.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:otzaria/widgets/lists/nav_tree_tile.dart';
-import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:pdfrx/pdfrx.dart';
 import 'package:otzaria/search/utils/find_match_utils.dart';
@@ -414,7 +414,7 @@ class _OutlineViewState extends State<OutlineView>
             title: node.title,
             level: level,
             isSelected: selected,
-            icon: FluentIcons.text_bullet_list_24_regular,
+            icon: OtzariaIcons.text_bullet_list_24_regular,
             onTap: navigateToEntry,
           ),
         ),

--- a/lib/personal_notes/view/personal_notes_screen.dart
+++ b/lib/personal_notes/view/personal_notes_screen.dart
@@ -364,6 +364,7 @@ class _PersonalNotesManagerScreenState
             ),
           ],
           center: OtzariaSearchField(
+            icon: OtzariaIcons.search_in_the_document_24_regular,
             controller: _searchController,
             focusNode: _searchFocusNode,
             hintText: 'חפש בהערות...',
@@ -388,8 +389,7 @@ class _PersonalNotesManagerScreenState
                     : 'סנן לפי תאריך',
                 icon: _dateRange != null
                     ? FluentIcons.calendar_checkmark_24_filled
-                    : FluentIcons.calendar_24_regular,
-                flipInRtl: true,
+                    : OtzariaIcons.calendar_24_regular,
                 onPressed: _pickDateRange,
               ),
             ),
@@ -1055,8 +1055,8 @@ class _PersonalNotesManagerScreenState
       ),
       child: Row(
         children: [
-          RtlIcon(
-            FluentIcons.calendar_24_regular,
+          Icon(
+            OtzariaIcons.calendar_24_regular,
             size: 18,
             color: cs.onSecondaryContainer,
           ),
@@ -1171,7 +1171,7 @@ class _PersonalNotesManagerScreenState
                   crossAxisAlignment: WrapCrossAlignment.center,
                   children: [
                     _InfoChip(
-                      icon: FluentIcons.calendar_24_regular,
+                      icon: OtzariaIcons.calendar_24_regular,
                       text: hebrewDate,
                       backgroundColor: cs.secondaryContainer,
                       foregroundColor: cs.onSecondaryContainer,
@@ -1205,7 +1205,7 @@ class _PersonalNotesManagerScreenState
                   if (!isMissing)
                     BarButton.icon(
                       tooltip: 'פתח ספר בשורה',
-                      icon: FluentIcons.book_open_24_regular,
+                      icon: OtzariaIcons.otzaria_icon_2_page_24_regular,
                       onPressed: () => _openNoteInBook(note),
                     ),
                   BarButton.icon(

--- a/lib/personal_notes/widgets/notes_search_header.dart
+++ b/lib/personal_notes/widgets/notes_search_header.dart
@@ -1,3 +1,4 @@
+import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:flutter/material.dart';
 import 'package:otzaria/theme/app_tokens.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
@@ -72,6 +73,7 @@ class _NotesSearchHeaderState extends State<NotesSearchHeader> {
                 children: [
                   Expanded(
                     child: OtzariaSearchField(
+                      icon: OtzariaIcons.search_in_the_document_24_regular,
                       controller: _searchController,
                       hintText: 'חפש בהערות...',
                       onChanged: (value) {

--- a/lib/personal_notes/widgets/personal_note_editor.dart
+++ b/lib/personal_notes/widgets/personal_note_editor.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:otzaria/theme/app_tokens.dart';
 
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -508,13 +509,13 @@ class _PersonalNoteToolbar extends StatelessWidget {
         ),
         IconButton(
           tooltip: 'רשימה',
-          icon: const Icon(FluentIcons.text_bullet_list_24_regular, size: 18),
+          icon: const Icon(OtzariaIcons.text_bullet_list_24_regular, size: 18),
           onPressed: () => _toggleAttribute(quill.Attribute.ul),
         ),
         IconButton(
           tooltip: 'רשימה ממוספרת',
           icon: const Icon(
-            FluentIcons.text_number_list_rtl_24_regular,
+            OtzariaIcons.text_number_list_24_regular,
             size: 18,
           ),
           onPressed: () => _toggleAttribute(quill.Attribute.ol),

--- a/lib/personal_notes/widgets/personal_notes_export_dialog.dart
+++ b/lib/personal_notes/widgets/personal_notes_export_dialog.dart
@@ -3,8 +3,7 @@ import 'package:otzaria/personal_notes/models/personal_note.dart';
 import 'package:otzaria/widgets/misc/app_menu_exports.dart';
 import 'package:otzaria/widgets/widgets_exports.dart';
 import 'package:otzaria/widgets/text/rtl_text_field.dart';
-import 'package:fluentui_system_icons/fluentui_system_icons.dart';
-import 'package:otzaria/widgets/misc/rtl_icon.dart';
+import 'package:otzaria_icons/otzaria_icons.dart';
 
 enum NotesExportMode {
   all,
@@ -148,7 +147,7 @@ class _PersonalNotesExportDialogState extends State<PersonalNotesExportDialog> {
                       ? 'בחר טווח תאריכים'
                       : '${_dateRange!.start.toString().split(' ').first} - ${_dateRange!.end.toString().split(' ').first}',
                 ),
-                trailing: const RtlIcon(FluentIcons.calendar_24_regular),
+                trailing: const Icon(OtzariaIcons.calendar_24_regular),
                 onTap: () async {
                   final picked = await showDateRangePicker(
                     context: context,

--- a/lib/plugins/models/plugin_permission_labels.dart
+++ b/lib/plugins/models/plugin_permission_labels.dart
@@ -1,8 +1,11 @@
+import 'package:flutter/widgets.dart';
+import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:otzaria/plugins/models/plugin_manifest.dart';
 import 'package:otzaria/plugins/models/plugin_startup_contributions.dart';
 import 'package:otzaria/plugins/models/plugin_valid_permissions.dart';
 
-/// מידע תצוגה עבור הרשאת תוסף — שם עברי ותיאור קצר
+/// מידע תצוגה עבור הרשאת תוסף — שם עברי, תיאור קצר ואייקון לפי התחום
 class PluginPermissionInfo {
   /// שם קצר בעברית (מוצג כותרת)
   final String label;
@@ -10,7 +13,32 @@ class PluginPermissionInfo {
   /// תיאור מה ההרשאה מאפשרת (מוצג כsubtitle)
   final String description;
 
-  const PluginPermissionInfo({required this.label, required this.description});
+  /// אייקון שמזהה את תחום ההרשאה. מצב ההענקה מובע בצבע, לא באייקון.
+  final IconData icon;
+
+  const PluginPermissionInfo({
+    required this.label,
+    required this.description,
+    required this.icon,
+  });
+}
+
+/// האייקון להצגה לצד הרשאה בשני מסכי ההרשאות.
+/// הרשאות רגישות מקבלות אזהרה שגוברת על אייקון התחום.
+IconData pluginPermissionIcon(
+  String permission, {
+  required bool isGranted,
+  PluginManifest? manifest,
+}) {
+  final isSensitive =
+      permission == pluginRunOnStartupPermission ||
+      permission == pluginBackgroundKeepAlivePermission;
+  if (isSensitive) {
+    return isGranted
+        ? FluentIcons.warning_24_filled
+        : FluentIcons.warning_24_regular;
+  }
+  return getPermissionInfo(permission, manifest: manifest).icon;
 }
 
 /// מחזיר מידע תצוגה עבור הרשאה בשמה הטכני.
@@ -25,6 +53,7 @@ PluginPermissionInfo getPermissionInfo(
       if (!startup.hasBackgroundActivationTrigger) {
         return const PluginPermissionInfo(
           label: 'הפעלה ברקע לפי אירוע',
+          icon: FluentIcons.power_24_regular,
           description:
               'לא הוגדר אירוע שמפעיל מנוע רקע, ולכן הרשאה זו אינה בשימוש '
               'בגרסה הנוכחית של התוסף.',
@@ -33,6 +62,7 @@ PluginPermissionInfo getPermissionInfo(
       final reasons = pluginBackgroundActivationReasons(manifest).join(', ');
       return PluginPermissionInfo(
         label: 'הפעלה ברקע לפי אירוע',
+        icon: FluentIcons.power_24_regular,
         description:
             'התוסף יפעיל מנוע WebView ברקע כאשר: $reasons. המנוע יכובה אחרי '
             '3 דקות ללא פעילות, אלא אם תאושר גם מניעת הכיבוי.',
@@ -42,6 +72,7 @@ PluginPermissionInfo getPermissionInfo(
   return _permissionLabels[permissionKey] ??
       PluginPermissionInfo(
         label: permissionKey,
+        icon: FluentIcons.shield_24_regular,
         description: 'גישה לפונקציונליות: $permissionKey',
       );
 }
@@ -128,30 +159,36 @@ const Map<String, PluginPermissionInfo> _permissionLabels = {
   // ===== מידע על האפליקציה =====
   'app.info.read': PluginPermissionInfo(
     label: 'מידע אפליקציה',
+    icon: FluentIcons.info_24_regular,
     description: 'קריאת מידע כללי על האפליקציה: גרסה, פלטפורמה, ערכת נושא',
   ),
   'app.user_email.read': PluginPermissionInfo(
     label: 'כתובת מייל',
+    icon: FluentIcons.mail_24_regular,
     description: 'גישה לכתובת המייל של המשתמש, לשימוש בדיווח שגיאות בלבד',
   ),
   'app.open_url': PluginPermissionInfo(
     label: 'פתיחת קישורים בדפדפן',
+    icon: FluentIcons.globe_24_regular,
     description:
         'פתיחת כתובות אינטרנט (http/https) בדפדפן ברירת המחדל של מערכת ההפעלה',
   ),
   'app.run_on_startup': PluginPermissionInfo(
     label: 'טעינה אוטומטית ברקע',
+    icon: FluentIcons.power_24_regular,
     description:
         'תוסף מדור קודם ייטען עם עליית אוצריא ויישאר פעיל כל עוד התוכנה פתוחה.',
   ),
   'app.background_keep_alive': PluginPermissionInfo(
     label: 'מניעת כיבוי מנוע הרקע',
+    icon: FluentIcons.hourglass_24_regular,
     description:
         'התוסף מבקש להשאיר את מנוע ה-WebView פעיל ללא הגבלת זמן. הדבר מגדיל '
         'את צריכת הזיכרון והמעבד; אשר רק לתוסף מהימן שחייב להאזין ברציפות.',
   ),
   'app.startup_contributions': PluginPermissionInfo(
     label: 'הוספת רכיבים לתוכנה',
+    icon: FluentIcons.puzzle_piece_24_regular,
     description:
         'מאפשר לתוסף להוסיף פקדים, פריטי תפריט ונתונים שמנוהלים בידי אוצריא. '
         'פעולות מובנות עשויות להתבצע בלי לפתוח את דף התוסף.',
@@ -160,14 +197,17 @@ const Map<String, PluginPermissionInfo> _permissionLabels = {
   // ===== ספרייה =====
   'library.books.read': PluginPermissionInfo(
     label: 'רשימת ספרים',
+    icon: FluentIcons.library_24_regular,
     description: 'חיפוש וצפייה ברשימת כל הספרים בספרייה',
   ),
   'library.content.read': PluginPermissionInfo(
     label: 'תוכן ספרים',
+    icon: OtzariaIcons.book_24_regular,
     description: 'קריאת תוכן הספרים מהספרייה',
   ),
   'library.links.read': PluginPermissionInfo(
     label: 'מפרשים וקישורים',
+    icon: FluentIcons.link_24_regular,
     description:
         'צפייה ברשימת המפרשים של ספר ובקישורים בין הספרים, בלי תוכן הספרים',
   ),
@@ -175,26 +215,31 @@ const Map<String, PluginPermissionInfo> _permissionLabels = {
   // ===== חיפוש =====
   'search.fulltext.read': PluginPermissionInfo(
     label: 'חיפוש טקסט מלא',
+    icon: OtzariaIcons.search_in_the_library_24_regular,
     description: 'ביצוע חיפושי טקסט ברחבי כל הספרייה',
   ),
   'search.dialog': PluginPermissionInfo(
     label: 'רכיבים בחלון החיפוש',
+    icon: FluentIcons.search_24_regular,
     description: 'הוספת שורות סטטיות לדיאלוג החיפוש, ללא הפעלת קוד התוסף ברקע',
   ),
 
   // ===== קורא =====
   'reader.open': PluginPermissionInfo(
     label: 'פתיחת ספרים',
+    icon: OtzariaIcons.otzaria_icon_2_page_24_regular,
     description: 'פתיחת ספרים בקורא האפליקציה',
   ),
 
   // ===== ניווט =====
   'navigation.write': PluginPermissionInfo(
     label: 'ניווט במסכים',
+    icon: FluentIcons.navigation_24_regular,
     description: 'מעבר בין מסכים שונים באפליקציה',
   ),
   'plugin.open_other': PluginPermissionInfo(
     label: 'פתיחת תוסף אחר',
+    icon: FluentIcons.apps_list_24_regular,
     description:
         'פתיחת דף של תוסף אחר שמותקן אצלך, כולל הפעלת הקוד שלו. התוסף הנפתח '
         'פועל בהרשאות שלו בלבד',
@@ -203,43 +248,51 @@ const Map<String, PluginPermissionInfo> _permissionLabels = {
   // ===== הערות אישיות =====
   'notes.read': PluginPermissionInfo(
     label: 'צפייה בהערות',
+    icon: FluentIcons.note_24_regular,
     description: 'קריאה וצפייה בהערות האישיות שלך',
   ),
   'notes.write': PluginPermissionInfo(
     label: 'עריכת הערות',
+    icon: FluentIcons.note_edit_24_regular,
     description: 'יצירה, עריכה ומחיקה של הערות אישיות',
   ),
 
   // ===== לוח שנה =====
   'calendar.read': PluginPermissionInfo(
     label: 'לוח שנה עברי',
+    icon: OtzariaIcons.calendar_24_regular,
     description: 'גישה ללוח השנה העברי, זמנים הלכתיים ואירועים',
   ),
 
   // ===== הגדרות =====
   'settings.read': PluginPermissionInfo(
     label: 'הגדרות האפליקציה',
+    icon: FluentIcons.settings_24_regular,
     description: 'קריאת הגדרות האפליקציה (רק הגדרות שאושרו לתוספים)',
   ),
 
   // ===== ממשק משתמש =====
   'ui.feedback': PluginPermissionInfo(
     label: 'הודעות ודיאלוגים',
+    icon: FluentIcons.chat_24_regular,
     description: 'הצגת הודעות, דיאלוגים ועדכונים בממשק המשתמש',
   ),
   'ui.create_shortcut': PluginPermissionInfo(
     label: 'יצירת קיצור דרך',
+    icon: FluentIcons.desktop_24_regular,
     description: 'יצירת קיצור דרך בשולחן העבודה או בתפריט ההתחל (לאחר אישור)',
   ),
 
   // ===== קבצים אישיים =====
   'fs.user_files.read': PluginPermissionInfo(
     label: 'קבצים אישיים',
+    icon: FluentIcons.document_24_regular,
     description:
         'בחירה וקריאה של קבצים שתבחר במפורש בדיאלוג — לא גישה חופשית לדיסק',
   ),
   'fs.folder_access': PluginPermissionInfo(
     label: 'גישה לתיקייה שתבחר',
+    icon: FluentIcons.folder_24_regular,
     description:
         'בחירת תיקייה בדיאלוג מערכת ועבודה על קבצים בתוכה (חילוץ ומחיקה). '
         'הגישה מוגבלת לתיקיות שאישרת בדיאלוג בלבד',
@@ -248,16 +301,19 @@ const Map<String, PluginPermissionInfo> _permissionLabels = {
   // ===== אחסון תוסף =====
   'plugin.storage.read': PluginPermissionInfo(
     label: 'אחסון מקומי — קריאה',
+    icon: FluentIcons.database_24_regular,
     description: 'קריאת נתונים שהתוסף שמר בעבר על המכשיר',
   ),
   'plugin.storage.write': PluginPermissionInfo(
     label: 'אחסון מקומי — כתיבה',
+    icon: FluentIcons.save_24_regular,
     description: 'שמירת נתוני התוסף על המכשיר',
   ),
 
   // ===== פרסום נתונים =====
   'published_data.write': PluginPermissionInfo(
     label: 'שיתוף נתונים עם האפליקציה',
+    icon: FluentIcons.share_24_regular,
     description:
         'פרסום נתונים מהתוסף לחלקים אחרים באפליקציה (כגון אירועי לוח שנה)',
   ),
@@ -265,10 +321,12 @@ const Map<String, PluginPermissionInfo> _permissionLabels = {
   // ===== רשת =====
   'network.access': PluginPermissionInfo(
     label: 'גישה לאינטרנט',
+    icon: FluentIcons.globe_24_regular,
     description: 'שליחה וקבלה של מידע מרשת האינטרנט',
   ),
   'network.localhost': PluginPermissionInfo(
     label: 'גישה לשירותים מקומיים',
+    icon: FluentIcons.plug_connected_24_regular,
     description:
         'התחברות לשירותים שרצים על המחשב שלך (localhost), כגון מודל שפה מקומי (Ollama / LM Studio). אינה מאפשרת גישה לאינטרנט.',
   ),
@@ -276,78 +334,95 @@ const Map<String, PluginPermissionInfo> _permissionLabels = {
   // ===== משוב ומיילים =====
   'feedback.send_email': PluginPermissionInfo(
     label: 'שליחת מייל',
+    icon: FluentIcons.send_24_regular,
     description: 'שליחת משוב ודיווחים לכתובת מייל שהתוסף מגדיר',
   ),
 
   // ===== היסטוריית קריאה =====
   'history.read': PluginPermissionInfo(
     label: 'היסטוריית קריאה — צפייה',
+    icon: FluentIcons.history_24_regular,
     description: 'צפייה בהיסטוריית הקריאה והחיפושים שלך',
   ),
   'history.write': PluginPermissionInfo(
     label: 'היסטוריית קריאה — עריכה',
+    icon: FluentIcons.history_dismiss_24_regular,
     description: 'מחיקה ועריכה של היסטוריית הקריאה',
   ),
 
   // ===== מסד נתונים =====
   'database.read': PluginPermissionInfo(
     label: 'קריאת מסד נתונים',
+    icon: FluentIcons.database_24_regular,
     description: 'קריאת נתונים ממקורות SQLite שהאפליקציה מאשרת לתוסף',
   ),
 
   // ===== התראות =====
   'notifications.send': PluginPermissionInfo(
     label: 'הודעות מובנות',
+    icon: FluentIcons.alert_24_regular,
     description: 'הצגת הודעות פופ-אפ בתוך האפליקציה',
   ),
   'notifications.system': PluginPermissionInfo(
     label: 'התראות מערכת',
+    icon: FluentIcons.alert_urgent_24_regular,
     description: 'שליחת התראות למערכת ההפעלה (גם כשהאפליקציה סגורה)',
   ),
 
   // ===== אירועים =====
   'events.subscribe:navigation.changed': PluginPermissionInfo(
     label: 'אירועי ניווט',
+    icon: FluentIcons.navigation_24_regular,
     description: 'קבלת עדכון בכל פעם שמשתמש עובר בין מסכים',
   ),
   'events.subscribe:reader.current_book_changed': PluginPermissionInfo(
     label: 'אירועי פתיחת ספר',
+    icon: OtzariaIcons.otzaria_icon_2_page_24_regular,
     description: 'קבלת עדכון בכל פעם שנפתח ספר חדש בקורא',
   ),
   'events.subscribe:reader.current_ref_changed': PluginPermissionInfo(
     label: 'אירועי שינוי מיקום',
+    icon: FluentIcons.location_24_regular,
     description: 'קבלת עדכון בכל פעם שמיקום הקריאה משתנה (דף, פרק, סעיף)',
   ),
   'events.subscribe:theme.changed': PluginPermissionInfo(
     label: 'אירועי ערכת נושא',
+    icon: FluentIcons.color_24_regular,
     description: 'קבלת עדכון בכל פעם שמשתמש מחליף ערכת נושא',
   ),
   'events.subscribe:settings.changed': PluginPermissionInfo(
     label: 'אירועי הגדרות',
+    icon: FluentIcons.settings_24_regular,
     description: 'קבלת עדכון בכל פעם שמשתמש משנה הגדרה',
   ),
   'events.subscribe:calendar.date_changed': PluginPermissionInfo(
     label: 'אירועי שינוי תאריך',
+    icon: OtzariaIcons.calendar_24_regular,
     description: 'קבלת עדכון בכל פעם שמשתמש מחליף תאריך בלוח השנה',
   ),
   'events.subscribe:calendar.city_changed': PluginPermissionInfo(
     label: 'אירועי שינוי עיר',
+    icon: FluentIcons.location_24_regular,
     description: 'קבלת עדכון בכל פעם שמשתמש מחליף את העיר הנבחרת בלוח השנה',
   ),
   'events.subscribe:workspace.changed': PluginPermissionInfo(
     label: 'אירועי סביבת עבודה',
+    icon: FluentIcons.apps_24_regular,
     description: 'קבלת עדכון בכל פעם שמשתמש מחליף סביבת עבודה',
   ),
   'events.subscribe:plugin.permissions_changed': PluginPermissionInfo(
     label: 'אירועי שינוי הרשאות',
+    icon: FluentIcons.shield_24_regular,
     description: 'קבלת עדכון בכל פעם שהרשאות התוסף משתנות',
   ),
   'events.subscribe:reader.sectionContentChanged': PluginPermissionInfo(
     label: 'אירועי שינוי תוכן בקורא',
+    icon: OtzariaIcons.text_continuous_24_regular,
     description: 'קבלת עדכון כאשר נוסח של סעיף או אופן ההצגה שלו משתנים בקורא',
   ),
   'events.subscribe:reader.selection_changed': PluginPermissionInfo(
     label: 'אירועי סימון טקסט',
+    icon: FluentIcons.select_all_on_24_regular,
     description: 'קבלת עדכון בכל פעם שהטקסט המסומן בקורא משתנה',
   ),
 };

--- a/lib/plugins/view/plugin_install_screen.dart
+++ b/lib/plugins/view/plugin_install_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:otzaria/theme/app_tokens.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:otzaria/plugins/bloc/plugin_system_bloc.dart';
 import 'package:otzaria/plugins/bloc/plugin_system_event.dart';
@@ -191,15 +192,12 @@ class _PluginInstallScreenState extends State<PluginInstallScreen> {
         !isTemporarilyUnavailable && (_permissionToggles[permission] ?? true);
     final isSensitive = permission == pluginRunOnStartupPermission;
     final isCritical = permission == pluginBackgroundKeepAlivePermission;
-    final iconData = isSensitive || isCritical
-        ? (isGranted
-              ? FluentIcons.warning_24_filled
-              : FluentIcons.warning_24_regular)
-        : (isGranted
-              ? FluentIcons.shield_checkmark_24_regular
-              : FluentIcons.shield_error_24_regular);
     return SettingsActionTile.switchTile(
-      icon: iconData,
+      icon: pluginPermissionIcon(
+        permission,
+        isGranted: isGranted,
+        manifest: widget.manifest,
+      ),
       iconColor: isCritical
           ? colorScheme.error
           : isSensitive
@@ -254,7 +252,7 @@ class _PluginInstallScreenState extends State<PluginInstallScreen> {
                   subtitle: widget.manifest.description,
                 ),
               SettingsActionTile.text(
-                icon: FluentIcons.person_24_regular,
+                icon: OtzariaIcons.person_24_regular,
                 title: 'מחבר: ${widget.manifest.author}',
                 subtitle: isUpdate
                     ? 'עדכון גרסה ${widget.previousVersion}  ←  ${widget.manifest.version}'

--- a/lib/plugins/view/plugin_settings_screen.dart
+++ b/lib/plugins/view/plugin_settings_screen.dart
@@ -144,13 +144,11 @@ class _PluginSettingsScreenState extends State<PluginSettingsScreen> {
                         final isCritical =
                             p == pluginBackgroundKeepAlivePermission;
                         final colorScheme = Theme.of(context).colorScheme;
-                        final iconData = isSensitive || isCritical
-                            ? (isGranted
-                                  ? FluentIcons.warning_24_filled
-                                  : FluentIcons.warning_24_regular)
-                            : (isGranted
-                                  ? FluentIcons.shield_checkmark_24_regular
-                                  : FluentIcons.shield_error_24_regular);
+                        final iconData = pluginPermissionIcon(
+                          p,
+                          isGranted: isGranted,
+                          manifest: currentPlugin.manifest,
+                        );
                         final iconColor = isCritical
                             ? colorScheme.error
                             : isSensitive

--- a/lib/search/view/category_tree_selector.dart
+++ b/lib/search/view/category_tree_selector.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:otzaria/theme/app_tokens.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:otzaria/library/bloc/library_bloc.dart';
 import 'package:otzaria/library/bloc/library_state.dart';
@@ -473,7 +474,7 @@ class _CategoryTreeSelectorState extends State<CategoryTreeSelector> {
       controller: _searchController,
       decoration: InputDecoration(
         hintText: 'איתור קטגוריה או ספר...',
-        prefixIcon: const Icon(FluentIcons.search_24_regular),
+        prefixIcon: const Icon(OtzariaIcons.search_24_regular),
         suffixIcon: _searchController.text.isEmpty
             ? null
             : IconButton(
@@ -591,7 +592,7 @@ class _CategoryTreeSelectorState extends State<CategoryTreeSelector> {
                         padding: const EdgeInsets.only(top: 2),
                         child: Icon(
                           item.isBook
-                              ? FluentIcons.book_24_regular
+                              ? OtzariaIcons.book_24_regular
                               : FluentIcons.folder_24_regular,
                           size: 18,
                           color: item.isBook

--- a/lib/search/view/enhanced_search_field.dart
+++ b/lib/search/view/enhanced_search_field.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:otzaria/core/ui_snack.dart';
 import 'package:otzaria/core/messages/library_messages.dart';
 import 'package:otzaria/history/bloc/history_bloc.dart';
@@ -568,10 +569,10 @@ class _EnhancedSearchFieldState extends State<EnhancedSearchField> {
                               ? IconButton(
                                   onPressed: _performSearch,
                                   icon: const Icon(
-                                    FluentIcons.search_24_regular,
+                                    OtzariaIcons.search_24_regular,
                                   ),
                                 )
-                              : const Icon(FluentIcons.search_24_regular),
+                              : const Icon(OtzariaIcons.search_24_regular),
                           suffixIcon: widget.trailingAction != null
                               ? Row(
                                   mainAxisSize: MainAxisSize.min,

--- a/lib/search/view/external_search_results_section.dart
+++ b/lib/search/view/external_search_results_section.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:otzaria/core/messages/plugin_messages.dart';
@@ -654,7 +654,7 @@ class _ExternalSearchResultsSectionState
                       child: CircularProgressIndicator(strokeWidth: 2),
                     )
                   : Icon(
-                      FluentIcons.book_open_24_regular,
+                      OtzariaIcons.otzaria_icon_2_page_24_regular,
                       size: 20,
                       color: cs.primary,
                     ),

--- a/lib/search/view/full_text_settings_widgets.dart
+++ b/lib/search/view/full_text_settings_widgets.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:otzaria/theme/theme_exports.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_spinbox/flutter_spinbox.dart';
 import 'package:otzaria/search/bloc/search_bloc.dart';
@@ -319,7 +320,7 @@ class _ScopeAndMatchMenu extends StatelessWidget {
           mainAxisSize: MainAxisSize.min,
           children: [
             Icon(
-              FluentIcons.apps_list_24_regular,
+              OtzariaIcons.apps_list_24_regular,
               size: 20,
               color: isDefault ? colorScheme.onSurface : colorScheme.primary,
             ),

--- a/lib/search/view/search_dialog.dart
+++ b/lib/search/view/search_dialog.dart
@@ -3,6 +3,7 @@ import 'package:otzaria/theme/app_surfaces.dart';
 import 'package:otzaria/theme/app_tokens.dart';
 import 'package:flutter/services.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_settings_screens/flutter_settings_screens.dart';
 import 'package:otzaria/core/focus_repository.dart';
@@ -427,7 +428,7 @@ class _SearchDialogState extends State<SearchDialog> {
                   return ListTile(
                     dense: true,
                     leading: const Icon(
-                      FluentIcons.search_24_regular,
+                      OtzariaIcons.search_24_regular,
                       size: 18,
                     ),
                     title: Text(
@@ -1017,7 +1018,7 @@ class _SearchDialogState extends State<SearchDialog> {
                 borderRadius: AppTokens.borderRadiusAll,
               ),
               child: Icon(
-                FluentIcons.search_24_filled,
+                OtzariaIcons.search_24_filled,
                 size: 22,
                 color: colorScheme.onPrimaryContainer,
               ),

--- a/lib/search/view/search_scope_menu.dart
+++ b/lib/search/view/search_scope_menu.dart
@@ -4,6 +4,7 @@ import 'dart:math' as math;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:otzaria/data/data_providers/sqlite_data_provider.dart';
 import 'package:otzaria/data/data_providers/user_books_database_holder.dart';
@@ -850,7 +851,7 @@ class _ScopeMenuPanelState extends State<_ScopeMenuPanel> {
     return _MenuItem(
       label: node.title,
       subtitle: node.subtitle,
-      icon: FluentIcons.book_24_regular,
+      icon: OtzariaIcons.book_24_regular,
       useRtlIcon: true,
       check: tree.isFacetCovered(node.facet, _categoryPart),
       onToggle: (v) => _toggleCategoryFacet(node.facet, v),
@@ -935,7 +936,7 @@ class _ScopeMenuPanelState extends State<_ScopeMenuPanel> {
       ),
       _MenuItem(
         label: 'ספרי יסוד',
-        icon: FluentIcons.book_star_24_regular,
+        icon: OtzariaIcons.book_star_24_regular,
         useRtlIcon: true,
         check: baseSelected,
         onToggle: (v) => _toggleDimension(FacetHelper.baseDimensionFacet, v),
@@ -945,7 +946,7 @@ class _ScopeMenuPanelState extends State<_ScopeMenuPanel> {
       for (final era in _eraNames)
         _MenuItem(
           label: era,
-          icon: FluentIcons.calendar_24_regular,
+          icon: OtzariaIcons.calendar_24_regular,
           useRtlIcon: true,
           check: _selection.contains(FacetHelper.buildEraFacet(era)),
           onToggle: (v) => _toggleDimension(FacetHelper.buildEraFacet(era), v),
@@ -967,7 +968,7 @@ class _ScopeMenuPanelState extends State<_ScopeMenuPanel> {
         _MenuItem(
           label: author,
           subtitle: 'מחבר',
-          icon: FluentIcons.person_24_regular,
+          icon: OtzariaIcons.person_24_regular,
           check: _selection.contains(FacetHelper.buildAuthorFacet(author)),
           onToggle: (v) =>
               _toggleDimension(FacetHelper.buildAuthorFacet(author), v),
@@ -976,7 +977,7 @@ class _ScopeMenuPanelState extends State<_ScopeMenuPanel> {
         _MenuItem(
           label: era,
           subtitle: 'תקופה',
-          icon: FluentIcons.calendar_24_regular,
+          icon: OtzariaIcons.calendar_24_regular,
           useRtlIcon: true,
           check: _selection.contains(FacetHelper.buildEraFacet(era)),
           onToggle: (v) => _toggleDimension(FacetHelper.buildEraFacet(era), v),
@@ -986,7 +987,7 @@ class _ScopeMenuPanelState extends State<_ScopeMenuPanel> {
           label: item.title,
           subtitle: item.subtitle,
           icon: item.isBook
-              ? FluentIcons.book_24_regular
+              ? OtzariaIcons.book_24_regular
               : FluentIcons.folder_24_regular,
           useRtlIcon: item.isBook,
           check: tree.isFacetCovered(item.facet, categoryPart),
@@ -1136,7 +1137,7 @@ class _ScopeMenuPanelState extends State<_ScopeMenuPanel> {
     final isFolder =
         item.icon == FluentIcons.folder_24_regular ||
         item.icon == FluentIcons.library_24_regular ||
-        item.icon == FluentIcons.book_star_24_regular;
+        item.icon == OtzariaIcons.book_star_24_regular;
     final iconColor = isFolder
         ? colorScheme.primary
         : colorScheme.onSurfaceVariant;

--- a/lib/search/view/tantivy_search_results.dart
+++ b/lib/search/view/tantivy_search_results.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:otzaria/theme/app_tokens.dart';
 import 'package:flutter/services.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_settings_screens/flutter_settings_screens.dart';
 import 'package:otzaria/core/messages/library_messages.dart';
@@ -496,7 +497,7 @@ class _TantivySearchResultsState extends State<TantivySearchResults> {
         SliverFillRemaining(
           hasScrollBody: false,
           child: _buildInformativeEmptyState(
-            icon: FluentIcons.search_24_regular,
+            icon: OtzariaIcons.search_24_regular,
             title: 'לא בוצע חיפוש',
             message: 'הקלד מילות חיפוש ולחץ על כפתור "חפש" כדי להתחיל.',
           ),
@@ -761,7 +762,7 @@ class _TantivySearchResultsState extends State<TantivySearchResults> {
                                     Padding(
                                       padding: const EdgeInsets.only(left: 8),
                                       child: Icon(
-                                        FluentIcons.document_pdf_24_regular,
+                                        OtzariaIcons.book_pdf_24_regular,
                                         size: 16,
                                         color: Theme.of(
                                           context,

--- a/lib/services/target_line_links_service.dart
+++ b/lib/services/target_line_links_service.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 import 'dart:collection';
 
 import 'package:flutter/widgets.dart';
-import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:otzaria/data/data_providers/file_system_data_provider.dart';
 import 'package:otzaria/models/books.dart';
 import 'package:otzaria/models/link_types.dart';
@@ -289,7 +289,7 @@ class TargetLineLinksService {
       removeNikud: removeNikud,
       removePunctuation: removePunctuation,
       label: 'מפרשים',
-      icon: FluentIcons.book_24_regular,
+      icon: OtzariaIcons.book_24_regular,
       emptyLabel: 'אין מפרשים על קטע זה',
       select: (data) => data.commentaries,
       groupByEra: true,
@@ -309,7 +309,7 @@ class TargetLineLinksService {
       removeNikud: removeNikud,
       removePunctuation: removePunctuation,
       label: 'קישורים',
-      icon: FluentIcons.link_24_regular,
+      icon: OtzariaIcons.link_24_regular,
       emptyLabel: 'אין קישורים על קטע זה',
       select: (data) => data.references,
       groupByEra: false,

--- a/lib/settings/dialogs/books_list_dialog.dart
+++ b/lib/settings/dialogs/books_list_dialog.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:flutter/material.dart';
 import 'package:path_provider/path_provider.dart';
 
@@ -118,7 +119,7 @@ class _BooksListDialogState extends State<_BooksListDialog> {
             children: [
               Row(
                 children: [
-                  Icon(FluentIcons.book_24_regular, color: cs.primary),
+                  Icon(OtzariaIcons.book_24_regular, color: cs.primary),
                   const SizedBox(width: 8),
                   Expanded(
                     child: Text(
@@ -139,7 +140,7 @@ class _BooksListDialogState extends State<_BooksListDialog> {
                 controller: _searchController,
                 autofocus: true,
                 decoration: InputDecoration(
-                  prefixIcon: const Icon(FluentIcons.search_24_regular),
+                  prefixIcon: const Icon(OtzariaIcons.search_24_regular),
                   hintText: context.settingsText(
                     'חיפוש לפי שם, מחבר או קטגוריה',
                   ),

--- a/lib/settings/dialogs/color_picker_dialog.dart
+++ b/lib/settings/dialogs/color_picker_dialog.dart
@@ -173,7 +173,7 @@ class _ColorPickerDialogState extends State<_ColorPickerDialog> {
                         ),
                         child: isSelected
                             ? const Icon(
-                                Icons.check,
+                                FluentIcons.checkmark_24_regular,
                                 color: Colors.white,
                                 size: 20,
                               )

--- a/lib/settings/panels/calendar_settings_panel.dart
+++ b/lib/settings/panels/calendar_settings_panel.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:otzaria/settings/engine/settings_bloc.dart';
 import 'package:otzaria/settings/l10n/settings_l10n_exports.dart';
@@ -376,7 +377,7 @@ class _CalendarSettingsTabState extends State<CalendarSettingsTab> {
                                           .length,
                                     },
                                   ),
-                                  icon: FluentIcons.calendar_24_regular,
+                                  icon: OtzariaIcons.calendar_24_regular,
                                   onPressed: () async {
                                     final cubit = context.read<CalendarCubit>();
                                     final calendars = await cubit

--- a/lib/settings/panels/custom_folders_panel.dart
+++ b/lib/settings/panels/custom_folders_panel.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:file_picker/file_picker.dart';
 import 'dart:async';
@@ -531,7 +532,7 @@ class _CustomFoldersPanelState extends State<CustomFoldersPanel> {
               ),
             ),
             item(
-              FluentIcons.link_24_regular,
+              OtzariaIcons.link_24_regular,
               context.settingsText('דורות וקישורים'),
               context.settingsText(
                 'לייבוא סדר דורות וקישורים לספרים האישיים השתמש בכפתור '

--- a/lib/settings/panels/gematria_settings_panel.dart
+++ b/lib/settings/panels/gematria_settings_panel.dart
@@ -184,7 +184,7 @@ class _GematriaSettingsTabState extends State<GematriaSettingsTab> {
               },
             ),
             SettingsActionTile.switchTile(
-              rtlIcon: FluentIcons.book_24_regular,
+              rtlIcon: OtzariaIcons.book_24_regular,
               title: context.settingsText('חיפוש בתורה בלבד'),
               subtitle: torahOnly
                   ? context.settingsText('חיפוש רק בחמישה חומשי תורה')

--- a/lib/settings/panels/library_settings_panel.dart
+++ b/lib/settings/panels/library_settings_panel.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:otzaria/external_catalog/repository/external_catalog_repository.dart';
 import 'package:otzaria/external_catalog/view/external_catalog_settings_helper.dart';
 import 'package:otzaria/settings/engine/settings_engine_exports.dart';
@@ -120,7 +121,7 @@ class _LibrarySettingsPanelState extends State<LibrarySettingsPanel> {
                     SegmentOption(
                       value: 'list',
                       label: context.settingsText('רשימה'),
-                      rtlIcon: FluentIcons.list_24_regular,
+                      rtlIcon: OtzariaIcons.list_24_regular,
                       subtitle: context.settingsText(
                         'התיקיות והספרים יוצגו ברשימה נפתחת (עץ מתרחב)',
                       ),

--- a/lib/settings/panels/personal_books_import_panel.dart
+++ b/lib/settings/panels/personal_books_import_panel.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:file_picker/file_picker.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:otzaria/core/messages/settings_messages.dart';
@@ -13,7 +14,6 @@ import 'package:otzaria/settings/services/custom_folders/personal_books_import_s
 import 'package:otzaria/settings/widgets/settings_widgets_exports.dart';
 import 'package:otzaria/utils/file/document_format.dart';
 import 'package:otzaria/theme/app_tokens.dart';
-import 'package:otzaria/widgets/misc/rtl_icon.dart';
 import 'package:otzaria/widgets/widgets_exports.dart';
 import 'package:path/path.dart' as p;
 
@@ -234,8 +234,8 @@ class _PersonalBooksImportPanelState extends State<PersonalBooksImportPanel> {
     return ListTile(
       dense: true,
       hoverColor: Colors.transparent,
-      leading: RtlIcon(
-        FluentIcons.book_24_regular,
+      leading: Icon(
+        OtzariaIcons.book_24_regular,
         color: cs.primary,
         size: 20,
       ),

--- a/lib/settings/search/settings_search_field.dart
+++ b/lib/settings/search/settings_search_field.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:otzaria/theme/app_tokens.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:otzaria/settings/l10n/settings_text.dart';
 import 'package:otzaria/widgets/text/rtl_text_field.dart';
 
@@ -68,7 +69,7 @@ class _SettingsSearchFieldState extends State<SettingsSearchField> {
             color: colorScheme.onSurfaceVariant,
           ),
           prefixIcon: Icon(
-            FluentIcons.search_24_regular,
+            OtzariaIcons.search_in_the_settings_24_regular,
             color: colorScheme.onSurfaceVariant,
             size: 16,
           ),

--- a/lib/settings/search/settings_search_results_view.dart
+++ b/lib/settings/search/settings_search_results_view.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:otzaria/theme/app_tokens.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:otzaria/settings/l10n/settings_text.dart';
 import 'package:otzaria/settings/search/settings_search_models.dart';
 import 'package:otzaria/settings/view/settings_screen.dart';
@@ -307,7 +308,7 @@ IconData _iconForTab(SettingsTab tab) {
     case SettingsTab.design:
       return FluentIcons.paint_brush_24_regular;
     case SettingsTab.text:
-      return FluentIcons.book_24_regular;
+      return OtzariaIcons.book_24_regular;
     case SettingsTab.library:
       return FluentIcons.library_24_regular;
     case SettingsTab.tools:

--- a/lib/settings/tabs/about_settings_tab.dart
+++ b/lib/settings/tabs/about_settings_tab.dart
@@ -184,7 +184,7 @@ class AboutSettingsTab extends StatelessWidget {
                   actions: [
                     _InfoChipWrap(
                       items: aboutEssentialPeople,
-                      icon: FluentIcons.person_24_regular,
+                      icon: OtzariaIcons.person_24_regular,
                     ),
                   ],
                 ),
@@ -202,7 +202,7 @@ class AboutSettingsTab extends StatelessWidget {
                 _padded(
                   _InfoChipSection(
                     items: aboutDevelopers,
-                    icon: FluentIcons.person_24_regular,
+                    icon: OtzariaIcons.person_24_regular,
                   ),
                 ),
                 SettingsActionTile.text(

--- a/lib/settings/tabs/design_settings_tab.dart
+++ b/lib/settings/tabs/design_settings_tab.dart
@@ -370,7 +370,7 @@ class DesignSettingsTab extends StatelessWidget {
                   title: context.settingsText('תצוגת PDF'),
                   children: [
                     SettingsActionTile.switchTile(
-                      icon: FluentIcons.book_open_24_regular,
+                      icon: OtzariaIcons.otzaria_icon_2_page_24_regular,
                       title: context.settingsText('תצוגת ספר בPDF'),
                       subtitle: context.settingsText(
                         state.enablePerBookSettings

--- a/lib/settings/tabs/library_settings_tab.dart
+++ b/lib/settings/tabs/library_settings_tab.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'dart:io';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:flutter_settings_screens/flutter_settings_screens.dart'
     hide SwitchSettingsTile;
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -558,7 +559,7 @@ class _LibrarySettingsTabState extends State<LibrarySettingsTab> {
                       kSettingsCardSpacing,
                       CustomFoldersPanel(
                         mergeToggle: SettingsActionTile.switchTile(
-                          icon: FluentIcons.person_24_regular,
+                          icon: OtzariaIcons.person_24_regular,
                           title: context.settingsText(
                             'מיזוג ספרים אישיים לעץ הספרייה',
                           ),

--- a/lib/settings/tabs/shortcuts_settings_tab.dart
+++ b/lib/settings/tabs/shortcuts_settings_tab.dart
@@ -469,7 +469,7 @@ class ShortcutsSettingsTab extends StatelessWidget {
       _ShortcutTile(
         settingKey: 'key-shortcut-open-tool-calendar',
         label: context.settingsText('פתיחת לוח שנה'),
-        icon: FluentIcons.calendar_24_regular,
+        icon: OtzariaIcons.calendar_24_regular,
         allShortcuts: _shortcutsList,
       ),
       _ShortcutTile(
@@ -726,7 +726,7 @@ class ShortcutsSettingsTab extends StatelessWidget {
             _ShortcutTile(
               settingKey: 'key-shortcut-toggle-pdf-view',
               label: context.settingsText('החלף מצב תצוגה (PDF/טקסט)'),
-              icon: FluentIcons.document_pdf_24_regular,
+              icon: OtzariaIcons.book_pdf_24_regular,
               allShortcuts: _shortcutsList,
             ),
             _ShortcutTile(
@@ -777,7 +777,7 @@ class ShortcutsSettingsTab extends StatelessWidget {
             _ShortcutTile(
               settingKey: 'key-shortcut-calendar-toggle-events',
               label: context.settingsText('לוח שנה: פתיחה/סגירה אירועים'),
-              icon: FluentIcons.calendar_24_regular,
+              icon: OtzariaIcons.calendar_24_regular,
               allShortcuts: _shortcutsList,
             ),
             _ShortcutTile(

--- a/lib/settings/tabs/system_settings_tab.dart
+++ b/lib/settings/tabs/system_settings_tab.dart
@@ -1281,7 +1281,7 @@ class _SystemSettingsTabState extends State<SystemSettingsTab> {
     return Column(
       children: [
         ListTile(
-          leading: const Icon(FluentIcons.document_bullet_list_24_regular),
+          leading: const Icon(OtzariaIcons.document_bullet_list_24_regular),
           title: Text(
             report.bookTitle,
             style: kSettingsTitleStyle,
@@ -1928,7 +1928,7 @@ class _SystemSettingsTabState extends State<SystemSettingsTab> {
           actions: [
             if (_bookCount != null)
               ActionButton.ghost(
-                icon: FluentIcons.list_24_regular,
+                icon: OtzariaIcons.list_24_regular,
                 text: context.settingsText('הצג רשימה'),
                 onPressed: () => _openBooksListDialog(context),
               ),
@@ -2482,7 +2482,7 @@ class _SystemSettingsTabState extends State<SystemSettingsTab> {
                 onChanged: () => setState(() {}),
               ),
               _BackupOptionTile(
-                icon: FluentIcons.book_24_regular,
+                icon: OtzariaIcons.book_24_regular,
                 title: context.settingsText('שמור וזכור'),
                 subtitle: context.settingsText('ספרים ומעקב לימוד'),
                 settingKey: _keyBackupShamorZachor,

--- a/lib/settings/tabs/text_settings_tab.dart
+++ b/lib/settings/tabs/text_settings_tab.dart
@@ -258,7 +258,7 @@ class TextSettingsTab extends StatelessWidget {
                 },
               ),
               _FontDropdown(
-                icon: OtzariaIcons.alef_near_alef_24_regular,
+                icon: OtzariaIcons.tet_near_tet_24_regular,
                 label: context.settingsText('גופן טקסט'),
                 value: state.fontFamily,
                 onChanged: (value) {
@@ -294,7 +294,7 @@ class TextSettingsTab extends StatelessWidget {
                   },
                 ),
               _FontDropdown(
-                icon: OtzariaIcons.beit_near_alef_24_regular,
+                icon: OtzariaIcons.beit_behind_alef_24_regular,
                 label: context.settingsText('גופן מפרשים'),
                 value: state.commentatorsFontFamily,
                 onChanged: (value) {
@@ -595,7 +595,7 @@ class TextSettingsTab extends StatelessWidget {
       title: context.settingsText('הגדרות לפי ספר'),
       children: [
         SettingsActionTile.switchTile(
-          icon: FluentIcons.book_open_24_regular,
+          icon: OtzariaIcons.otzaria_icon_2_page_24_regular,
           title: context.settingsText('שמירת התאמות לכל ספר בנפרד'),
           subtitle: context.settingsText(
             state.enablePerBookSettings

--- a/lib/settings/view/settings_screen.dart
+++ b/lib/settings/view/settings_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:otzaria/core/focus_repository.dart';
 import 'package:otzaria/tools/calendar/utils/calendar_cubit.dart';
 import 'package:otzaria/settings/search/settings_search_field.dart';
@@ -257,8 +258,8 @@ class _MySettingsScreenState extends State<MySettingsScreen> {
     ),
     (
       label: 'כתב',
-      icon: FluentIcons.book_24_regular,
-      iconFilled: FluentIcons.book_24_filled,
+      icon: OtzariaIcons.book_24_regular,
+      iconFilled: OtzariaIcons.book_24_filled,
       pageBuilder: () => const TextSettingsTab(),
     ),
     (

--- a/lib/tabs/reading_screen.dart
+++ b/lib/tabs/reading_screen.dart
@@ -1,9 +1,9 @@
+import 'package:fluentui_system_icons/fluentui_system_icons.dart';
 import 'dart:io';
 import 'package:flutter/foundation.dart'
     show ValueListenable, visibleForTesting;
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
-import 'package:fluentui_system_icons/fluentui_system_icons.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:otzaria/core/focus_repository.dart';
 import 'package:otzaria/history/bloc/history_bloc.dart';
@@ -399,7 +399,9 @@ class _ReadingScreenState extends State<ReadingScreen>
                                   const NavigateToScreen(Screen.library),
                                 );
                               },
-                              icon: const Icon(FluentIcons.library_24_regular),
+                              icon: const Icon(
+                                FluentIcons.library_24_regular,
+                              ),
                               label: const Text('דפדף בספרייה'),
                             ),
                           ),

--- a/lib/text_book/editing/widgets/markdown_toolbar.dart
+++ b/lib/text_book/editing/widgets/markdown_toolbar.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:otzaria/theme/app_tokens.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:otzaria_icons/otzaria_icons.dart';
 
 /// Toolbar widget providing markdown formatting controls
 class MarkdownToolbar extends StatelessWidget {
@@ -101,7 +102,7 @@ class MarkdownToolbar extends StatelessWidget {
 
           // Lists
           _ToolbarButton(
-            icon: FluentIcons.text_bullet_list_24_regular,
+            icon: OtzariaIcons.text_bullet_list_24_regular,
             tooltip: hasLinksFile
                 ? 'רשימה לא ממוספרת - מושבת בספר עם לינקים'
                 : 'רשימה לא ממוספרת',
@@ -141,7 +142,7 @@ class MarkdownToolbar extends StatelessWidget {
 
           // Search and navigation
           _ToolbarButton(
-            icon: FluentIcons.search_24_regular,
+            icon: OtzariaIcons.search_24_regular,
             tooltip: 'חיפוש (Ctrl+F)',
             onPressed: onSearch,
           ),

--- a/lib/text_book/editing/widgets/text_section_editor_dialog.dart
+++ b/lib/text_book/editing/widgets/text_section_editor_dialog.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:isolate';
 import 'package:flutter/material.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:otzaria/theme/app_fonts.dart';
@@ -744,7 +745,7 @@ class _SearchDialogState extends State<_SearchDialog> {
             decoration: const InputDecoration(
               labelText: 'הכנס טקסט לחיפוש',
               hintText: 'מה לחפש...',
-              prefixIcon: Icon(FluentIcons.search_24_regular),
+              prefixIcon: Icon(OtzariaIcons.search_24_regular),
             ),
             autofocus: true,
             onSubmitted: (_) => _performSearch(),

--- a/lib/text_book/view/alt_toc_sidebar_view.dart
+++ b/lib/text_book/view/alt_toc_sidebar_view.dart
@@ -3,7 +3,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:otzaria/widgets/lists/nav_tree_tile.dart';
 import 'package:flutter/scheduler.dart';
-import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:otzaria/data/data_providers/database_library_provider.dart';
 import 'package:otzaria/migration/models/alt_toc_entry.dart';
@@ -625,7 +625,7 @@ class _AltTocSidebarViewState extends State<AltTocSidebarView>
               title: entry.text ?? '',
               level: 0,
               isSelected: entry.id == _activeEntryId,
-              icon: FluentIcons.text_bullet_list_24_regular,
+              icon: OtzariaIcons.text_bullet_list_24_regular,
               onTap: () => _handleEntryTap(structureId, entry),
             ),
           );
@@ -691,7 +691,7 @@ class _AltTocSidebarViewState extends State<AltTocSidebarView>
             title: entry.text ?? '',
             level: level,
             isSelected: isSelected,
-            icon: FluentIcons.text_bullet_list_24_regular,
+            icon: OtzariaIcons.text_bullet_list_24_regular,
             onTap: () => _handleEntryTap(structureId, entry),
           );
 

--- a/lib/text_book/view/book_source_dialog.dart
+++ b/lib/text_book/view/book_source_dialog.dart
@@ -1,5 +1,7 @@
+import 'package:fluentui_system_icons/fluentui_system_icons.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:otzaria/models/books.dart';
 import 'package:otzaria/text_book/bloc/text_book_state.dart';
 import 'package:otzaria/services/book_details_service.dart';
@@ -172,62 +174,93 @@ Widget _buildBookDetailsContent(
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          DetailsInfoSection(title: 'שם הספר:', value: book.title),
+          DetailsInfoSection(
+            icon: OtzariaIcons.booklet_empty_24_regular,
+            title: 'שם הספר:',
+            value: book.title,
+          ),
           if (information.authors.isNotEmpty)
             DetailsInfoSection(
               title: 'מחבר:',
+              icon: OtzariaIcons.person_24_regular,
               value: information.authors.join(', '),
             ),
           if (information.generation != null)
-            DetailsInfoSection(title: 'דור:', value: information.generation!),
+            DetailsInfoSection(
+              icon: FluentIcons.people_team_24_regular,
+              title: 'דור:',
+              value: information.generation!,
+            ),
           if (book.heEra != null && book.heEra!.isNotEmpty)
-            DetailsInfoSection(title: 'תקופה:', value: book.heEra!),
+            DetailsInfoSection(
+              icon: FluentIcons.history_24_regular,
+              title: 'תקופה:',
+              value: book.heEra!,
+            ),
           if (information.categories != null)
             DetailsInfoSection(
               title: 'קטגוריות:',
+              icon: FluentIcons.folder_24_regular,
               value: information.categories!,
             ),
           if (book.compDateStringHe != null &&
               book.compDateStringHe!.isNotEmpty)
             DetailsInfoSection(
               title: 'תאריך חיבור:',
+              icon: OtzariaIcons.calendar_24_regular,
               value: book.compDateStringHe!,
             ),
           if (book.compPlaceStringHe != null &&
               book.compPlaceStringHe!.isNotEmpty)
             DetailsInfoSection(
               title: 'מקום חיבור:',
+              icon: FluentIcons.location_24_regular,
               value: book.compPlaceStringHe!,
             ),
           if (information.publicationDates.isNotEmpty)
             DetailsInfoSection(
               title: 'תאריך פרסום:',
+              icon: FluentIcons.print_24_regular,
               value: information.publicationDates.join(', '),
             ),
           if (information.publicationPlaces.isNotEmpty)
             DetailsInfoSection(
               title: 'מקום פרסום:',
+              icon: FluentIcons.building_24_regular,
               value: information.publicationPlaces.join(', '),
             ),
           if (information.topics.isNotEmpty)
             DetailsInfoSection(
               title: 'נושאים:',
+              icon: FluentIcons.tag_24_regular,
               value: information.topics.join(', '),
             ),
           if (information.shortDescription != null)
             DetailsInfoSection(
               title: 'תיאור קצר:',
+              icon: OtzariaIcons.book_information_24_regular,
               value: information.shortDescription!,
             ),
           if (information.fullDescription != null)
             DetailsInfoSection(
               title: 'תיאור מורחב:',
+              icon: FluentIcons.document_text_24_regular,
               value: information.fullDescription!,
             ),
           const Divider(height: 24),
-          const Text(
-            'מקור הספר:',
-            style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+          Row(
+            children: [
+              Icon(
+                OtzariaIcons.book_information_24_filled,
+                size: 18,
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+              ),
+              const SizedBox(width: 6),
+              const Text(
+                'מקור הספר:',
+                style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+              ),
+            ],
           ),
           const SizedBox(height: 8),
           if (isTashma)
@@ -254,6 +287,7 @@ Widget _buildBookDetailsContent(
           if (bookDetails['נתיב הקובץ'] != BookDetailsService.bookNotFoundText)
             DetailsInfoSection(
               title: 'נתיב הקובץ:',
+              icon: FluentIcons.folder_open_24_regular,
               value: bookDetails['נתיב הקובץ']!,
               valueDirection: TextDirection.ltr,
             ),

--- a/lib/text_book/view/combined_view/combined_book_screen.dart
+++ b/lib/text_book/view/combined_view/combined_book_screen.dart
@@ -7,6 +7,7 @@ import 'package:otzaria/text_book/utils/visible_index.dart';
 
 import 'package:flutter/services.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:otzaria/widgets/text/rtl_selection_shortcuts.dart';
 import 'package:otzaria/widgets/text/selection_copy_shortcuts.dart';
@@ -1248,13 +1249,13 @@ class _CombinedViewState extends State<CombinedView> {
       ),
       AppContextMenuEntry(
         label: 'מפרשים',
-        icon: FluentIcons.book_24_regular,
+        icon: OtzariaIcons.book_24_regular,
         enabled: state.availableCommentators.isNotEmpty,
         children: commentatorChildren,
       ),
       AppContextMenuEntry(
         label: 'קישורים',
-        icon: FluentIcons.link_24_regular,
+        icon: OtzariaIcons.link_24_regular,
         enabled: paragraphLinks.isNotEmpty,
         childrenBuilder: buildLinkChildren,
       ),

--- a/lib/text_book/view/commentary_list_base.dart
+++ b/lib/text_book/view/commentary_list_base.dart
@@ -3,6 +3,7 @@ import 'package:otzaria/theme/app_fonts.dart';
 import 'package:otzaria/theme/app_tokens.dart';
 import 'package:flutter/gestures.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:otzaria/widgets/text/rtl_selection_shortcuts.dart';
 import 'package:otzaria/widgets/text/selection_copy_shortcuts.dart';
@@ -611,7 +612,7 @@ class CommentaryListBaseState extends State<CommentaryListBase> {
         const SizedBox(width: gap),
         // 4. הפעלת שדה החיפוש
         IconButton(
-          icon: const Icon(FluentIcons.search_24_regular),
+          icon: const Icon(OtzariaIcons.search_24_regular),
           tooltip: 'חיפוש',
           onPressed: _openInlineSearch,
         ),
@@ -697,7 +698,9 @@ class CommentaryListBaseState extends State<CommentaryListBase> {
                         controller: _searchController,
                         decoration: InputDecoration(
                           hintText: 'חפש בתוך המפרשים המוצגים...',
-                          prefixIcon: const Icon(FluentIcons.search_24_regular),
+                          prefixIcon: const Icon(
+                            OtzariaIcons.search_in_the_library_24_regular,
+                          ),
                           suffixIcon: Row(
                             mainAxisSize: MainAxisSize.min,
                             children: [

--- a/lib/text_book/view/commentators_tab_screen.dart
+++ b/lib/text_book/view/commentators_tab_screen.dart
@@ -1100,11 +1100,11 @@ class _CommentatorsTabScreenState extends State<CommentatorsTabScreen>
               ActionButtonData(
                 widget: BarButton.icon(
                   tooltip: 'חיפוש',
-                  icon: FluentIcons.search_24_regular,
+                  icon: OtzariaIcons.search_24_regular,
                   compact: context.read<SettingsBloc>().state.compactMenuMode,
                   onPressed: _openSearchPane,
                 ),
-                icon: FluentIcons.search_24_regular,
+                icon: OtzariaIcons.search_24_regular,
                 tooltip: 'חיפוש',
                 onPressed: _openSearchPane,
               ),
@@ -1239,13 +1239,13 @@ class _CommentatorsTabScreenState extends State<CommentatorsTabScreen>
               label: 'ניווט',
             ),
             (
-              icon: FluentIcons.apps_list_24_regular,
-              iconFilled: FluentIcons.apps_list_24_filled,
+              icon: OtzariaIcons.apps_list_24_regular,
+              iconFilled: OtzariaIcons.apps_list_24_filled,
               label: 'מפרשים',
             ),
             (
-              icon: FluentIcons.search_24_regular,
-              iconFilled: FluentIcons.search_24_filled,
+              icon: OtzariaIcons.search_24_regular,
+              iconFilled: OtzariaIcons.search_24_filled,
               label: 'חיפוש',
             ),
           ],
@@ -1746,8 +1746,8 @@ class _CommentatorsTabScreenState extends State<CommentatorsTabScreen>
       level: 1,
       isSelected: isSelected,
       icon: isAllChapter
-          ? FluentIcons.book_24_regular
-          : FluentIcons.text_bullet_list_24_regular,
+          ? OtzariaIcons.book_24_regular
+          : OtzariaIcons.text_bullet_list_24_regular,
       onTap: onTap,
     );
   }

--- a/lib/text_book/view/page_shape/page_shape_screen.dart
+++ b/lib/text_book/view/page_shape/page_shape_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:otzaria/theme/app_fonts.dart';
 import 'package:otzaria/text_book/bloc/text_book_bloc.dart';
 import 'package:otzaria/text_book/bloc/text_book_event.dart';
@@ -640,7 +641,7 @@ class _PageShapeScreenState extends State<PageShapeScreen> {
           children: [
             ActionButton.recommended(
               onPressed: onSelectCommentator,
-              icon: FluentIcons.book_24_regular,
+              icon: OtzariaIcons.book_24_regular,
               text: 'בחר מפרש',
             ),
             const SizedBox(height: 12),

--- a/lib/text_book/view/page_shape/page_shape_settings_panel.dart
+++ b/lib/text_book/view/page_shape/page_shape_settings_panel.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:otzaria/theme/app_tokens.dart';
 import 'package:otzaria/theme/app_surfaces.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:flutter_settings_screens/flutter_settings_screens.dart';
 import 'package:otzaria/settings/engine/settings_repository.dart';
 import 'package:otzaria/theme/app_fonts.dart';
@@ -14,7 +15,6 @@ import 'package:otzaria/widgets/controls/action_buttons.dart';
 import 'package:otzaria/widgets/dialogs/dialogs_exports.dart';
 import 'package:otzaria/widgets/controls/segmented_control.dart';
 import 'package:otzaria/widgets/misc/app_menu_exports.dart';
-import 'package:otzaria/widgets/misc/rtl_icon.dart';
 
 /// סוג שמירת הגדרות מפרשים
 enum CommentatorSaveScope {
@@ -343,7 +343,7 @@ class _PageShapeSettingsPanelState extends State<PageShapeSettingsPanel> {
   IconData get _displaySettingsIcon {
     switch (_displaySettingsScope) {
       case PageShapeDisplaySettingsScope.book:
-        return FluentIcons.book_24_regular;
+        return OtzariaIcons.book_24_regular;
       case PageShapeDisplaySettingsScope.workspace:
         return FluentIcons.window_24_regular;
       case PageShapeDisplaySettingsScope.global:
@@ -354,8 +354,8 @@ class _PageShapeSettingsPanelState extends State<PageShapeSettingsPanel> {
   Widget _buildDisplaySettingsIcon(BuildContext context) {
     final color = Theme.of(context).colorScheme.primary;
     if (_displaySettingsScope == PageShapeDisplaySettingsScope.book) {
-      return RtlIcon(
-        FluentIcons.book_24_regular,
+      return Icon(
+        OtzariaIcons.book_24_regular,
         size: 20,
         color: color,
       );

--- a/lib/text_book/view/page_shape/simple_text_viewer.dart
+++ b/lib/text_book/view/page_shape/simple_text_viewer.dart
@@ -37,6 +37,7 @@ import 'package:otzaria/core/focus_repository.dart';
 import 'package:otzaria/widgets/text/rtl_selection_shortcuts.dart';
 import 'package:otzaria/widgets/misc/app_menu_exports.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:otzaria/utils/text/copy_utils.dart';
 import 'package:otzaria/core/messages/text_book_messages.dart';
 import 'package:otzaria/core/ui_snack.dart';
@@ -1712,7 +1713,7 @@ class _SimpleTextViewerState extends State<SimpleTextViewer> {
       entries.add(
         AppContextMenuEntry(
           label: hasSelectedText ? 'חפש "${quote(10)}" בספר זה' : 'חיפוש',
-          icon: FluentIcons.book_search_24_regular,
+          icon: OtzariaIcons.book_search_24_regular,
           enabled: hasSelectedText,
           onTap: hasSelectedText
               ? () {
@@ -1737,7 +1738,7 @@ class _SimpleTextViewerState extends State<SimpleTextViewer> {
       entries.add(
         AppContextMenuEntry(
           label: 'מפרשים',
-          icon: FluentIcons.book_24_regular,
+          icon: OtzariaIcons.book_24_regular,
           enabled: state.availableCommentators.isNotEmpty,
           childrenBuilder: () => _buildCommentatorsMenuItems(state, index),
         ),
@@ -1745,7 +1746,7 @@ class _SimpleTextViewerState extends State<SimpleTextViewer> {
       entries.add(
         AppContextMenuEntry(
           label: 'קישורים',
-          icon: FluentIcons.link_24_regular,
+          icon: OtzariaIcons.link_24_regular,
           enabled: hasLinkItems,
           childrenBuilder: buildLinksItems,
         ),

--- a/lib/text_book/view/sibling_commentaries_menu.dart
+++ b/lib/text_book/view/sibling_commentaries_menu.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:otzaria/models/link_types.dart';
 import 'package:otzaria/models/links.dart';
 import 'package:otzaria/services/commentary_service.dart';
@@ -78,7 +78,7 @@ class SiblingCommentariesController {
           overflow: TextOverflow.ellipsis,
         ),
       ),
-      icon: FluentIcons.book_24_regular,
+      icon: OtzariaIcons.book_24_regular,
       childrenBuilder: () => _buildChildren(
         lineIndex,
         sourceLink,

--- a/lib/text_book/view/tabbed_commentary_panel.dart
+++ b/lib/text_book/view/tabbed_commentary_panel.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:otzaria/tabs/models/tab.dart';
 import 'package:otzaria/text_book/bloc/text_book_bloc.dart';
@@ -148,7 +149,7 @@ class _TabbedCommentaryPanelState extends State<TabbedCommentaryPanel>
                 // מתחת לסף זה - הצג אייקונים בלבד (ללא טקסט)
                 final isCompact = constraints.maxWidth < 270;
                 final firstTabIconData = widget.showSplitView
-                    ? FluentIcons.book_24_regular
+                    ? OtzariaIcons.book_24_regular
                     : FluentIcons.settings_24_regular;
                 return PanelTabHeader(
                   controller: _tabController,
@@ -183,7 +184,7 @@ class _TabbedCommentaryPanelState extends State<TabbedCommentaryPanel>
                   tabs: isCompact
                       ? [
                           PanelTab(icon: firstTabIconData),
-                          const PanelTab(icon: FluentIcons.link_24_regular),
+                          const PanelTab(icon: OtzariaIcons.link_24_regular),
                           const PanelTab(icon: FluentIcons.note_24_regular),
                         ]
                       : [
@@ -194,7 +195,7 @@ class _TabbedCommentaryPanelState extends State<TabbedCommentaryPanel>
                                 : 'סינון מפרשים',
                           ),
                           const PanelTab(
-                            icon: FluentIcons.link_24_regular,
+                            icon: OtzariaIcons.link_24_regular,
                             label: 'קישורים',
                           ),
                           const PanelTab(

--- a/lib/text_book/view/text_book_screen.dart
+++ b/lib/text_book/view/text_book_screen.dart
@@ -1936,11 +1936,11 @@ class _TextBookViewerBlocState extends State<TextBookViewerBloc>
           70,
           ActionButtonData(
             widget: IconButton(
-              icon: const Icon(FluentIcons.book_information_24_regular),
+              icon: const Icon(OtzariaIcons.book_information_24_regular),
               tooltip: 'אודות הספר',
               onPressed: () => _handleBookSourcePress(context, state),
             ),
-            icon: FluentIcons.book_information_24_regular,
+            icon: OtzariaIcons.book_information_24_regular,
             tooltip: 'אודות הספר',
             onPressed: () => _handleBookSourcePress(context, state),
           ),
@@ -1985,7 +1985,7 @@ class _TextBookViewerBlocState extends State<TextBookViewerBloc>
               ),
               ActionButtonData(
                 widget: const SizedBox.shrink(),
-                icon: FluentIcons.book_information_24_regular,
+                icon: OtzariaIcons.book_information_24_regular,
                 tooltip: 'אודות הספר',
                 onPressed: () => _handleBookSourcePress(context, state),
               ),
@@ -2590,17 +2590,17 @@ class _TextBookViewerBlocState extends State<TextBookViewerBloc>
       return ActionButtonData(
         widget: BarButton.icon(
           tooltip: tooltip,
-          icon: FluentIcons.document_pdf_24_regular,
+          icon: OtzariaIcons.book_pdf_24_regular,
           compact: compact,
           onPressed: () => _openParallelEdition(context, state, primary),
         ),
-        icon: FluentIcons.document_pdf_24_regular,
+        icon: OtzariaIcons.book_pdf_24_regular,
         tooltip: tooltip,
         onPressed: () => _openParallelEdition(context, state, primary),
       );
     }
     return ActionButtonData.split(
-      icon: FluentIcons.document_pdf_24_regular,
+      icon: OtzariaIcons.book_pdf_24_regular,
       tooltip: tooltip,
       compact: compact,
       onPressed: () => _openParallelEdition(context, state, primary),
@@ -2609,8 +2609,8 @@ class _TextBookViewerBlocState extends State<TextBookViewerBloc>
           ActionButtonData(
             widget: const SizedBox.shrink(),
             icon: edition.isCompanion
-                ? FluentIcons.document_pdf_24_regular
-                : FluentIcons.book_24_regular,
+                ? OtzariaIcons.book_pdf_24_regular
+                : OtzariaIcons.book_24_regular,
             tooltip: edition.isCompanion
                 ? '${edition.book.title} — מהדורה מודפסת (אוצריא)'
                 : edition.book.title,

--- a/lib/text_book/view/toc_navigator_screen.dart
+++ b/lib/text_book/view/toc_navigator_screen.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 import 'package:flutter/material.dart';
-import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:otzaria/text_book/bloc/text_book_bloc.dart';
 import 'package:otzaria/text_book/bloc/text_book_state.dart';
@@ -356,7 +356,7 @@ class _TocViewerState extends State<TocViewer>
             title: title,
             level: level,
             isSelected: selected,
-            icon: FluentIcons.text_bullet_list_24_regular,
+            icon: OtzariaIcons.text_bullet_list_24_regular,
             onTap: navigateToEntry,
           )
         : NavTreeTile.category(

--- a/lib/tools/acronyms_dictionary/acronyms_dictionary_screen.dart
+++ b/lib/tools/acronyms_dictionary/acronyms_dictionary_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:otzaria/core/messages/tools_messages.dart';
 import 'package:otzaria/core/ui_snack.dart';
@@ -176,7 +177,7 @@ class _AcronymsDictionaryScreenState extends State<AcronymsDictionaryScreen> {
 
     if (_filteredResults.isEmpty) {
       return const ToolEmptyState(
-        icon: FluentIcons.search_24_regular,
+        icon: OtzariaIcons.search_24_regular,
         message: 'לא נמצאו תוצאות',
       );
     }

--- a/lib/tools/aramaic_dictionary/aramaic_dictionary_screen.dart
+++ b/lib/tools/aramaic_dictionary/aramaic_dictionary_screen.dart
@@ -244,7 +244,7 @@ class _AramaicDictionaryScreenState extends State<AramaicDictionaryScreen> {
 
     if (_filteredResults.isEmpty) {
       return const ToolEmptyState(
-        icon: FluentIcons.search_24_regular,
+        icon: OtzariaIcons.search_24_regular,
         message: 'לא נמצאו תוצאות',
       );
     }

--- a/lib/tools/built_in_tools_catalog.dart
+++ b/lib/tools/built_in_tools_catalog.dart
@@ -40,8 +40,8 @@ const List<BuiltInToolMeta> kBuiltInToolsCatalog = [
     toolId: 'builtin.calendar',
     label: 'לוח שנה',
     order: 10,
-    icon: FluentIcons.calendar_24_regular,
-    iconFilled: FluentIcons.calendar_24_filled,
+    icon: OtzariaIcons.calendar_24_regular,
+    iconFilled: OtzariaIcons.calendar_24_filled,
   ),
   BuiltInToolMeta(
     toolId: 'builtin.shamor_zachor',

--- a/lib/tools/calendar/dialogs/calendar_event_dialog.dart
+++ b/lib/tools/calendar/dialogs/calendar_event_dialog.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 import 'dart:math' as math;
 
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:otzaria/widgets/misc/rtl_icon.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -835,7 +836,7 @@ class _CalendarEventDialogState extends State<CalendarEventDialog> {
   }) {
     if (!_isDesktop) {
       return _pickerButton(
-        icon: FluentIcons.calendar_24_regular,
+        icon: OtzariaIcons.calendar_24_regular,
         label: label,
         onTap: () => _pickDateWithDialog(
           initialDate: selectedDate,
@@ -860,7 +861,7 @@ class _CalendarEventDialogState extends State<CalendarEventDialog> {
         );
       },
       buttonBuilder: (ctx, open) => _pickerButton(
-        icon: FluentIcons.calendar_24_regular,
+        icon: OtzariaIcons.calendar_24_regular,
         label: label,
         onTap: open,
       ),
@@ -1063,7 +1064,7 @@ class _CalendarEventDialogState extends State<CalendarEventDialog> {
               // תחילת האירוע — תאריך + שעה מאוחדים.
               // מיקום הכפתורים והגלישה שלהם מנוהלים ע"י SettingsActionTile.
               SettingsActionTile.text(
-                rtlIcon: FluentIcons.calendar_24_regular,
+                rtlIcon: OtzariaIcons.calendar_24_regular,
                 title: 'תחילת האירוע',
                 subtitle: _startSubtitle(),
                 actions: [

--- a/lib/tools/calendar/widgets/calendar_events_panel.dart
+++ b/lib/tools/calendar/widgets/calendar_events_panel.dart
@@ -1,4 +1,5 @@
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:otzaria/widgets/misc/rtl_icon.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -99,8 +100,8 @@ class _CalendarEventsPanelState extends State<CalendarEventsPanel> {
                     ? 'חפש רק בכותרת'
                     : 'חפש גם בתיאור',
                 icon: widget.state.searchInDescriptions
-                    ? FluentIcons.document_text_24_regular
-                    : FluentIcons.text_t_24_regular,
+                    ? OtzariaIcons.search_in_the_text_24_regular
+                    : OtzariaIcons.search_in_the_document_24_regular,
                 onPressed: () =>
                     context.read<CalendarCubit>().toggleSearchInDescriptions(
                       !widget.state.searchInDescriptions,
@@ -319,7 +320,7 @@ class _CalendarEventsPanelState extends State<CalendarEventsPanel> {
                           child: Align(
                             alignment: AlignmentDirectional.bottomStart,
                             child: _EventMetaChip(
-                              icon: FluentIcons.calendar_24_regular,
+                              icon: OtzariaIcons.calendar_24_regular,
                               text: splitDate
                                   ? formatEventDate(
                                       event.baseGregorianDate,

--- a/lib/tools/calendar/widgets/calendar_times_panel.dart
+++ b/lib/tools/calendar/widgets/calendar_times_panel.dart
@@ -591,7 +591,7 @@ class _CalendarTimesPanelState extends State<CalendarTimesPanel> {
 
     return ActionButton.recommended(
       text: _buildDafYomiButtonText(bavliTractate, dafLabel),
-      icon: FluentIcons.book_24_regular,
+      icon: OtzariaIcons.book_24_regular,
       onPressed: bavliTractate == 'לא זמין'
           ? () => UiSnack.showError(ToolsMessages.dafYomiUnavailableForDate)
           : () => openDafYomiBook(

--- a/lib/tools/calendar/widgets/calendar_top_bar.dart
+++ b/lib/tools/calendar/widgets/calendar_top_bar.dart
@@ -17,6 +17,7 @@ import 'dart:math' as math;
 import 'package:otzaria/theme/app_tokens.dart';
 
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -660,8 +661,8 @@ class _CalendarTopBarState extends State<CalendarTopBar>
             icon:
                 widget.isSidePanelVisible &&
                     widget.activeSidePanelView == CalendarSidePanelView.events
-                ? FluentIcons.task_list_square_rtl_24_filled
-                : FluentIcons.task_list_square_rtl_24_regular,
+                ? OtzariaIcons.task_list_square_24_filled
+                : OtzariaIcons.task_list_square_24_regular,
             selected:
                 widget.isSidePanelVisible &&
                 widget.activeSidePanelView == CalendarSidePanelView.events,

--- a/lib/tools/gematria/gematria_search_screen.dart
+++ b/lib/tools/gematria/gematria_search_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:flutter_settings_screens/flutter_settings_screens.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:otzaria/core/messages/tools_messages.dart';
@@ -368,7 +369,9 @@ class GematriaSearchScreenState extends State<GematriaSearchScreen> {
                 onSubmitted: (_) => _performSearch(),
                 onClear: _clearResults,
                 leading: IconButton(
-                  icon: const Icon(FluentIcons.search_24_regular),
+                  icon: const Icon(
+                    OtzariaIcons.search_in_numbered_list_24_regular,
+                  ),
                   onPressed: _performSearch,
                   color: Theme.of(context).colorScheme.primary,
                 ),
@@ -499,7 +502,7 @@ class GematriaSearchScreenState extends State<GematriaSearchScreen> {
 
     if (_searchResults.isEmpty && _hasSearched) {
       return const ToolEmptyState(
-        icon: FluentIcons.search_24_regular,
+        icon: OtzariaIcons.search_in_numbered_list_24_regular,
         message: 'לא נמצאו תוצאות',
       );
     }

--- a/lib/tools/shamor_zachor/screens/book_detail_screen.dart
+++ b/lib/tools/shamor_zachor/screens/book_detail_screen.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:otzaria/theme/app_tokens.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:provider/provider.dart';
 import 'package:logging/logging.dart';
 
@@ -235,7 +236,7 @@ class _BookDetailScreenState extends State<BookDetailScreen>
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
                   Icon(
-                    FluentIcons.book_24_regular,
+                    OtzariaIcons.book_24_regular,
                     size: 64,
                     color: cs.onSurfaceVariant,
                   ),
@@ -269,7 +270,7 @@ class _BookDetailScreenState extends State<BookDetailScreen>
 
     if (learnableItems.isEmpty) {
       return const ToolEmptyState(
-        icon: FluentIcons.book_24_regular,
+        icon: OtzariaIcons.book_24_regular,
         message: 'אין פריטים ללימוד בספר זה',
       );
     }

--- a/lib/tools/shamor_zachor/screens/shamor_zachor_main_screen.dart
+++ b/lib/tools/shamor_zachor/screens/shamor_zachor_main_screen.dart
@@ -1,3 +1,4 @@
+import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
@@ -515,6 +516,8 @@ class _ShamorZachorMainScreenState extends State<ShamorZachorMainScreen>
                                 ],
                                 Expanded(
                                   child: OtzariaSearchField(
+                                    icon: OtzariaIcons
+                                        .search_in_the_library_24_regular,
                                     controller: _searchController,
                                     focusNode: _searchFocusNode,
                                     hintText: 'חפש...',

--- a/lib/tools/shamor_zachor/widgets/add_books_to_tracking_dialog.dart
+++ b/lib/tools/shamor_zachor/widgets/add_books_to_tracking_dialog.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:otzaria/theme/app_tokens.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:otzaria/core/messages/tools_messages.dart';
@@ -183,7 +184,7 @@ class _AddBooksToTrackingDialogState extends State<AddBooksToTrackingDialog> {
       autofocus: true,
       decoration: InputDecoration(
         hintText: 'חיפוש ספר...',
-        prefixIcon: const Icon(FluentIcons.search_24_regular),
+        prefixIcon: const Icon(OtzariaIcons.search_in_the_book_24_regular),
         suffixIcon: _searchController.text.isEmpty
             ? null
             : IconButton(
@@ -345,8 +346,8 @@ class _AddBooksToTrackingDialogState extends State<AddBooksToTrackingDialog> {
                 style: TextStyle(color: colorScheme.onSurfaceVariant),
               )
             : null,
-        secondary: RtlIcon(
-          FluentIcons.book_24_regular,
+        secondary: Icon(
+          OtzariaIcons.book_24_regular,
           size: 18,
           color: colorScheme.onSurfaceVariant,
         ),

--- a/lib/tools/shamor_zachor/widgets/category_books_grid.dart
+++ b/lib/tools/shamor_zachor/widgets/category_books_grid.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:provider/provider.dart';
 import 'package:logging/logging.dart';
 import 'package:otzaria/core/messages/tools_messages.dart';
@@ -262,7 +263,7 @@ class _CategoryBooksGridState extends State<CategoryBooksGrid> {
         );
       default:
         return const ToolEmptyState(
-          icon: FluentIcons.book_24_regular,
+          icon: OtzariaIcons.book_24_regular,
           message: 'אין ספרים להצגה',
         );
     }

--- a/lib/tools/view/tools_launcher_panel.dart
+++ b/lib/tools/view/tools_launcher_panel.dart
@@ -5,6 +5,7 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:otzaria/plugins/bloc/plugin_system_bloc.dart';
 import 'package:otzaria/plugins/bloc/plugin_system_event.dart';
@@ -567,6 +568,7 @@ class _ToolsLauncherPanelState extends State<ToolsLauncherPanel> {
       controller: _searchController,
       focusNode: _searchFocusNode,
       autofocus: true,
+      icon: OtzariaIcons.search_24_regular,
       hintText: 'חיפוש כלי או תוסף',
       onChanged: _onQueryChanged,
       onClear: () => _onQueryChanged(''),

--- a/lib/utils/ui/book_format_icon.dart
+++ b/lib/utils/ui/book_format_icon.dart
@@ -1,6 +1,7 @@
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
 import 'package:flutter/widgets.dart';
 import 'package:otzaria/models/books.dart';
+import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:otzaria/utils/file/document_format.dart';
 
 /// אייקון הספר לפי פורמט המסמך — מקור יחיד לכל רשימות הספרייה, תוצאות
@@ -18,10 +19,10 @@ IconData bookFormatIcon(Book book) {
       documentFormatFromFileType(book.fileType);
   if (format == null) {
     return book is PdfBook
-        ? FluentIcons.document_pdf_24_regular
+        ? OtzariaIcons.book_pdf_24_regular
         : FluentIcons.document_text_24_regular;
   }
-  if (format == DocumentFormat.pdf) return FluentIcons.document_pdf_24_regular;
+  if (format == DocumentFormat.pdf) return OtzariaIcons.book_pdf_24_regular;
   if (format.isWordDocument) return FluentIcons.document_edit_24_regular;
   return FluentIcons.document_text_24_regular;
 }

--- a/lib/widgets/commentary/links_list_view.dart
+++ b/lib/widgets/commentary/links_list_view.dart
@@ -1,3 +1,4 @@
+import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:flutter/material.dart';
 import 'package:otzaria/theme/app_fonts.dart';
 import 'package:otzaria/theme/app_tokens.dart';
@@ -389,7 +390,9 @@ class _LinksListViewState extends State<LinksListView> {
                 controller: _searchController,
                 decoration: InputDecoration(
                   hintText: 'חפש בתוך הקישורים המוצגים...',
-                  prefixIcon: const Icon(FluentIcons.search_24_regular),
+                  prefixIcon: const Icon(
+                    OtzariaIcons.search_in_titles_24_regular,
+                  ),
                   suffixIcon: _searchQuery.isNotEmpty
                       ? IconButton(
                           icon: const Icon(FluentIcons.dismiss_24_regular),

--- a/lib/widgets/dialogs/ad_popup_dialog.dart
+++ b/lib/widgets/dialogs/ad_popup_dialog.dart
@@ -1,9 +1,10 @@
+import 'package:otzaria/widgets/misc/rtl_icon.dart';
 import 'package:flutter/foundation.dart';
 import 'package:otzaria/theme/app_tokens.dart';
 import 'package:flutter/material.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:otzaria/models/support_organization.dart';
-import 'package:otzaria/widgets/misc/rtl_icon.dart';
 import 'package:otzaria/services/ad_popup_service.dart';
 import 'package:otzaria/services/support_organizations_service.dart';
 import 'package:otzaria/theme/app_surfaces.dart';
@@ -321,7 +322,7 @@ class _AdPopupDialogState extends State<AdPopupDialog>
                 value: 'week',
                 child: Row(
                   children: [
-                    RtlIcon(FluentIcons.calendar_24_regular, size: 20),
+                    Icon(OtzariaIcons.calendar_24_regular, size: 20),
                     SizedBox(width: 12),
                     Text('למשך שבוע'),
                   ],
@@ -331,7 +332,7 @@ class _AdPopupDialogState extends State<AdPopupDialog>
                 value: 'month',
                 child: Row(
                   children: [
-                    Icon(FluentIcons.calendar_month_24_regular, size: 20),
+                    RtlIcon(FluentIcons.calendar_month_24_regular, size: 20),
                     SizedBox(width: 12),
                     Text('למשך חודש'),
                   ],
@@ -558,8 +559,8 @@ class _ExpandableOrgCardState extends State<_ExpandableOrgCard> {
                   );
                   final arrow = Icon(
                     _isExpanded
-                        ? Icons.keyboard_arrow_up
-                        : Icons.keyboard_arrow_down,
+                        ? FluentIcons.chevron_up_24_regular
+                        : FluentIcons.chevron_down_24_regular,
                     color: Colors.grey[600],
                   );
 

--- a/lib/widgets/dialogs/details_info_section.dart
+++ b/lib/widgets/dialogs/details_info_section.dart
@@ -6,6 +6,7 @@ class DetailsInfoSection extends StatelessWidget {
     super.key,
     required this.title,
     required this.value,
+    this.icon,
     this.valueDirection,
   });
 
@@ -15,20 +16,38 @@ class DetailsInfoSection extends StatelessWidget {
   /// הערך המלא. הבחירה וההעתקה מסופקות ע"י AppSelectionArea שעוטף את הדיאלוג.
   final String value;
 
+  /// אייקון שמזהה את סוג הפרט, מוצג לפני התווית.
+  final IconData? icon;
+
   /// כיוון הערך, כאשר הוא שונה מכיוון הממשק.
   final TextDirection? valueDirection;
 
   @override
   Widget build(BuildContext context) {
+    final titleText = Text(
+      title,
+      style: const TextStyle(fontSize: 14, fontWeight: FontWeight.bold),
+    );
+
     return Padding(
       padding: const EdgeInsets.only(bottom: 12),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text(
-            title,
-            style: const TextStyle(fontSize: 14, fontWeight: FontWeight.bold),
-          ),
+          if (icon == null)
+            titleText
+          else
+            Row(
+              children: [
+                Icon(
+                  icon,
+                  size: 16,
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                ),
+                const SizedBox(width: 6),
+                titleText,
+              ],
+            ),
           const SizedBox(height: 4),
           Text(
             value,

--- a/lib/widgets/dialogs/selection_dialog.dart
+++ b/lib/widgets/dialogs/selection_dialog.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:otzaria/core/focus_repository.dart';
 import 'package:otzaria/widgets/controls/action_buttons.dart';
 import 'package:otzaria/widgets/misc/keyboard_dialog_navigation.dart';
@@ -91,7 +92,7 @@ class _SelectionDialogState<T> extends State<SelectionDialog<T>>
               Expanded(
                 child: filteredItems.isEmpty
                     ? const ToolEmptyState(
-                        icon: FluentIcons.search_24_regular,
+                        icon: OtzariaIcons.search_24_regular,
                         message: 'לא נמצאו תוצאות',
                       )
                     : ListView.builder(

--- a/lib/widgets/lists/items_list_view.dart
+++ b/lib/widgets/lists/items_list_view.dart
@@ -1,3 +1,4 @@
+import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
@@ -48,6 +49,9 @@ class ItemsListView extends StatefulWidget {
   final String emptyText;
   final String notFoundText;
   final String clearAllText;
+
+  /// אייקון שדה החיפוש — ממוקד לפי מה שמסתנן ברשימה.
+  final IconData searchIcon;
   final Widget? Function(dynamic item)? leadingIconBuilder;
   final String? Function(dynamic item)? subtitleBuilder;
   final String? Function(dynamic item)? subtitleTooltipBuilder;
@@ -93,6 +97,7 @@ class ItemsListView extends StatefulWidget {
     required this.emptyText,
     required this.notFoundText,
     required this.clearAllText,
+    this.searchIcon = OtzariaIcons.search_24_regular,
     this.leadingIconBuilder,
     this.subtitleBuilder,
     this.subtitleTooltipBuilder,
@@ -563,6 +568,7 @@ class _ItemsListViewState extends State<ItemsListView> {
               builder: (context) {
                 final searchField = OtzariaSearchField(
                   controller: _searchController,
+                  icon: widget.searchIcon,
                   focusNode: _searchFocusNode,
                   hintText: widget.hintText,
                   onClear: () {

--- a/lib/widgets/lists/nav_tree_tile.dart
+++ b/lib/widgets/lists/nav_tree_tile.dart
@@ -1,4 +1,5 @@
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:flutter/material.dart';
 import 'package:otzaria/theme/app_surfaces.dart';
 import 'package:otzaria/theme/app_tokens.dart';
@@ -148,7 +149,7 @@ class NavTreeTile extends StatelessWidget {
     String? subtitle,
     bool isSelected = false,
     int? count,
-    IconData icon = FluentIcons.book_24_regular,
+    IconData icon = OtzariaIcons.book_24_regular,
     Widget? leading,
     Widget? trailing,
     VoidCallback? onClearFilter,

--- a/lib/widgets/misc/app_context_menu.dart
+++ b/lib/widgets/misc/app_context_menu.dart
@@ -19,7 +19,7 @@ import 'package:otzaria/widgets/misc/overlay_scroll_anchor.dart';
 //       const AppContextMenuEntry.divider(),
 //       AppContextMenuEntry(
 //         label: 'מפרשים',
-//         icon: FluentIcons.book_24_regular,
+//         icon: OtzariaIcons.book_24_regular,
 //         children: [...],
 //       ),
 //     ],

--- a/lib/widgets/misc/app_popup_menu.dart
+++ b/lib/widgets/misc/app_popup_menu.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:math';
 
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:otzaria/theme/theme_exports.dart';
@@ -837,7 +838,7 @@ class _AnchoredSearchMenuContentState<T>
                         ),
                         isDense: true,
                         prefixIcon: Icon(
-                          FluentIcons.search_24_regular,
+                          OtzariaIcons.search_24_regular,
                           size: widget.metrics.iconSize,
                           color: cs.onSurfaceVariant,
                         ),

--- a/lib/widgets/misc/commentators_filter_button.dart
+++ b/lib/widgets/misc/commentators_filter_button.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:otzaria_icons/otzaria_icons.dart';
 
 class CommentatorsFilterButton extends StatelessWidget {
   final bool isActive;
@@ -23,7 +23,7 @@ class CommentatorsFilterButton extends StatelessWidget {
   Widget build(BuildContext context) {
     return IconButton(
       icon: Icon(
-        FluentIcons.apps_list_24_regular,
+        OtzariaIcons.apps_list_24_regular,
         color: isActive
             ? Theme.of(context).colorScheme.primary
             : Theme.of(

--- a/lib/widgets/misc/link_context_menu_entry.dart
+++ b/lib/widgets/misc/link_context_menu_entry.dart
@@ -1,3 +1,4 @@
+import 'package:fluentui_system_icons/fluentui_system_icons.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:otzaria/models/links.dart';
@@ -130,7 +131,7 @@ class _LinkHoverPreviewContentState extends State<LinkHoverPreviewContent> {
                       Expanded(child: titleText),
                       const SizedBox(width: 6),
                       Icon(
-                        Icons.open_in_new,
+                        FluentIcons.open_24_regular,
                         size: compact ? 13 : 16,
                         color: colorScheme.primary,
                       ),

--- a/lib/widgets/misc/rtl_icon.dart
+++ b/lib/widgets/misc/rtl_icon.dart
@@ -1,6 +1,11 @@
 // ווידג'ט RtlIcon — אייקון RTL-מודע שמהפך חיצי ניווט אוטומטית.
 // ⚠️ לא ניתן להשתמש ב-const Map<IconData,...> כי IconData לא מימש ==.
-//    מפות הנגד מוגדרות כ-static final.
+//    המפה והסט מוגדרים כ-static final.
+// ⚠️ אייקוני OtzariaIcons אסור להוסיף לכאן — הם מצוירים RTL מלכתחילה.
+//    אייקוני פלואנט נשארים כאן גם כשהאפליקציה עברה לאוצריא, כי תוסף
+//    יכול להצהיר עליהם בשם דרך fluentIconFromName.
+// ⚠️ _flippableIcons הוא פתרון ביניים: היפוך גאומטרי הופך גם פרטים
+//    א-סימטריים. אייקון שנראה רע כך — לצייר ב-otzaria_icons ולהסיר מכאן.
 
 import 'package:flutter/material.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
@@ -18,25 +23,6 @@ class RtlIcon extends StatelessWidget {
     this.color,
     this.semanticLabel,
   });
-
-  static final Map<IconData, IconData> _materialMirrorMap = {
-    Icons.arrow_forward: Icons.arrow_back,
-    Icons.arrow_back: Icons.arrow_forward,
-    Icons.arrow_forward_ios: Icons.arrow_back_ios,
-    Icons.arrow_back_ios: Icons.arrow_forward_ios,
-    Icons.arrow_right: Icons.arrow_left,
-    Icons.arrow_left: Icons.arrow_right,
-    Icons.chevron_right: Icons.chevron_left,
-    Icons.chevron_left: Icons.chevron_right,
-    Icons.navigate_next: Icons.navigate_before,
-    Icons.navigate_before: Icons.navigate_next,
-    Icons.keyboard_arrow_right: Icons.keyboard_arrow_left,
-    Icons.keyboard_arrow_left: Icons.keyboard_arrow_right,
-    Icons.first_page: Icons.last_page,
-    Icons.last_page: Icons.first_page,
-    Icons.skip_next: Icons.skip_previous,
-    Icons.skip_previous: Icons.skip_next,
-  };
 
   static final Map<IconData, IconData> _fluentMirrorMap = {
     FluentIcons.chevron_right_24_regular: FluentIcons.chevron_left_24_regular,
@@ -68,7 +54,6 @@ class RtlIcon extends StatelessWidget {
   static final Set<IconData> _flippableIcons = {
     FluentIcons.book_24_regular,
     FluentIcons.book_24_filled,
-    FluentIcons.book_star_24_regular,
     FluentIcons.book_information_24_regular,
     FluentIcons.text_align_distributed_24_regular,
     FluentIcons.list_24_regular,
@@ -91,7 +76,7 @@ class RtlIcon extends StatelessWidget {
 
     if (!isRtl) return baseIcon;
 
-    final mirroredIcon = _materialMirrorMap[icon] ?? _fluentMirrorMap[icon];
+    final mirroredIcon = _fluentMirrorMap[icon];
     if (mirroredIcon != null) {
       return Icon(
         mirroredIcon,

--- a/lib/widgets/navigation/search_pane_base.dart
+++ b/lib/widgets/navigation/search_pane_base.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
-import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:otzaria/widgets/navigation/nav_panel_search.dart';
 import 'package:otzaria/widgets/text/otzaria_search_field.dart';
 
@@ -143,7 +143,7 @@ class _SearchPaneBaseState extends State<SearchPaneBase> {
             },
             isCompact: _isCompact,
             onExpand: () => setState(() => _isCompact = false),
-            leading: const Icon(FluentIcons.search_24_regular),
+            leading: const Icon(OtzariaIcons.search_24_regular),
             trailingActions: [
               if (widget.onAdvancedSearch != null)
                 OtzariaSearchAction.settings(

--- a/lib/widgets/text/otzaria_search_field.dart
+++ b/lib/widgets/text/otzaria_search_field.dart
@@ -15,6 +15,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:otzaria/settings/engine/settings_bloc.dart';
 import 'package:otzaria/theme/theme_exports.dart';
 import 'package:otzaria/widgets/text/rtl_text_field.dart';
@@ -242,6 +243,10 @@ class OtzariaSearchField extends StatefulWidget {
   final Widget? leading;
   final List<Widget>? trailingActions;
 
+  /// אייקון החיפוש. עדיף למקד אותו לפי מה שמחפשים בו — למשל
+  /// `search_in_the_library_24_regular` בספרייה. `leading` דוחה אותו.
+  final IconData icon;
+
   /// `null` = יורש אוטומטית מ-compactMenuMode אם זמין.
   /// `true` = שדה צר, `false` = שדה רחב.
   final bool? slim;
@@ -267,6 +272,7 @@ class OtzariaSearchField extends StatefulWidget {
     this.maxWidth,
     this.leading,
     this.trailingActions,
+    this.icon = OtzariaIcons.search_24_regular,
     this.slim,
     this.isCompact = false,
     this.onExpand,
@@ -358,7 +364,7 @@ class _OtzariaSearchFieldState extends State<OtzariaSearchField> {
         padding: EdgeInsets.zero,
         visualDensity: VisualDensity.compact,
         icon: Icon(
-          FluentIcons.search_24_regular,
+          widget.icon,
           size: 20,
           color: cs.onSurfaceVariant,
         ),
@@ -438,7 +444,7 @@ class _OtzariaSearchFieldState extends State<OtzariaSearchField> {
     final prefixIcon =
         widget.leading ??
         Icon(
-          FluentIcons.search_24_regular,
+          widget.icon,
           size: prefixIconSize,
           color: _hasFocus && widget.enabled ? focusedIconColor : hintColor,
         );

--- a/test/library/view/library_daf_yomi_test.dart
+++ b/test/library/view/library_daf_yomi_test.dart
@@ -1,4 +1,4 @@
-import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:otzaria/library/view/library_daf_yomi.dart';
@@ -20,7 +20,7 @@ void main() {
       await tester.pumpWidget(wrap(LibraryDafYomi(onDafYomiTap: (_, _) {})));
 
       expect(
-        buttonForIcon(tester, FluentIcons.book_24_regular).onPressed,
+        buttonForIcon(tester, OtzariaIcons.book_24_regular).onPressed,
         isNotNull,
       );
     });
@@ -33,11 +33,11 @@ void main() {
       );
 
       expect(
-        buttonForIcon(tester, FluentIcons.book_24_regular).onPressed,
+        buttonForIcon(tester, OtzariaIcons.book_24_regular).onPressed,
         isNull,
       );
       expect(
-        buttonForIcon(tester, FluentIcons.calendar_24_regular).onPressed,
+        buttonForIcon(tester, OtzariaIcons.calendar_24_regular).onPressed,
         isNotNull,
       );
     });

--- a/test/navigation/custom_title_bar_test.dart
+++ b/test/navigation/custom_title_bar_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_settings_screens/flutter_settings_screens.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:otzaria/models/books.dart';
 import 'package:otzaria/tabs/models/combined_tab.dart';
 import 'package:otzaria/tabs/models/commentators_tab.dart';
@@ -446,8 +447,8 @@ void main() {
     expect(find.text('מפרשים | ספר א'), findsOneWidget);
     expect(tester.takeException(), isNull);
     // רק טאב-PDF מקבל אייקון-סוג; בטאב מפרשים אין אייקון מוביל.
-    expect(find.byIcon(FluentIcons.book_24_regular), findsNothing);
-    expect(find.byIcon(FluentIcons.document_pdf_16_regular), findsNothing);
+    expect(find.byIcon(OtzariaIcons.book_24_regular), findsNothing);
+    expect(find.byIcon(OtzariaIcons.book_pdf_24_regular), findsNothing);
   });
 
   testWidgets('טאב PDF רחב מציג אייקון PDF ליד שם הספר', (tester) async {
@@ -475,7 +476,7 @@ void main() {
       settingsBloc: settingsBloc,
     );
 
-    expect(find.byIcon(FluentIcons.document_pdf_16_regular), findsOneWidget);
+    expect(find.byIcon(OtzariaIcons.book_pdf_24_regular), findsOneWidget);
   });
 
   testWidgets('טאב PDF צר (רוחב < 100) מסתיר את אייקון ה-PDF', (tester) async {
@@ -506,7 +507,7 @@ void main() {
       settingsBloc: settingsBloc,
     );
 
-    expect(find.byIcon(FluentIcons.document_pdf_16_regular), findsNothing);
+    expect(find.byIcon(OtzariaIcons.book_pdf_24_regular), findsNothing);
   });
 
   testWidgets('CombinedTab מציג את התחלת שני הספרים, כל אחד בחצי', (

--- a/test/search/word_match_mode_menu_test.dart
+++ b/test/search/word_match_mode_menu_test.dart
@@ -1,4 +1,4 @@
-import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_spinbox/flutter_spinbox.dart';
@@ -26,7 +26,7 @@ void main() {
 
   // פותח את תת-התפריט של טווח "מרווח בין מילים" בתוך התפריט המרוכז.
   Future<void> openWordDistanceSubmenu(WidgetTester tester) async {
-    await tester.tap(find.byIcon(FluentIcons.apps_list_24_regular));
+    await tester.tap(find.byIcon(OtzariaIcons.apps_list_24_regular));
     await tester.pumpAndSettle();
     await tester.tap(
       find.descendant(
@@ -94,7 +94,7 @@ void main() {
       await tester.pumpWidget(harness(bloc, tab));
       await tester.pumpAndSettle();
       expect(
-        find.byIcon(FluentIcons.apps_list_24_regular),
+        find.byIcon(OtzariaIcons.apps_list_24_regular),
         findsNothing,
       );
     });

--- a/test/settings/reading_settings_commentary_font_test.dart
+++ b/test/settings/reading_settings_commentary_font_test.dart
@@ -65,13 +65,19 @@ void main() {
 
       expect(find.text('גודל גופן מפרשים'), findsOneWidget);
       expect(find.text('גופן מפרשים'), findsOneWidget);
+      // כל אחת מארבע ההגדרות מקבלת אייקון משלה: גודל/גופן × טקסט/מפרשים.
       expect(
         find.byIcon(OtzariaIcons.alef_near_alef_24_regular),
-        findsNWidgets(2),
+        findsOneWidget,
       );
+      expect(find.byIcon(OtzariaIcons.tet_near_tet_24_regular), findsOneWidget);
       expect(
         find.byIcon(OtzariaIcons.beit_near_alef_24_regular),
-        findsNWidgets(2),
+        findsOneWidget,
+      );
+      expect(
+        find.byIcon(OtzariaIcons.beit_behind_alef_24_regular),
+        findsOneWidget,
       );
       expect(
         find.byIcon(OtzariaIcons.alef_with_score_24_regular),

--- a/test/text_book/view/commentary_search_focus_test.dart
+++ b/test/text_book/view/commentary_search_focus_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:otzaria/data/data_providers/book_composite_key.dart';
 import 'package:otzaria/data/data_providers/library_provider.dart';
@@ -104,14 +105,14 @@ Future<void> main() async {
 
       // השדה נסגר וחוזרים לשורת הלחצנים (כולל אייקון החיפוש).
       expect(find.byType(TextField), findsNothing);
-      expect(find.byIcon(FluentIcons.search_24_regular), findsWidgets);
+      expect(find.byIcon(OtzariaIcons.search_24_regular), findsWidgets);
       expect(controller.text, isEmpty);
     }, skip: !engineReady);
   });
 }
 
 Future<void> _openInlineSearch(WidgetTester tester) async {
-  await tester.tap(find.byIcon(FluentIcons.search_24_regular).first);
+  await tester.tap(find.byIcon(OtzariaIcons.search_24_regular).first);
   await tester.pumpAndSettle();
 }
 

--- a/test/text_book/view/page_shape/page_shape_sidebar_tabs_test.dart
+++ b/test/text_book/view/page_shape/page_shape_sidebar_tabs_test.dart
@@ -1,4 +1,5 @@
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_settings_screens/flutter_settings_screens.dart';
@@ -147,8 +148,8 @@ void main() {
       ),
       findsNWidgets(3),
     );
-    expect(tabWithIcon(FluentIcons.book_24_regular), findsOneWidget);
-    expect(tabWithIcon(FluentIcons.link_24_regular), findsOneWidget);
+    expect(tabWithIcon(OtzariaIcons.book_24_regular), findsOneWidget);
+    expect(tabWithIcon(OtzariaIcons.link_24_regular), findsOneWidget);
     expect(tabWithIcon(FluentIcons.note_24_regular), findsOneWidget);
 
     // הלשונית הפעילה היא "מפרשים" — בלי מפרשים נבחרים מוצג מסך הבחירה,
@@ -163,7 +164,7 @@ void main() {
     await tester.tap(find.byType(PanelOpenHandle));
     await tester.pumpAndSettle();
 
-    await tester.tap(tabWithIcon(FluentIcons.link_24_regular));
+    await tester.tap(tabWithIcon(OtzariaIcons.link_24_regular));
     await tester.pumpAndSettle();
 
     expect(find.text('לא נמצאו קישורים לקטע הנבחר'), findsOneWidget);

--- a/test/tools/tools_launcher_panel_test.dart
+++ b/test/tools/tools_launcher_panel_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -44,7 +45,7 @@ ToolCatalogEntry _entry(
   toolId: toolId,
   label: label,
   order: 10,
-  icon: icon ?? FluentIcons.calendar_24_regular,
+  icon: icon ?? OtzariaIcons.calendar_24_regular,
   imageIcon: imageIcon,
 );
 
@@ -566,7 +567,7 @@ void main() {
       final cs = Theme.of(context).colorScheme;
 
       final icon = tester.widget<Icon>(
-        find.byIcon(FluentIcons.calendar_24_regular),
+        find.byIcon(OtzariaIcons.calendar_24_regular),
       );
       expect(icon.color, cs.onSecondaryContainer);
       expect(icon.size, NavTreeTile.iconContentSize);
@@ -577,7 +578,7 @@ void main() {
       await tester.pumpWidget(_tileHost(buildTile()));
 
       final iconCenter = tester.getCenter(
-        find.byIcon(FluentIcons.calendar_24_regular),
+        find.byIcon(OtzariaIcons.calendar_24_regular),
       );
       final textCenter = tester.getCenter(find.text('לוח שנה'));
 

--- a/test/widgets/app_context_menu_test.dart
+++ b/test/widgets/app_context_menu_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -1644,7 +1645,7 @@ void main() {
           AppContextMenuIconAction(
             label: 'חיפוש',
             tooltip: 'חיפוש בכל המאגר',
-            icon: FluentIcons.library_24_regular,
+            icon: OtzariaIcons.bookshelf_24_regular,
           ),
           AppContextMenuIconAction(
             label: 'העתקה',
@@ -1660,7 +1661,7 @@ void main() {
         trailingEntries: [AppContextMenuEntry(label: 'פריט', onTap: () {})],
       );
 
-      expect(find.byIcon(FluentIcons.library_24_regular), findsOneWidget);
+      expect(find.byIcon(OtzariaIcons.bookshelf_24_regular), findsOneWidget);
       expect(find.byIcon(FluentIcons.copy_24_regular), findsOneWidget);
       expect(find.byIcon(FluentIcons.note_add_24_regular), findsOneWidget);
       expect(
@@ -1717,7 +1718,7 @@ void main() {
         actions: [
           AppContextMenuIconAction(
             label: 'א',
-            icon: FluentIcons.library_24_regular,
+            icon: OtzariaIcons.bookshelf_24_regular,
             onTap: () => tapped.add('a'),
           ),
           AppContextMenuIconAction(
@@ -1756,7 +1757,7 @@ void main() {
           ),
           AppContextMenuIconAction(
             label: 'מושבת',
-            icon: FluentIcons.library_24_regular,
+            icon: OtzariaIcons.bookshelf_24_regular,
             enabled: false,
             onTap: () => disabledTapped = true,
           ),
@@ -1764,7 +1765,7 @@ void main() {
         trailingEntries: [AppContextMenuEntry(label: 'פריט', onTap: () {})],
       );
 
-      await tester.tap(find.byIcon(FluentIcons.library_24_regular));
+      await tester.tap(find.byIcon(OtzariaIcons.bookshelf_24_regular));
       await tester.pumpAndSettle();
       expect(disabledTapped, isFalse);
       expect(
@@ -1786,7 +1787,7 @@ void main() {
         actions: const [
           AppContextMenuIconAction(
             label: 'כיתוב ארוך מאוד שלא נכנס לכפתור צר',
-            icon: FluentIcons.library_24_regular,
+            icon: OtzariaIcons.bookshelf_24_regular,
           ),
           AppContextMenuIconAction(
             label: 'עוד כיתוב ארוך במיוחד לבדיקה',
@@ -1818,7 +1819,7 @@ void main() {
           AppContextMenuIconAction(
             label: 'חיפוש',
             tooltip: 'חיפוש בכל המאגר',
-            icon: FluentIcons.library_24_regular,
+            icon: OtzariaIcons.bookshelf_24_regular,
           ),
         ],
       );
@@ -1868,7 +1869,7 @@ void main() {
           AppContextMenuIconAction(
             label: 'חיפוש',
             tooltip: 'חיפוש בכל הספרים',
-            icon: FluentIcons.library_24_regular,
+            icon: OtzariaIcons.bookshelf_24_regular,
           ),
         ],
       );
@@ -1924,14 +1925,14 @@ void main() {
         actions: [
           AppContextMenuIconAction(
             tooltip: 'חיפוש בכל המאגר',
-            icon: FluentIcons.library_24_regular,
+            icon: OtzariaIcons.bookshelf_24_regular,
             enabled: false,
             onTap: () => tapped = true,
           ),
         ],
       );
 
-      await tester.tap(find.byIcon(FluentIcons.library_24_regular));
+      await tester.tap(find.byIcon(OtzariaIcons.bookshelf_24_regular));
       await tester.pumpAndSettle();
 
       expect(
@@ -2025,7 +2026,7 @@ void main() {
           AppContextMenuIconAction(
             label: 'קישור ישיר',
             tooltip: 'העתק קישור ישיר',
-            icon: FluentIcons.link_24_regular,
+            icon: OtzariaIcons.link_24_regular,
             submenuBuilder: () => [
               AppContextMenuSubAction(
                 label: 'העתק קישור למקטע',
@@ -2043,7 +2044,7 @@ void main() {
         reason: 'פעולה עם submenuBuilder מציגה חץ למטה',
       );
 
-      await tester.tap(find.byIcon(FluentIcons.link_24_regular));
+      await tester.tap(find.byIcon(OtzariaIcons.link_24_regular));
       await tester.pumpAndSettle();
       expect(
         find.text('העתק קישור למקטע'),

--- a/test/widgets/app_menu_preferred_width_test.dart
+++ b/test/widgets/app_menu_preferred_width_test.dart
@@ -1,4 +1,4 @@
-import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:otzaria/theme/theme_exports.dart';
 import 'package:otzaria/widgets/misc/app_menu_exports.dart';
@@ -60,7 +60,7 @@ void main() {
         AppMenuEntry<int>(
           value: 1,
           label: label,
-          icon: FluentIcons.book_24_regular,
+          icon: OtzariaIcons.book_24_regular,
         ),
       ],
     );

--- a/test/widgets/book_view_actions_test.dart
+++ b/test/widgets/book_view_actions_test.dart
@@ -1,4 +1,4 @@
-import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:otzaria/widgets/navigation/book_view_actions.dart';
@@ -12,7 +12,7 @@ void main() {
       var pressed = false;
 
       final action = ActionButtonData.simple(
-        icon: FluentIcons.search_24_regular,
+        icon: OtzariaIcons.search_24_regular,
         tooltip: 'חיפוש',
         onPressed: () {
           pressed = true;
@@ -27,7 +27,7 @@ void main() {
         ),
       );
 
-      expect(action.icon, FluentIcons.search_24_regular);
+      expect(action.icon, OtzariaIcons.search_24_regular);
       expect(action.tooltip, 'חיפוש');
       expect(action.onPressed, isNotNull);
 
@@ -78,7 +78,7 @@ void main() {
 ActionButtonData _action(String tooltip) {
   return ActionButtonData(
     widget: const SizedBox.shrink(),
-    icon: FluentIcons.book_24_regular,
+    icon: OtzariaIcons.book_24_regular,
     tooltip: tooltip,
     onPressed: () {},
   );

--- a/test/widgets/nav_rail_item_test.dart
+++ b/test/widgets/nav_rail_item_test.dart
@@ -15,7 +15,7 @@ void main() {
         home: Directionality(
           textDirection: TextDirection.rtl,
           child: NavRailItem(
-            icon: FluentIcons.search_24_regular,
+            icon: OtzariaIcons.search_24_regular,
             label: 'איתור',
             isSelected: true,
             onTap: () {},
@@ -40,7 +40,7 @@ void main() {
           home: Directionality(
             textDirection: TextDirection.rtl,
             child: NavRailItem(
-              icon: FluentIcons.library_24_regular,
+              icon: OtzariaIcons.bookshelf_24_regular,
               label: 'ספרייה',
               isSelected: false,
               onTap: () {},
@@ -70,7 +70,7 @@ void main() {
           home: Directionality(
             textDirection: TextDirection.rtl,
             child: NavRailItem(
-              icon: FluentIcons.library_24_regular,
+              icon: OtzariaIcons.bookshelf_24_regular,
               label: 'ספרייה',
               isSelected: true,
               onTap: () {},
@@ -285,7 +285,7 @@ void main() {
           home: Directionality(
             textDirection: TextDirection.ltr,
             child: NavRailItem(
-              icon: FluentIcons.book_24_regular,
+              icon: OtzariaIcons.book_24_regular,
               label: 'ספרייה',
               isSelected: false,
               onTap: () {},

--- a/test/widgets/responsive_action_bar_test.dart
+++ b/test/widgets/responsive_action_bar_test.dart
@@ -1,4 +1,5 @@
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:otzaria_icons/otzaria_icons.dart';
 import 'dart:ui' show Tristate;
 
 import 'package:flutter/material.dart';
@@ -42,14 +43,14 @@ void main() {
 
       final actions = [
         ActionButtonData(
-          widget: buildAction(FluentIcons.book_24_regular, 'ספר'),
-          icon: FluentIcons.book_24_regular,
+          widget: buildAction(OtzariaIcons.book_24_regular, 'ספר'),
+          icon: OtzariaIcons.book_24_regular,
           tooltip: 'ספר',
           onPressed: () {},
         ),
         ActionButtonData(
-          widget: buildAction(FluentIcons.search_24_regular, 'חיפוש'),
-          icon: FluentIcons.search_24_regular,
+          widget: buildAction(OtzariaIcons.search_24_regular, 'חיפוש'),
+          icon: OtzariaIcons.search_24_regular,
           tooltip: 'חיפוש',
           onPressed: () {},
         ),
@@ -92,8 +93,8 @@ void main() {
       );
 
       expect(find.byIcon(FluentIcons.more_vertical_24_regular), findsOneWidget);
-      expect(find.byIcon(FluentIcons.book_24_regular), findsOneWidget);
-      expect(find.byIcon(FluentIcons.search_24_regular), findsOneWidget);
+      expect(find.byIcon(OtzariaIcons.book_24_regular), findsOneWidget);
+      expect(find.byIcon(OtzariaIcons.search_24_regular), findsOneWidget);
       expect(find.byIcon(FluentIcons.settings_24_regular), findsNothing);
     },
   );
@@ -592,7 +593,7 @@ void main() {
     });
 
     testWidgets('השורה מוצגת גם במצב הישן (originalOrder)', (tester) async {
-      final visible = [action(FluentIcons.search_24_regular, 'חיפוש')];
+      final visible = [action(OtzariaIcons.search_24_regular, 'חיפוש')];
       await pumpBar(
         tester,
         actions: visible,
@@ -612,14 +613,14 @@ void main() {
       await pumpBar(
         tester,
         actions: [
-          action(FluentIcons.search_24_regular, 'חיפוש'),
+          action(OtzariaIcons.search_24_regular, 'חיפוש'),
           action(FluentIcons.settings_24_regular, 'הגדרות'),
         ],
         menuHeaderActions: navActions(onPressed: (_) {}),
         maxVisibleButtons: 2,
       );
 
-      expect(find.byIcon(FluentIcons.search_24_regular), findsOneWidget);
+      expect(find.byIcon(OtzariaIcons.search_24_regular), findsOneWidget);
       expect(find.byIcon(FluentIcons.settings_24_regular), findsOneWidget);
       // אייקוני הניווט מופיעים רק אחרי פתיחת התפריט
       expect(find.byIcon(FluentIcons.chevron_right_24_regular), findsNothing);

--- a/test/widgets/rtl_icon_registered_usage_test.dart
+++ b/test/widgets/rtl_icon_registered_usage_test.dart
@@ -6,6 +6,9 @@ import 'package:test/test.dart';
 /// ב-lib/widgets/misc/rtl_icon.dart (ב-_fluentMirrorMap, _materialMirrorMap,
 /// או _flippableIcons).
 ///
+/// אייקוני OtzariaIcons מצוירים RTL מלכתחילה, ולכן RtlIcon עליהם הוא תמיד
+/// הפרה — הוא יהפוך אייקון שכבר פונה לכיוון הנכון.
+///
 /// שימוש עם משתנה (למשל RtlIcon(rtlIcon)) — לא נבדק כאן, זו אחריות הקורא.
 void main() {
   test('כל ליטרל אייקון ב-RtlIcon() רשום ב-rtl_icon.dart', () {
@@ -24,8 +27,9 @@ void main() {
       reason:
           'שימושי RtlIcon עם אייקונים לא רשומים:\n${violations.join('\n')}'
           '\n\nאפשרויות:\n'
-          '  1. אייקון סימטרי? השתמש ב-Icon(...) רגיל.\n'
-          '  2. אייקון כיווני? הוסף אותו ל-rtl_icon.dart ואז השתמש ב-RtlIcon.',
+          '  1. אייקון OtzariaIcons? השתמש ב-Icon(...) — הוא כבר RTL.\n'
+          '  2. אייקון סימטרי? השתמש ב-Icon(...) רגיל.\n'
+          '  3. אייקון כיווני? הוסף אותו ל-rtl_icon.dart ואז השתמש ב-RtlIcon.',
     );
   });
 }
@@ -49,9 +53,9 @@ Set<String> _extractRegisteredIcons() {
 List<String> _findViolations(Set<String> registered) {
   final violations = <String>[];
 
-  // תופס: RtlIcon( ואז ליטרל FluentIcons.xxx או Icons.xxx (עם רווחים/שורות חדשות)
+  // תופס: RtlIcon( ואז ליטרל FluentIcons.xxx / OtzariaIcons.xxx / Icons.xxx
   final pattern = RegExp(
-    r'RtlIcon\(\s*((?:FluentIcons|Icons)\.\w+)',
+    r'RtlIcon\(\s*((?:FluentIcons|OtzariaIcons|Icons)\.\w+)',
     multiLine: true,
   );
 

--- a/test/widgets/short_window_state_screens_test.dart
+++ b/test/widgets/short_window_state_screens_test.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:otzaria/empty_library/empty_library_screen.dart';
 import 'package:otzaria/library/view/library_empty_state_widget.dart';
 import 'package:otzaria/widgets/feedback/tool_empty_state.dart';
@@ -154,7 +154,7 @@ void main() {
   group('ToolEmptyState', () {
     const sizes = [Size(640, 200), Size(800, 180)];
     ToolEmptyState build() => const ToolEmptyState(
-      icon: FluentIcons.search_24_regular,
+      icon: OtzariaIcons.search_24_regular,
       message: 'לא נמצאו תוצאות עבור החיפוש שהוזן',
       subtitle: 'ניתן לנסות ניסוח אחר או להרחיב את טווח החיפוש',
     );
@@ -172,7 +172,7 @@ void main() {
         tester,
         const Size(640, 180),
         const ToolEmptyState(
-          icon: FluentIcons.search_24_regular,
+          icon: OtzariaIcons.search_24_regular,
           message: 'לא נמצאו תוצאות עבור החיפוש שהוזן',
         ),
       );


### PR DESCRIPTION
### שינויי אייקונים חלק ב

שלב ב בשינויי האייקונים

לשים לב שספריית האייקונים מעודכנת ביצעתי בה כמה שינויים ועדכונים לאחרונה pub get בלעז

_מכאן נאום קלוד_

### מעבר לאייקוני otzaria_icons, הוצאת Material מ-lib ועדכון מדיניות האייקונים

## מה זה עושה

מעביר את האפליקציה להשתמש ב-`otzaria_icons` בכל מקום שיש בו מקבילה, מוציא את
אייקוני Material מ-`lib/` לגמרי, ומעדכן את `CLAUDE.md`/`AGENTS.md` שקבעו עד כה
את ההפוך המדויק.

**ב-`lib/`:** `OtzariaIcons` מ-90 ל-**273** שימושים (60 אייקונים שונים),
`FluentIcons` מ-1,177 ל-1,055, ו-Material מ-5 ל-**0**.

## שלוש שכבות ההחלפה

**שם זהה (166 מקומות)** — לאוצריא יש אייקון בשם זהה לחלוטין, כלומר הוא נוצר
במכוון כתחליף: `search`, `book`, `link`, `calendar`, `list`, `person`,
`text_bullet_list`, `apps_list`, `book_information`, `book_search` ועוד.

**התאמה סמנטית טובה יותר (47 מקומות)** — `book_pdf` לספר PDF במקום מסמך גנרי,
`otzaria_icon_2_page` לספר פתוח, `books_stacked_high` לערימת גרסאות.

**חיפוש ממוקד לפי מה שמחפשים בו** — במקום משקפת גנרית שלא אומרת כלום:
`search_in_the_library` בספרייה ובסינון מפרשים · `search_in_titles` בכותרות
ובסימניות · `search_in_the_document` בהערות · `search_in_the_book` בהוספת ספרים
למעקב · `search_in_the_settings` בהגדרות · `search_in_numbered_list` בגימטריה.

## שני באגי RTL שההמרה חשפה

**בורר מצב התצוגה ב-PDF** הפך את האייקון ב-`Transform.scale(scaleX: -1)` ידני,
כפיצוי על כך שאייקון פלואנט מצויר LTR. משנעשה אייקון אוצריא שכבר פונה לכיוון
הנכון, ההיפוך הצביע אותו לכיוון ההפוך. ההיפוך הידני הוסר.

**`calendar_month`** הוצג בפופאפ הפרסום ב-`Icon()` רגיל בזמן ששני מקומות אחרים
העבירו אותו ב-`RtlIcon` — אותו אייקון, שני כיוונים באותה תוכנה.

## `_materialMirrorMap` נמחק

משנעלמו אייקוני Material מ-`lib/`, המפה הפכה לקוד בלתי-מושג: תוסף מצהיר על
אייקון בשם דרך `fluentIconFromName`, שמחזיר IconData של פלואנט בלבד — אין שום
מסלול שמזרים Material ל-`RtlIcon`. 16 רשומות ירדו, `rtl_icon.dart` מ-113 ל-95
שורות.

הרשומות של פלואנט **נשארו** גם כשאין להן קורא ב-`lib/`, כי תוסף כן יכול להצהיר
עליהן בשם. `book_star` יצא מ-`_flippableIcons` אחרי שנצרב מחדש ב-`otzaria_icons`
— ההיפוך הגאומטרי שיבש אותו.

## אכיפה מכנית

`test/widgets/rtl_icon_registered_usage_test.dart` מפיל את הבנייה על כל
`RtlIcon(OtzariaIcons.…)`, מפני שאייקוני אוצריא מצוירים RTL מלכתחילה והיפוך
נוסף מקלקל אותם. הוא תפס ארבע קריאות רב-שורתיות שההחלפה האוטומטית פספסה.

## שדות `icon` חדשים בווידג'טים משותפים

`OtzariaSearchField`, `ItemsListView`, `DetailsInfoSection` ו-`PluginPermissionInfo`
קיבלו פרמטר אייקון עם ברירת מחדל תואמת-לאחור. זה מה שמאפשר אייקון ממוקד לכל
הקשר במקום אחד גנרי:

- **דיאלוג "אודות הספר"** — אייקון לכל שדה (מחבר, דור, תקופה, מקום חיבור, פרסום).
- **מסכי הרשאות התוספים** — אייקון לפי תחום ההרשאה במקום מגן אחיד ל-40 ההרשאות.
  מצב ההענקה נשאר מובע בצבע, והרשאות רגישות שומרות על אזהרת ה-warning.
  ההיגיון רוכז ב-`pluginPermissionIcon` כדי שלא יתפצל בין שני המסכים.

## המדיניות בתיעוד

`CLAUDE.md` ו-`AGENTS.md` קבעו `"Icons - ONLY from fluentui_system_icons"` ואסרו
במפורש `"custom icon fonts"` — כלומר בדיוק ההפוך מה-PR הזה. הכלל חזר בשלושה
מקומות וכולם התהפכו, אחרת כל עבודה עתידית הייתה מחזירה אייקונים לפלואנט.

תועדו גם ארבע המטרות של `otzaria_icons` (אייקון שמשתבש בהיפוך · שתמיד מוצג
ב-RTL · שחסר בפלואנט · שצורתו פחות מתאימה לספריה תורנית) עם השורה המשלימה שכל
השאר — chrome גנרי כמו `dismiss`, `delete`, `copy` — נשאר פלואנט.

וההחרגות שנקבעו בפועל: הספרייה עצמה, פעולת החיפוש במסך העיון, אייקון חיפוש
בתוך לחצן מתויג, וקישור ישיר לספר או למקטע. וכן ההבחנה בין קישור יחיד (פלואנט)
לקישורים בין ספרים (אוצריא) — שני אייקונים דומים לשתי משמעויות היו מבלבלים.

## אימות

- `flutter analyze` — נקי
- `dart format` — 106 קבצים, 0 שינויים
- 15 קבצי הבדיקה שה-PR נוגע בהם — **298 עברו, 0 נכשלו**
- ריצה מלאה — **8,351 עברו**, 6 נכשלו: כולם נכשלים גם על עץ נקי והם ארטיפקטים
  של Windows (מפריד נתיבים, תיקייה זמנית נעולה ב-`tearDown`). ה-CI רץ על
  `ubuntu-latest` ולא אמור לראות אותם.

## נקודה לתשומת לב הבודק

`otzaria_icons` ב-`pubspec.yaml` הוא בלי `ref:` — ענף נייד. ה-PR משתמש
באייקונים שקיימים מ-`72c04ce` והלאה (`book_star`, `search_in_titles`,
`search_in_numbered_list`, `tet_near_tet`, `otzaria_icon_2_page_24_filled`).
כרגע HEAD מכיל את כולם, אבל בלי lockfile במעקב זו אותה מלכודת שתוקנה עבור
`file_picker`. אין תג שמכיל אותם (`v0.2.0` קודם להם), אז ההצמדה תהיה ל-SHA.
שמח להוסיף קומיט כזה אם מעדיפים.

## מה נשאר בכוונה

- **6 מועמדים ב-`_flippableIcons`** שעדיין מתהפכים גאומטרית:
  `calendar_month_*`, `calendar_week_start_*`, `text_align_distributed`.
- **אייקוני תוספים** מוצגים ב-18 מקומות, 4 מהם דרך `RtlIcon` ו-14 ב-`Icon()`
  רגיל — חוסר עקביות שקדם ל-PR. הפתרון הנקי הוא לחשוף את `otzaria_icons`
  לתוספים בשם (32 שמות נפתרים מיד), וזו עבודה נפרדת בחוזה התוספים.
- **75 אייקונים שקיימים בספרייה ואינם בשימוש**, בהם `search_not_found` ל-5
  מצבי-ריק ו-`book_download`/`book_upload` ל-15 מקומות.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
