### PR TITLE
fix(library): התאריך והדף היומי בסרגל הספרייה לפי היום הלוחי

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -804,6 +804,7 @@ dart format lib/file.dart    # Format ONLY files you modified
 | Windows installer scripts (`.iss` invariants) | `test/installer/installer_scripts_test.dart` |
 | App paths / install-mode detection | `test/core/app_paths_test.dart` |
 | Library browser | `test/library/view/library_browser_preview_width_test.dart`, `…grid_items_test.dart`, `…library_browser_flat_tree_test.dart` |
+| תאריך עברי + דף יומי בסרגל הספרייה (היום הלוחי) | `test/library/view/library_daf_yomi_test.dart` |
 | Empty library screen | `test/empty_library/empty_library_screen_test.dart` |
 | PDF isolate / rasterizer | `test/printing/pdf_isolate_test.dart`, `…pdf_text_rasterizer_test.dart` |
 | PDF in-book search highlight pattern | `test/pdf_book/pdf_search_highlight_pattern_test.dart` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -867,6 +867,7 @@ dart format lib/file.dart    # Format ONLY files you modified
 | Windows installer scripts (`.iss` invariants) | `test/installer/installer_scripts_test.dart` |
 | App paths / install-mode detection | `test/core/app_paths_test.dart` |
 | Library browser | `test/library/view/library_browser_preview_width_test.dart`, `…grid_items_test.dart`, `…library_browser_flat_tree_test.dart` |
+| תאריך עברי + דף יומי בסרגל הספרייה (היום הלוחי) | `test/library/view/library_daf_yomi_test.dart` |
 | Empty library screen | `test/empty_library/empty_library_screen_test.dart` |
 | PDF isolate / rasterizer | `test/printing/pdf_isolate_test.dart`, `…pdf_text_rasterizer_test.dart` |
 | PDF in-book search highlight pattern | `test/pdf_book/pdf_search_highlight_pattern_test.dart` |

--- a/lib/library/view/library_daf_yomi.dart
+++ b/lib/library/view/library_daf_yomi.dart
@@ -42,11 +42,16 @@ class _LibraryDafYomiState extends State<LibraryDafYomi> {
 
   @override
   Widget build(BuildContext context) {
-    final Daf dafYomi = getDafYomi(DateTime.now());
+    // היום הלוחי בא מלוח השנה, שמעביר יום בשקיעה/צאת/ר"ת לפי העיר.
+    // DateTime.now() מתחלף בחצות, ולכן הציג כל הערב יום ודף אחרים מהלוח.
+    final calendarDay = context.select<CalendarCubit, DateTime>(
+      (cubit) => cubit.state.todayGregorianDate,
+    );
+    final Daf dafYomi = getDafYomi(calendarDay);
     final tractate = dafYomi.getMasechta();
     final dafAmud = dafYomi.getDaf();
     final dafText = '$tractate ${formatAmud(dafAmud)}';
-    final dateText = getHebrewDateFormattedAsString(DateTime.now());
+    final dateText = getHebrewDateFormattedAsString(calendarDay);
 
     final content = Row(
       mainAxisSize: MainAxisSize.min,

--- a/lib/navigation/view/main_window_screen.dart
+++ b/lib/navigation/view/main_window_screen.dart
@@ -1270,7 +1270,7 @@ class MainWindowScreenState extends State<MainWindowScreen>
         );
         return true;
       case OpenDailyPageAction():
-        final Daf daf = getDafYomi(DateTime.now());
+        final Daf daf = getDafYomi(_calendarCubit.state.todayGregorianDate);
         openDafYomiBook(
           context,
           daf.getMasechta(),

--- a/lib/navigation/view/main_window_screen.dart
+++ b/lib/navigation/view/main_window_screen.dart
@@ -1270,6 +1270,8 @@ class MainWindowScreenState extends State<MainWindowScreen>
         );
         return true;
       case OpenDailyPageAction():
+        await _calendarCubit.initialized;
+        if (!mounted) return false;
         final Daf daf = getDafYomi(_calendarCubit.state.todayGregorianDate);
         openDafYomiBook(
           context,

--- a/lib/tools/calendar/utils/calendar_cubit.dart
+++ b/lib/tools/calendar/utils/calendar_cubit.dart
@@ -326,11 +326,15 @@ class CalendarCubit extends Cubit<CalendarState> {
   final NotificationService _notificationService;
   final GoogleCalendarService _googleCalendarService;
   final CalendarPluginSource _pluginCalendarAdapter;
+  final Completer<void> _initializationCompleter = Completer<void>();
   Timer? _todayRefreshTimer;
   int _pluginRefreshGeneration = 0;
 
   // Getter for accessing notification service from outside
   NotificationService get notificationService => _notificationService;
+
+  /// מסתיים לאחר שטעינת ההגדרות קבעה את היום הלוחי.
+  Future<void> get initialized => _initializationCompleter.future;
 
   CalendarCubit({
     SettingsRepository? settingsRepository,
@@ -452,6 +456,9 @@ class CalendarCubit extends Cubit<CalendarState> {
             : null,
       ),
     );
+    if (!_initializationCompleter.isCompleted) {
+      _initializationCompleter.complete();
+    }
     if (isClosed) return;
     _updateTimesForDate(selectedGregorianDate, selectedCity);
     await _rescheduleNotifications();
@@ -902,6 +909,9 @@ class CalendarCubit extends Cubit<CalendarState> {
   @override
   Future<void> close() {
     _todayRefreshTimer?.cancel();
+    if (!_initializationCompleter.isCompleted) {
+      _initializationCompleter.complete();
+    }
     return super.close();
   }
 

--- a/test/library/view/library_daf_yomi_test.dart
+++ b/test/library/view/library_daf_yomi_test.dart
@@ -1,10 +1,52 @@
 import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:otzaria/library/view/library_daf_yomi.dart';
+import 'package:otzaria/tools/calendar/utils/calendar_cubit.dart';
+
+/// מספק CalendarState קבוע בלי להריץ את אתחול ה-cubit האמיתי.
+class _StubCalendarCubit extends Cubit<CalendarState> implements CalendarCubit {
+  _StubCalendarCubit(super.initialState);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
 
 void main() {
-  Widget wrap(Widget child) => MaterialApp(home: Scaffold(body: child));
+  late _StubCalendarCubit calendarCubit;
+
+  CalendarState stateWithToday(DateTime today) =>
+      CalendarState.initial().copyWith(todayGregorianDate: today);
+
+  setUp(() {
+    calendarCubit = _StubCalendarCubit(stateWithToday(DateTime.now()));
+  });
+
+  tearDown(() async {
+    await calendarCubit.close();
+  });
+
+  Widget wrap(Widget child) => MaterialApp(
+    home: Scaffold(
+      body: BlocProvider<CalendarCubit>.value(
+        value: calendarCubit,
+        child: child,
+      ),
+    ),
+  );
+
+  /// הטקסט שעל כפתור הדף היומי.
+  String dafText(WidgetTester tester) {
+    final label = find.descendant(
+      of: find.ancestor(
+        of: find.byIcon(OtzariaIcons.book_24_regular),
+        matching: find.byType(TextButton),
+      ),
+      matching: find.byType(Text),
+    );
+    return tester.widget<Text>(label.first).data ?? '';
+  }
 
   TextButton buttonForIcon(WidgetTester tester, IconData icon) {
     return tester.widget<TextButton>(
@@ -40,6 +82,66 @@ void main() {
         buttonForIcon(tester, OtzariaIcons.calendar_24_regular).onPressed,
         isNotNull,
       );
+    });
+  });
+
+  group('LibraryDafYomi — היום הלוחי', () {
+    // רגרסיה: התאריך חושב מ-DateTime.now() ולכן התחלף בחצות, בעוד לוח השנה
+    // מתחלף בשקיעה — כל הערב הוצג בסרגל יום אחד ובלוח יום אחר.
+    testWidgets('התאריך נלקח מהיום הלוחי של הלוח, לא משעון המערכת', (
+      tester,
+    ) async {
+      // 18/08/2026 = ה׳ אלול תשפ״ו.
+      calendarCubit.emit(stateWithToday(DateTime(2026, 8, 18)));
+
+      await tester.pumpWidget(wrap(LibraryDafYomi(onDafYomiTap: (_, _) {})));
+
+      expect(find.textContaining('ה׳ אלול תשפ״ו'), findsOneWidget);
+    });
+
+    testWidgets('מעבר יום בלוח מעדכן את הסרגל מיד', (tester) async {
+      calendarCubit.emit(stateWithToday(DateTime(2026, 8, 17)));
+      await tester.pumpWidget(wrap(LibraryDafYomi(onDafYomiTap: (_, _) {})));
+      expect(find.textContaining('ד׳ אלול'), findsOneWidget);
+
+      calendarCubit.emit(stateWithToday(DateTime(2026, 8, 18)));
+      await tester.pump();
+
+      expect(find.textContaining('ה׳ אלול'), findsOneWidget);
+      expect(find.textContaining('ד׳ אלול'), findsNothing);
+    });
+
+    testWidgets('הדף היומי מתחלף יחד עם היום הלוחי', (tester) async {
+      calendarCubit.emit(stateWithToday(DateTime(2026, 8, 17)));
+      await tester.pumpWidget(wrap(LibraryDafYomi(onDafYomiTap: (_, _) {})));
+      final dafBefore = dafText(tester);
+
+      calendarCubit.emit(stateWithToday(DateTime(2026, 8, 18)));
+      await tester.pump();
+
+      expect(dafText(tester), isNot(dafBefore));
+    });
+
+    testWidgets('הלחיצה פותחת את הדף של היום הלוחי', (tester) async {
+      final tapped = <String>[];
+      calendarCubit.emit(stateWithToday(DateTime(2026, 8, 17)));
+      await tester.pumpWidget(
+        wrap(
+          LibraryDafYomi(
+            onDafYomiTap: (tractate, daf) => tapped.add('$tractate $daf'),
+          ),
+        ),
+      );
+      await tester.tap(find.byIcon(OtzariaIcons.book_24_regular));
+      await tester.pump();
+
+      calendarCubit.emit(stateWithToday(DateTime(2026, 8, 18)));
+      await tester.pump();
+      await tester.tap(find.byIcon(OtzariaIcons.book_24_regular));
+      await tester.pump();
+
+      expect(tapped.first, isNot(tapped.last));
+      expect(tapped.last, dafText(tester));
     });
   });
 }

--- a/test/tools/calendar/utils/calendar_cubit_test.dart
+++ b/test/tools/calendar/utils/calendar_cubit_test.dart
@@ -54,6 +54,8 @@ class _InMemorySettingsRepository implements SettingsRepository {
   String calendarZmanAlertsJson = '{}';
   String calendarEnabledZmanim = '';
   String savedEventsJson = '[]';
+  String selectedCity = 'ירושלים';
+  String calendarDayTransition = 'sunset';
 
   @override
   Future<void> updateCalendarEvents(String json) async {
@@ -64,14 +66,14 @@ class _InMemorySettingsRepository implements SettingsRepository {
   Future<Map<String, dynamic>> loadSettings() async {
     return {
       'calendarType': 'combined',
-      'selectedCity': 'ירושלים',
+      'selectedCity': selectedCity,
       'calendarEvents': '[]',
       'calendarNotificationsEnabled': false,
       'calendarNotificationTime': 60,
       'calendarNotificationSound': false,
       'calendarZmanAlerts': calendarZmanAlertsJson,
       'calendarEnabledZmanim': calendarEnabledZmanim,
-      'calendarDayTransition': 'sunset',
+      'calendarDayTransition': calendarDayTransition,
       'googleCalendarEnabled': false,
       'googleCalendarSelectedIds': 'primary',
       'googleCalendarSyncPastDays': 60,
@@ -98,6 +100,18 @@ class _InMemorySettingsRepository implements SettingsRepository {
 
   @override
   noSuchMethod(Invocation i) => super.noSuchMethod(i);
+}
+
+class _DelayedSettingsRepository extends _InMemorySettingsRepository {
+  final Completer<void> _loadCompleter = Completer<void>();
+
+  @override
+  Future<Map<String, dynamic>> loadSettings() async {
+    await _loadCompleter.future;
+    return super.loadSettings();
+  }
+
+  void completeLoading() => _loadCompleter.complete();
 }
 
 /// SettingsRepository עם אירוע שמור + עיכוב מלאכותי ב-loadSettings.
@@ -284,6 +298,30 @@ void main() {
         transition: CalendarDayTransition.rabbeinuTam,
       );
       expect(afterRabbeinuTam, DateTime(2026, 4, 21));
+    });
+  });
+
+  group('CalendarCubit initialization', () {
+    test('initialized ממתין להגדרות שמגדירות את היום הלוחי', () async {
+      final settings = _DelayedSettingsRepository()
+        ..selectedCity = 'ניו יורק'
+        ..calendarDayTransition = 'midnight';
+      final cubit = CalendarCubit(
+        settingsRepository: settings,
+        notificationService: _FakeNotificationService(),
+      );
+      var isInitialized = false;
+      unawaited(cubit.initialized.then((_) => isInitialized = true));
+
+      await Future<void>.delayed(Duration.zero);
+      expect(isInitialized, isFalse);
+
+      settings.completeLoading();
+      await cubit.initialized;
+
+      expect(cubit.state.selectedCity, 'ניו יורק');
+      expect(cubit.state.dayTransition, CalendarDayTransition.midnight);
+      await cubit.close();
     });
   });
 


### PR DESCRIPTION
## הבאג

בין השקיעה לחצות, סרגל הספרייה ולוח השנה הציגו **שני תאריכים עבריים שונים** באותו רגע — הסרגל "ד׳ אלול" בעוד הלוח "אור לה׳ אלול".

## השורש

שני חישובים שונים של "היום":

| | מה חושב | מתחלף |
|---|---|---|
| `LibraryDafYomi` | `DateTime.now()` → `JewishCalendar.fromDateTime` | בחצות |
| `CalendarCubit` | `resolveCalendarDayForTransition` — לפי הגדרת "מעבר היום" והעיר | בשקיעה (ברירת מחדל) |

## התיקון

שני מסלולי הדף היומי נגזרים מ-`CalendarCubit.state.todayGregorianDate` — אותו מקור שהלוח עצמו מציג, כך שהם לא יכולים להיפרד:

- `LibraryDafYomi` — התאריך העברי והדף בסרגל הספרייה
- `OpenDailyPageAction` ב-`main_window_screen` — פתיחת "דף יומי" מה-Jump List של Windows / הפעלה חיצונית, שסבלה מאותו פער והייתה פותחת דף אחר מהכפתור בסרגל

הקריאה היא `context.select` ולא `watch`, כדי לא לבנות מחדש את הסרגל בכל שינוי אחר ב-`CalendarState` (בחירת יום בלוח, סנכרון גוגל, עריכת אירוע).

בונוס: הסרגל מתעדכן עכשיו לבד ברגע המעבר — ה-cubit מריץ טיימר מעבר יום. קודם התאריך נשאר תקוע עד rebuild מזדמן.

## שחזור

1. הזז את שעון המערכת ל-22:00
2. פתח את הספרייה — התאריך בסרגל
3. לחץ עליו לפתיחת לוח השנה — התאריך בסרגל שלו

לפני התיקון הלוח מקדים את הסרגל ביום. אימות שזה השורש: הגדרות לוח השנה → "מעבר היום" → **חצות** מבטל את הפער.

## בדיקות

`test/library/view/library_daf_yomi_test.dart` — 6 טסטים, כולל שלושה חדשים שמקבעים שהתאריך והדף באים מהיום הלוחי ולא משעון המערכת (שניים מהם משווים שני מצבי לוח, ולכן חסינים לשעון המכונה).

`flutter analyze` נקי, ו-`flutter test test/library/ test/navigation/` עובר (298 טסטים).

## מחוץ להיקף

`resolveCalendarDayForTransition` מקדם יום עם `add(Duration(days: 1))` — 24 שעות מוחלטות. בערב סיום שעון הקיץ (25/10/2026 בישראל) התוצאה נשארת באותו תאריך, ולכן הלוח לא מעביר יום עד חצות. באג קדם-קיים ברמת הלוח, ערב אחד בשנה, ואינו יוצר סתירה בין הסרגל ללוח — הסרגל יורש מהלוח. תיקון נפרד.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
