### PR TITLE
איתור מקורות: צמצום העבודה הסינכרונית על ה-UI בכל חיפוש (#840)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -716,6 +716,8 @@ dart format lib/file.dart    # Format ONLY files you modified
 | TantivyDataProvider (search index) | `test/data/data_providers/tantivy_data_provider_test.dart` |
 | External books scanner | `test/data/data_providers/scan_external_books_test.dart` |
 | Library book search (fuzzy + acronyms) | `test/data/repository/book_search_fuzzy_match_test.dart` |
+| אינדקס הביגרמים של הכינויים (איתור מקורות — קבוצת-על) | `test/data/cache/acronyms_bigram_index_test.dart` |
+| פתרון ספר של מפרש בדיאלוג "איתור מקורות" (id → כותרת, אינדקס העץ) | `test/find_ref/find_ref_book_by_id_test.dart` |
 
 **Search**
 | Area | Test File |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -771,6 +771,8 @@ dart format lib/file.dart    # Format ONLY files you modified
 | TantivyDataProvider (search index) | `test/data/data_providers/tantivy_data_provider_test.dart` |
 | External books scanner | `test/data/data_providers/scan_external_books_test.dart` |
 | Library book search (fuzzy + acronyms) | `test/data/repository/book_search_fuzzy_match_test.dart` |
+| אינדקס הביגרמים של הכינויים (איתור מקורות — קבוצת-על) | `test/data/cache/acronyms_bigram_index_test.dart` |
+| פתרון ספר של מפרש בדיאלוג "איתור מקורות" (id → כותרת, אינדקס העץ) | `test/find_ref/find_ref_book_by_id_test.dart` |
 
 **Search**
 | Area | Test File |

--- a/lib/data/cache/acronyms_cache.dart
+++ b/lib/data/cache/acronyms_cache.dart
@@ -4,6 +4,36 @@ import 'package:flutter/foundation.dart';
 import 'package:otzaria/data/data_providers/sqlite_data_provider.dart';
 import 'package:otzaria/utils/text/text_manipulation.dart';
 
+/// קבוצת-על ממוינת של מזהי ספרים שכינוי שלהם עלול להתאים לשאילתה.
+/// הבדיקה היא חיפוש בינארי — ללא הקצאות, כדי שתרוץ פעם אחת לכל ספר בכל הקלדה.
+class AcronymCandidateBooks {
+  const AcronymCandidateBooks._(this._sortedBookIds);
+
+  final Int32List _sortedBookIds;
+
+  /// האם ייתכן שכינוי של [bookId] מתאים לשאילתה. ההכרעה נשארת בידי הקורא —
+  /// זו קבוצת-על.
+  bool contains(int bookId) {
+    var low = 0;
+    var high = _sortedBookIds.length - 1;
+    while (low <= high) {
+      final mid = (low + high) >> 1;
+      final value = _sortedBookIds[mid];
+      if (value == bookId) return true;
+      if (value < bookId) {
+        low = mid + 1;
+      } else {
+        high = mid - 1;
+      }
+    }
+    return false;
+  }
+
+  /// בדיקות בלבד — מספר הספרים שנותרו לסריקה.
+  @visibleForTesting
+  int get length => _sortedBookIds.length;
+}
+
 /// In-memory cache for the `book_acronym` table, used for matching
 /// book acronyms and alternative titles (FindRef, library book search).
 ///
@@ -22,11 +52,47 @@ class AcronymsCache {
 
   final Map<int, List<String>> _acronymsByBookId = <int, List<String>>{};
 
+  /// אינדקס ביגרמים: לכל צמד תווים סמוכים שמופיע במונח כלשהו — מזהי הספרים
+  /// שלהם יש מונח כזה, ממוינים. המפתח הוא `(תו ראשון << 16) | תו שני`.
+  final Map<int, Int32List> _bookIdsByBigram = <int, Int32List>{};
+
+  static final AcronymCandidateBooks _noCandidates = AcronymCandidateBooks._(
+    Int32List(0),
+  );
+
   bool get isLoaded => _isLoaded;
 
   /// Returns all normalized acronyms for a given book ID.
   /// כל ערך כבר עבר [normalizeForFindRefMatch] בעת הטעינה.
   List<String>? getAcronymsForBook(int bookId) => _acronymsByBookId[bookId];
+
+  /// קבוצת-על של הספרים שכינוי שלהם עלול להתאים ל-[normalizedQuery] — בזהות,
+  /// בתחילית או בהכלה. `null` פירושו "אין צמצום, סרוק את כל הספרים".
+  ///
+  /// המסננת אינה מחמיצה: כל שלוש צורות ההתאמה דורשות מונח **שמכיל** את
+  /// השאילתה, ומונח כזה מכיל בהכרח כל ביגרם שלה — ולכן הספר מופיע בכל רשימות
+  /// הביגרמים, כולל הנדירה שבהן. שאילתה קצרה מ-2 תווים אינה ניתנת לאינדוקס.
+  AcronymCandidateBooks? candidatesFor(String normalizedQuery) {
+    // אינדקס ריק מול מונחים קיימים — נפילה לסריקה מלאה. קבוצה ריקה כאן
+    // הייתה משתיקה כל התאמת כינויים, בלי שגיאה.
+    if (!_isLoaded || _bookIdsByBigram.isEmpty) return null;
+    if (normalizedQuery.length < 2) return null;
+
+    Int32List? rarestBookIds;
+    for (var i = 0; i + 1 < normalizedQuery.length; i++) {
+      final bookIds =
+          _bookIdsByBigram[_bigramKey(
+            normalizedQuery.codeUnitAt(i),
+            normalizedQuery.codeUnitAt(i + 1),
+          )];
+      // ביגרם שאינו במאגר — אף מונח אינו מכיל את השאילתה.
+      if (bookIds == null) return _noCandidates;
+      if (rarestBookIds == null || bookIds.length < rarestBookIds.length) {
+        rarestBookIds = bookIds;
+      }
+    }
+    return AcronymCandidateBooks._(rarestBookIds!);
+  }
 
   Future<void> warmUp() async {
     if (_isLoaded) return;
@@ -48,6 +114,7 @@ class AcronymsCache {
       debugPrint('[AcronymsCache] DB not initialized; skipping warmup');
       if (myGen == _generation) {
         _acronymsByBookId.clear();
+        _bookIdsByBigram.clear();
         _isLoaded = false;
       }
       return;
@@ -62,13 +129,12 @@ class AcronymsCache {
       );
 
       // רק שליפת השורות חייבת לרוץ כאן (החיבור חי על ה-isolate הזה);
-      // נורמליזציית ה-regex — החלק היקר, על עשרות אלפי מונחים — עוברת
-      // ל-isolate נפרד כדי לא להתחרות ב-UI בזמן חלון החימומים.
+      // הנורמליזציה ובניית האינדקס עוברות ל-isolate כדי לא להתחרות ב-UI.
       final rawPairs = <(int, String)>[
         for (final row in acrRows)
           (row['bookId'] as int, (row['term'] as String?) ?? ''),
       ];
-      final local = await Isolate.run(() {
+      final (local, bigrams) = await Isolate.run(() {
         final result = <int, List<String>>{};
         for (final (bookId, term) in rawPairs) {
           if (term.isEmpty) continue;
@@ -76,13 +142,16 @@ class AcronymsCache {
           if (normalized.isEmpty) continue;
           result.putIfAbsent(bookId, () => <String>[]).add(normalized);
         }
-        return result;
+        return (result, _buildBigramIndex(result));
       });
 
       if (myGen != _generation) return;
       _acronymsByBookId
         ..clear()
         ..addAll(local);
+      _bookIdsByBigram
+        ..clear()
+        ..addAll(bigrams);
       _isLoaded = true;
       debugPrint(
         '[AcronymsCache] Loaded ${acrRows.length} acronyms for ${_acronymsByBookId.length} books',
@@ -93,6 +162,7 @@ class AcronymsCache {
       // ב-warmUp הבא, במקום ראשי-תיבות ריקים לכל ה-session.
       if (myGen == _generation) {
         _acronymsByBookId.clear();
+        _bookIdsByBigram.clear();
       }
     }
   }
@@ -100,6 +170,7 @@ class AcronymsCache {
   void clear() {
     _generation++;
     _acronymsByBookId.clear();
+    _bookIdsByBigram.clear();
     _isLoaded = false;
     _loadingFuture = null;
   }
@@ -116,6 +187,44 @@ class AcronymsCache {
           .toList();
       if (normalized.isNotEmpty) _acronymsByBookId[entry.key] = normalized;
     }
+    _bookIdsByBigram
+      ..clear()
+      ..addAll(_buildBigramIndex(_acronymsByBookId));
     _isLoaded = true;
   }
+}
+
+int _bigramKey(int first, int second) => (first << 16) | second;
+
+/// בונה את אינדקס הביגרמים מהמונחים המנורמלים. פונקציה top-level כדי שה-closure
+/// של ה-`Isolate.run` לא יוכל ללכוד את ה-singleton — שאינו sendable.
+///
+/// המזהים נצברים בסדר עולה כדי שכל רשימה תהיה ממוינת ([AcronymCandidateBooks]
+/// מסתמך על כך), ולכן די בהשוואה לאיבר האחרון לניכוי כפילויות.
+Map<int, Int32List> _buildBigramIndex(
+  Map<int, List<String>> acronymsByBookId,
+) {
+  final postings = <int, List<int>>{};
+  final bookIds = acronymsByBookId.keys.toList()..sort();
+  for (final bookId in bookIds) {
+    for (final term in acronymsByBookId[bookId]!) {
+      var previous = -1;
+      for (var i = 0; i < term.length; i++) {
+        final current = term.codeUnitAt(i);
+        if (previous >= 0) {
+          final list = postings[_bigramKey(previous, current)];
+          if (list == null) {
+            postings[_bigramKey(previous, current)] = <int>[bookId];
+          } else if (list.last != bookId) {
+            list.add(bookId);
+          }
+        }
+        previous = current;
+      }
+    }
+  }
+  return {
+    for (final entry in postings.entries)
+      entry.key: Int32List.fromList(entry.value),
+  };
 }

--- a/lib/find_ref/repository/reference_books_cache.dart
+++ b/lib/find_ref/repository/reference_books_cache.dart
@@ -532,6 +532,10 @@ class ReferenceBooksCache {
     final starts = <ReferenceBookHit>[];
     final contains = <ReferenceBookHit>[];
 
+    // מסננת הביגרמים חוסכת את המעבר על כינויי כל הספרים בכל הקלדה — היא
+    // קבוצת-על, ולכן הלולאה שמתחתיה נשארת הפוסקת היחידה על הדירוג.
+    final acronymCandidates = AcronymsCache.instance.candidatesFor(q);
+
     for (final book in BooksCache.instance.books) {
       final t = _normalizedTitles[book.id] ?? '';
       if (t.isEmpty) continue;
@@ -546,7 +550,7 @@ class ReferenceBooksCache {
         matchRank = 1;
       } else if (t.contains(q)) {
         matchRank = 2;
-      } else {
+      } else if (acronymCandidates?.contains(book.id) ?? true) {
         // התאמת ראשי תיבות — המונחים כבר מנורמלים בעת טעינת הקאש.
         final normalizedAcronyms = AcronymsCache.instance.getAcronymsForBook(
           book.id,
@@ -565,9 +569,7 @@ class ReferenceBooksCache {
               titleTokens ??= titleMatchTokens(t);
               final tailIsTitle = _acronymTailIsTitleWords(a, q, titleTokens);
               // דירוג טוב יותר גובר על קודמיו — אחרת מונח "contains" (5) שנסרק
-              // קודם היה מקבע 5 ומונע מהתאמת-התחילית הזו לדרג 4. ובין מונחי
-              // תחילית — עדיף זה שהזנב שלו מילות-כותרת (ראו [ReferenceBookHit
-              // .acronymTailIsTitleWords]).
+              // קודם היה מקבע 5 ומונע מהתאמת-התחילית הזו לדרג 4.
               if (matchRank == null ||
                   matchRank > 4 ||
                   (tailIsTitle && !tailIsTitleWords)) {

--- a/lib/find_ref/view/find_ref_dialog.dart
+++ b/lib/find_ref/view/find_ref_dialog.dart
@@ -66,21 +66,52 @@ class _CommentatorEntry {
   });
 }
 
-/// מאתר את ה-`Book` הנכון בעץ הספרייה לפי [bookId] אם נמסר, ולפי [title]
-/// אם לא. הסיבה: שני ספרים יכולים לחלוק כותרת זהה (למשל גרסאות שונות של
-/// פירוש), וה-link שייצא משאילתת המפרשים יודע בדיוק לאיזה ספר ללכת —
-/// פתרון רק לפי title היה פותח את הראשון שנמצא בעץ.
-Book? _resolveCommentatorBook(
-  Category library,
-  String title, {
-  required int? bookId,
-}) {
-  if (bookId != null && bookId > 0) {
-    final byId = findOfficialTextBookById(library, bookId);
-    if (byId != null) return byId;
+/// מפתח את עץ הספרייה במעבר אחד, כדי שפתרון ספרי המפרשים לא יסרוק את כל
+/// העץ מחדש לכל מפרש. קטע בספר יסוד מגיע לעשרות מפרשים, וכל שורה נראית
+/// מבקשת את שלה.
+///
+/// המפות נבנות בסדר ה-DFS של [findOfficialTextBookById] ושל
+/// [_findBookInLibraryByTitle], עם `putIfAbsent`, ולכן כשכמה ספרים חולקים
+/// מזהה או כותרת נבחר אותו ספר שהסריקות היו בוחרות.
+@visibleForTesting
+class LibraryBookIndex {
+  LibraryBookIndex(this.library) {
+    _collect(library);
   }
-  // fallback ל-title (תאימות לאחור עם DB שלא מחזיר targetBookId).
-  return _findBookInLibraryByTitle(library, title, preferTextBook: true);
+
+  final Category library;
+  final Map<int, TextBook> _officialTextBookById = {};
+  final Map<String, TextBook> _textBookByTitle = {};
+  final Map<String, Book> _bookByTitle = {};
+
+  void _collect(Category category) {
+    for (final book in category.books) {
+      final id = book.id;
+      if (book is TextBook) {
+        if (!book.isUserBook && id != null) {
+          _officialTextBookById.putIfAbsent(id, () => book);
+        }
+        _textBookByTitle.putIfAbsent(book.title, () => book);
+      }
+      _bookByTitle.putIfAbsent(book.title, () => book);
+    }
+    for (final subCategory in category.subCategories) {
+      _collect(subCategory);
+    }
+  }
+
+  /// מאתר את ה-`Book` הנכון לפי [bookId] אם נמסר, ולפי [title] אם לא. הסיבה:
+  /// שני ספרים יכולים לחלוק כותרת זהה (למשל גרסאות שונות של פירוש), וה-link
+  /// משאילתת המפרשים יודע בדיוק לאיזה ספר ללכת — פתרון רק לפי title היה
+  /// פותח את הראשון שנמצא בעץ.
+  Book? resolveCommentatorBook(String title, {required int? bookId}) {
+    if (bookId != null && bookId > 0) {
+      final byId = _officialTextBookById[bookId];
+      if (byId != null) return byId;
+    }
+    // fallback ל-title (תאימות לאחור עם DB שלא מחזיר targetBookId).
+    return _textBookByTitle[title] ?? _bookByTitle[title];
+  }
 }
 
 /// מאתר ספר טקסט רשמי לפי [bookId] מה-DB הראשי.
@@ -152,6 +183,11 @@ class _FindRefDialogState extends State<FindRefDialog> {
   // value=[] → אין מפרשים זמינים (לא יוצג כפתור).
   // value=[...] → רשומות מוכנות לפתיחה ישירה (כולל targetSegment ו-Book).
   final Map<String, List<_CommentatorEntry>?> _commentatorsByRef = {};
+
+  /// תקף כל עוד רענון ספרייה יוצר מופע `Category` חדש (`DataRepository.library`) —
+  /// עץ שישונה במקום יותיר כאן מפתח מיושן שיפתח את הספר הלא נכון.
+  LibraryBookIndex? _bookIndex;
+
   final ScrollController _resultsScrollController = ScrollController();
   // `true` כשיש תוצאות מתחת לאזור הנראה. מעודכן משני מקורות:
   //   1. listener על ה-ScrollController — מטפל בגלילה ע"י המשתמש.
@@ -260,15 +296,14 @@ class _FindRefDialogState extends State<FindRefDialog> {
         // `library` מוחזק בקאש ב-DataRepository.
         final library = await DataRepository.instance.library;
         if (!mounted) return;
+        final index = _indexFor(library);
         final entries = <_CommentatorEntry>[
           for (final e in dbEntries)
             _CommentatorEntry(
               title: e.title,
               targetSegment: e.targetSegment,
-              // פתרון לפי `bookId` כשזמין כדי שלא ייפתח ספר בעל אותה כותרת
-              // אך מזהה אחר; ה-fallback ל-title שומר על תאימות.
               book:
-                  _resolveCommentatorBook(library, e.title, bookId: e.bookId) ??
+                  index.resolveCommentatorBook(e.title, bookId: e.bookId) ??
                   TextBook(title: e.title),
             ),
         ];
@@ -283,6 +318,14 @@ class _FindRefDialogState extends State<FindRefDialog> {
         });
       }
     }();
+  }
+
+  LibraryBookIndex _indexFor(Category library) {
+    final existing = _bookIndex;
+    if (existing != null && identical(existing.library, library)) {
+      return existing;
+    }
+    return _bookIndex = LibraryBookIndex(library);
   }
 
   void _scrollToSelected() {

--- a/test/data/cache/acronyms_bigram_index_test.dart
+++ b/test/data/cache/acronyms_bigram_index_test.dart
@@ -1,0 +1,198 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/data/cache/acronyms_cache.dart';
+import 'package:otzaria/utils/text/text_manipulation.dart';
+
+/// בדיקות לאינדקס הביגרמים שמצמצם את סריקת הכינויים ב"איתור מקורות".
+///
+/// האינווריאנטה שכל האופטימיזציה נשענת עליה: המסננת היא **קבוצת-על** — ספר
+/// שיש לו כינוי המכיל את השאילתה חייב להיות בין המועמדים. אם היא נשברת,
+/// ספרים ייעלמו מתוצאות האיתור.
+void main() {
+  /// הכינויים והמזהים הם נתוני אמת מ-`seforim.db`.
+  const corpus = <int, List<String>>{
+    101: ['רמב"ם', 'משנה תורה', 'יד החזקה'],
+    102: ['רמב"ם הלכות תפילה', 'הלכות תפילה'],
+    103: ['שו"ע או"ח', 'שולחן ערוך אורח חיים'],
+    104: ['טור חושן משפט', 'טור חו"מ'],
+    105: ['רש"י', 'פירוש רש"י'],
+    106: ['פסקי הרא"ש', 'פסקי הראש על ברכות'],
+    107: ['ב"ק', 'בבא קמא'],
+    108: ['תוספות'],
+  };
+
+  tearDown(AcronymsCache.instance.clear);
+
+  /// כל התת-מחרוזות באורך 2 ומעלה של כל הכינויים — כל שאילתה שיכולה להתאים.
+  Set<String> allMatchableQueries() {
+    final queries = <String>{};
+    for (final terms in corpus.values) {
+      for (final raw in terms) {
+        final term = normalizeForFindRefMatch(raw);
+        for (var start = 0; start < term.length; start++) {
+          for (var end = start + 2; end <= term.length; end++) {
+            queries.add(term.substring(start, end));
+          }
+        }
+      }
+    }
+    return queries;
+  }
+
+  /// הספרים שהיום היו מקבלים דירוג כינוי עבור [query] — התאמה בזהות,
+  /// בתחילית או בהכלה, כלומר בדיוק "מונח שמכיל את השאילתה".
+  Set<int> booksMatchingByAcronym(String query) => {
+    for (final entry in corpus.entries)
+      if (entry.value.any(
+        (raw) => normalizeForFindRefMatch(raw).contains(query),
+      ))
+        entry.key,
+  };
+
+  group('AcronymsCache.candidatesFor - קבוצת-על', () {
+    test('כל ספר שכינויו מכיל את השאילתה נמצא בין המועמדים', () {
+      AcronymsCache.instance.setAcronymsForTesting(corpus);
+
+      final queries = allMatchableQueries();
+      expect(queries.length, greaterThan(200), reason: 'כיסוי סביר של שאילתות');
+
+      for (final query in queries) {
+        final candidates = AcronymsCache.instance.candidatesFor(query);
+        expect(candidates, isNotNull, reason: 'שאילתה "$query" ניתנת לאינדוקס');
+        for (final bookId in booksMatchingByAcronym(query)) {
+          expect(
+            candidates!.contains(bookId),
+            isTrue,
+            reason: 'ספר $bookId חייב להיות מועמד עבור "$query"',
+          );
+        }
+      }
+    });
+
+    test('האינווריאנטה נשמרת גם כשהספרים נזרעים בסדר יורד', () {
+      // רשימות ההצבעה חייבות להיות ממוינות כדי שהחיפוש הבינארי יעבוד;
+      // הבנייה ממיינת את המזהים בעצמה ואינה תלויה בסדר ההזרקה.
+      AcronymsCache.instance.setAcronymsForTesting({
+        for (final key in corpus.keys.toList().reversed) key: corpus[key]!,
+      });
+
+      for (final query in allMatchableQueries()) {
+        final candidates = AcronymsCache.instance.candidatesFor(query)!;
+        for (final bookId in booksMatchingByAcronym(query)) {
+          expect(
+            candidates.contains(bookId),
+            isTrue,
+            reason:
+                'ספר $bookId חייב להיות מועמד עבור "$query" גם בהזרקה '
+                'בסדר יורד — רשימות הביגרמים חייבות להיות ממוינות',
+          );
+        }
+      }
+    });
+
+    test('שאילתה נדירה מצמצמת בפועל את מספר המועמדים', () {
+      AcronymsCache.instance.setAcronymsForTesting(corpus);
+
+      // ללא צמצום ממשי אין ערך לאינדקס — הבדיקה מגנה מפני התדרדרות שקטה
+      // שבה כל השאילתות מחזירות את כל הספרים.
+      expect(
+        AcronymsCache.instance.candidatesFor('תוספות')!.length,
+        lessThan(corpus.length),
+      );
+      expect(AcronymsCache.instance.candidatesFor('קמא')!.length, 1);
+    });
+
+    test('נבחרת רשימת הביגרם הנדירה, לא הנפוצה', () {
+      // 'בם' משותף לכל הספרים; 'רמ' ו'מב' ייחודיים ל-201. בחירת הביגרם
+      // הנפוץ הייתה נשארת קבוצת-על תקינה ומוחקת את כל השיפור בשקט.
+      AcronymsCache.instance.setAcronymsForTesting({
+        201: ['רמב"ם'],
+        for (var id = 202; id <= 221; id++) id: ['רשב"ם'],
+      });
+
+      expect(AcronymsCache.instance.candidatesFor('רמבם')!.length, 1);
+    });
+
+    test('זריעה מחדש: ספר שנעלם אינו מועמד, וספר חדש כן', () {
+      AcronymsCache.instance.setAcronymsForTesting({
+        101: ['רמב"ם'],
+        102: ['תוספות'],
+      });
+      expect(AcronymsCache.instance.candidatesFor('רמבם')!.contains(101), true);
+
+      AcronymsCache.instance.setAcronymsForTesting({
+        102: ['תוספות'],
+        103: ['שולחן ערוך'],
+      });
+
+      expect(
+        AcronymsCache.instance.candidatesFor('רמבם')!.contains(101),
+        false,
+      );
+      expect(
+        AcronymsCache.instance.candidatesFor('שולחן')!.contains(103),
+        true,
+      );
+    });
+  });
+
+  group('AcronymsCache.candidatesFor - מקרי קצה', () {
+    test('שאילתה קצרה מ-2 תווים אינה ניתנת לאינדוקס — סריקה מלאה', () {
+      AcronymsCache.instance.setAcronymsForTesting(corpus);
+
+      expect(AcronymsCache.instance.candidatesFor('ב'), isNull);
+      expect(AcronymsCache.instance.candidatesFor(''), isNull);
+    });
+
+    test('ביגרם שאינו במאגר מחזיר קבוצת מועמדים ריקה', () {
+      AcronymsCache.instance.setAcronymsForTesting(corpus);
+
+      final candidates = AcronymsCache.instance.candidatesFor('זזזז');
+      expect(candidates, isNotNull);
+      expect(candidates!.length, 0);
+      for (final bookId in corpus.keys) {
+        expect(candidates.contains(bookId), isFalse);
+      }
+    });
+
+    test('אינדקס ריק מול מונחים קיימים מחזיר null — סריקה מלאה', () {
+      // מונחים בני תו אחד אינם מייצרים ביגרם. השסתום הזה הוא מה שמונע
+      // היעלמות שקטה של כל התאמת הכינויים.
+      AcronymsCache.instance.setAcronymsForTesting({
+        101: ['א'],
+        102: ['ב'],
+      });
+
+      expect(AcronymsCache.instance.getAcronymsForBook(101), isNotEmpty);
+      expect(AcronymsCache.instance.candidatesFor('אב'), isNull);
+    });
+
+    test('קאש שלא נטען מחזיר null ולא קבוצה ריקה', () {
+      // null = "סרוק את כל הספרים". קבוצה ריקה כאן הייתה מבטלת כל התאמת
+      // כינויים עד לחימום הקאש.
+      expect(AcronymsCache.instance.candidatesFor('רמבם'), isNull);
+    });
+
+    test('clear מאפס גם את האינדקס', () {
+      AcronymsCache.instance.setAcronymsForTesting(corpus);
+      expect(AcronymsCache.instance.candidatesFor('רמבם'), isNotNull);
+
+      AcronymsCache.instance.clear();
+
+      expect(AcronymsCache.instance.candidatesFor('רמבם'), isNull);
+    });
+
+    test('ספר בלי כינויים אינו מועמד לאף שאילתה', () {
+      AcronymsCache.instance.setAcronymsForTesting({
+        ...corpus,
+        999: const <String>[],
+      });
+
+      for (final query in ['רמבם', 'תוספות', 'קמא']) {
+        expect(
+          AcronymsCache.instance.candidatesFor(query)!.contains(999),
+          isFalse,
+        );
+      }
+    });
+  });
+}

--- a/test/find_ref/find_ref_acronym_match_test.dart
+++ b/test/find_ref/find_ref_acronym_match_test.dart
@@ -274,6 +274,18 @@ void main() {
       expect(hit.matchRank, 3);
     });
 
+    test('שאילתה בת תו אחד עדיין מתאימה לפי ראש-תיבות', () {
+      // מסננת הביגרמים אינה חלה על שאילתה קצרה מ-2 תווים, ולולאת הביטויים
+      // ב-findRefs יורדת עד טוקן בודד — אסור שהמסננת תחסום אותו.
+      seedLibrary(const [
+        (id: 401, title: 'שולחן ערוך אורח חיים', acronyms: ['ק']),
+      ]);
+      final hit = ReferenceBooksCache.instance.search('ק').single;
+
+      expect(hit.bookId, 401);
+      expect(hit.matchRank, 3);
+    });
+
     test('תחילית שכל זנבה מילות-כותרת → rank 4 עם '
         'acronymTailIsTitleWords', () async {
       seedLibrary(const [_rambamTefila]);

--- a/test/find_ref/find_ref_book_by_id_test.dart
+++ b/test/find_ref/find_ref_book_by_id_test.dart
@@ -55,4 +55,152 @@ void main() {
       expect(findOfficialTextBookById(library, 7), isNull);
     });
   });
+
+  // [LibraryBookIndex] מחליף סריקת-עץ לכל מפרש במעבר אחד. הוא חייב לבחור
+  // בדיוק את אותו ספר שהסריקות בחרו — אחרת קליק על מפרש יפתח ספר אחר.
+  group('LibraryBookIndex', () {
+    test('מדלג על ספר אישי בעל אותו id ומחזיר את הרשמי', () {
+      final personal = _category('ספרים אישיים');
+      final root = _category('תלמוד בבלי');
+      final userBook = TextBook(id: 7, title: 'ברכות שלי', isUserBook: true);
+      final official = TextBook(id: 7, title: 'ברכות');
+      personal.books.add(userBook);
+      root.books.add(official);
+
+      final library = Library(categories: [personal, root]);
+
+      expect(
+        LibraryBookIndex(library).resolveCommentatorBook('ברכות', bookId: 7),
+        same(official),
+      );
+    });
+
+    test('מדלג על PdfBook בעל אותו id ומחזיר את ספר הטקסט', () {
+      final root = _category('תלמוד בבלי');
+      final pdf = PdfBook(id: 7, title: 'ברכות', path: r'C:\ברכות.pdf');
+      final text = TextBook(id: 7, title: 'ברכות');
+      root.books.addAll([pdf, text]);
+
+      final library = Library(categories: [root]);
+
+      expect(
+        LibraryBookIndex(library).resolveCommentatorBook('ברכות', bookId: 7),
+        same(text),
+      );
+    });
+
+    test('בלי id — נופל לכותרת ומעדיף ספר טקסט על PDF', () {
+      final root = _category('תלמוד בבלי');
+      final pdf = PdfBook(id: 1, title: 'רש"י', path: r'C:\rashi.pdf');
+      final text = TextBook(id: 2, title: 'רש"י');
+      // ה-PDF ראשון בסדר המעבר — ההעדפה לטקסט חייבת לגבור על הסדר.
+      root.books.addAll([pdf, text]);
+
+      final library = Library(categories: [root]);
+
+      expect(
+        LibraryBookIndex(library).resolveCommentatorBook('רש"י', bookId: null),
+        same(text),
+      );
+    });
+
+    test('כותרת שאין לה ספר טקסט — מוחזר הספר מכל סוג', () {
+      final root = _category('תלמוד בבלי');
+      final pdf = PdfBook(id: 1, title: 'תוספות', path: r'C:\tos.pdf');
+      root.books.add(pdf);
+
+      final library = Library(categories: [root]);
+
+      expect(
+        LibraryBookIndex(library).resolveCommentatorBook('תוספות', bookId: 9),
+        same(pdf),
+      );
+    });
+
+    test('id שאינו בעץ ואין כותרת תואמת — null', () {
+      final root = _category('תלמוד בבלי');
+      root.books.add(TextBook(id: 1, title: 'ברכות'));
+
+      final library = Library(categories: [root]);
+
+      expect(
+        LibraryBookIndex(library).resolveCommentatorBook('שבת', bookId: 99),
+        isNull,
+      );
+    });
+
+    test('כותרות כפולות — נבחר הראשון בסדר המעבר, כמו הסריקה', () {
+      final first = _category('ראשונים');
+      final second = _category('אחרונים');
+      final early = TextBook(id: 1, title: 'חידושים');
+      final later = TextBook(id: 2, title: 'חידושים');
+      first.books.add(early);
+      second.books.add(later);
+
+      final library = Library(categories: [first, second]);
+
+      expect(
+        LibraryBookIndex(
+          library,
+        ).resolveCommentatorBook('חידושים', bookId: null),
+        same(early),
+      );
+    });
+
+    test('שני ספרים רשמיים באותו id — נבחר הראשון בסדר המעבר', () {
+      final first = _category('ראשונים');
+      final second = _category('אחרונים');
+      final early = TextBook(id: 5, title: 'חידושים א');
+      first.books.add(early);
+      second.books.add(TextBook(id: 5, title: 'חידושים ב'));
+
+      final library = Library(categories: [first, second]);
+
+      expect(
+        LibraryBookIndex(library).resolveCommentatorBook('אין', bookId: 5),
+        same(early),
+      );
+    });
+
+    test('ספרי הקטגוריה נסרקים לפני תתי-הקטגוריות', () {
+      // ספר אישי יושב ישירות על library.books ומצל על הרשמי לפי כותרת —
+      // כמו ב-_appendUserBooksToLibrary. היפוך הסדר יפתח ספר אחר.
+      final root = _category('תלמוד בבלי');
+      root.books.add(TextBook(id: 1, title: 'ברכות'));
+      final library = Library(categories: [root]);
+      final personal = TextBook(id: 9, title: 'ברכות', isUserBook: true);
+      library.books.add(personal);
+
+      expect(
+        LibraryBookIndex(library).resolveCommentatorBook('ברכות', bookId: null),
+        same(personal),
+      );
+    });
+
+    test('מסכים עם הסריקה על כל מזהי העץ', () {
+      final root = _category('תלמוד בבלי');
+      final sub = _category('ראשונים', parent: root);
+      final personal = _category('ספרים אישיים');
+      root.books.addAll([
+        TextBook(id: 1, title: 'ברכות'),
+        PdfBook(id: 2, title: 'שבת', path: r'C:\shabat.pdf'),
+      ]);
+      sub.books.addAll([
+        TextBook(id: 3, title: 'רש"י'),
+        TextBook(id: 2, title: 'תוספות'),
+      ]);
+      personal.books.add(TextBook(id: 3, title: 'שלי', isUserBook: true));
+
+      final library = Library(categories: [personal, root]);
+      final index = LibraryBookIndex(library);
+
+      for (var id = 0; id <= 5; id++) {
+        expect(
+          index.resolveCommentatorBook('אין כותרת כזו', bookId: id),
+          same(findOfficialTextBookById(library, id)),
+          reason: 'פתרון לפי id=$id חייב להיות זהה לסריקה',
+        );
+      }
+    });
+  });
 }


### PR DESCRIPTION
סוגר את #840 — "שדה האיתור איטי בהקלדה".

## הבעיה

שני מסלולים במסך "איתור מקורות" סרקו מבנה נתונים שלם **בכל חיפוש, סינכרונית על ה-isolate הראשי** — כלומר בזמן שהמשתמש מקליד:

1. `ReferenceBooksCache.search` עובר על כל ספרי הספרייה, ולכל ספר שכותרתו לא התאימה — על **כל** הכינויים שלו מטבלת `book_acronym`. על ספרייה מלאה: 7,290 ספרים ו-52,566 כינויים. מדידת AOT: **23.0ms לסריקה**, ו-`findRefs` קורא ל-`search` עד 4 פעמים (לולאת הביטויים + `nextToken`). מספר הכינויים גדל עם כל עדכון DB, ולכן זה מחמיר עם הזמן.
2. בדיאלוג, פתרון ה-`Book` של כל מפרש עשה **DFS מלא על עץ הספרייה** — לכל מפרש, בכל שורה נראית. קטע בספר יסוד מגיע ל-47–102 מפרשים, וכל שורה מבקשת את שלה: **19.0ms ל-800 מפרשים**.

## הפתרון

**אינדקס ביגרמים ב-`AcronymsCache`.** לכל צמד תווים סמוכים שמופיע בכינוי כלשהו — רשימת מזהי הספרים שיש להם כינוי כזה, כ-`Int32List` ממוין. `candidatesFor` מחזיר את רשימת הביגרם **הנדיר ביותר** בשאילתה, ו-`search` מריץ את בלוק הכינויים רק על אותם ספרים.

האינדקס נבנה בתוך ה-`Isolate.run` שכבר היה שם לנרמול המונחים, ולכן אינו מוסיף דבר ל-UI thread. גודלו ~0.6MB.

**למה זה לא יכול לשנות תוצאה:** שלוש צורות ההתאמה (`a == q`, `a.startsWith(q)`, `a.contains(q)`) כולן דורשות מונח **שמכיל** את השאילתה, ומונח כזה מכיל בהכרח כל ביגרם שלה — ולכן הספר מופיע בכל רשימות ההצבעה, כולל הנדירה. המסננת היא קבוצת-על, ו**לולאת הדירוג לא שונתה** ונשארת הפוסקת היחידה על `matchRank`/`matchedTerm`/הסדר. השינוי שם הוא שורה אחת: `} else {` → `} else if (acronymCandidates?.contains(book.id) ?? true) {`.

מסלולי נפילה לאחור, זהים להתנהגות הקיימת: שאילתה קצרה מ-2 תווים (אין ביגרם), קאש שאינו טעון, ואינדקס ריק מול מונחים קיימים — כולם מחזירים `null` = "סרוק את כל הספרים".

**`LibraryBookIndex` בדיאלוג.** מעבר אחד על העץ שבונה שלוש מפות (מזהה→ספר טקסט רשמי, כותרת→ספר טקסט, כותרת→ספר מכל סוג). המפות נבנות בסדר ה-DFS של החיפושים שהן מחליפות עם `putIfAbsent`, ולכן כשכמה ספרים חולקים מזהה או כותרת נבחר בדיוק אותו ספר. האינדקס מוחזק ב-State ונבנה מחדש כשמופע ה-`Category` מתחלף.

## מדידות (AOT, ספרייה של 7,290 ספרים / 52,566 כינויים)

| | לפני | אחרי |
|---|---|---|
| `ReferenceBooksCache.search` | 23.0ms | **6.1ms** |
| — מתוכו, חלק הכינויים | 86-89% | — |
| פתרון 800 מפרשים | 19.0ms | **4.1ms** |
| פתרון 400 מפרשים | 8.7ms | **3.9ms** |

הרווח תלוי-שאילתה: שאילתה שכל הביגרמים שלה נפוצים (למשל "רמבם", שבה `בם` מופיע ב-1,835 ספרים) משתפרת פחות. `LibraryBookIndex` עולה ~4ms קבוע לפתיחת דיאלוג, ולכן בסט תוצאות עם מעט מפרשים הוא מעט יקר יותר — נקודת החיתוך סביב 200 מפרשים כשהמזהים בעץ, ו-~10 כשאינם. הבנייה נדחית עד שיש מפרש אחד לפחות, כך שדיאלוג בלי מפרשים אינו משלם דבר.

## שקילות ובדיקות

מול מימוש מילולי של הקוד שלפני השינוי:

- **11,100 שאילתות** על הספרייה האמיתית — השוואת רשימת ה-hits המלאה לפי `bookId|matchRank|matchedTerm|acronymTailIsTitleWords|orderIndex`, **0 הפרשים**. כולל שאילתות עוינות: זוג surrogate, סימני RTL, גרשיים בלבד, ציוני דף, ניקוד מצרף.
- **7.5 מיליון** בדיקות תת-מחרוזת לאינווריאנטת קבוצת-העל — **0 הפרות**.
- **160,104 צירופי (מזהה, כותרת)** על 3,000 עצים אקראיים + 58,340 על העץ האמיתי לפתרון המפרשים — **0 אי-התאמות**.

טסטים חדשים מכסים את האינווריאנטה, את שוברי-השוויון (שני ספרים באותו מזהה, כותרות כפולות, ספר אישי מול רשמי, `PdfBook`), ואת מסלולי הנפילה לאחור. אומת בבדיקות מוטציה שכל אחד מהם נכשל על השינוי שהוא נכתב לתפוס — כולל היפוך בחירת הביגרם הנדיר לנפוץ, הידוק ה-`?? true`, והיפוך סדר המעבר על העץ.

`dart analyze` נקי, `dart format` נקי, `flutter test test/find_ref/ test/data/cache/` — **239 עוברים**.

## הערה למי שיסקור

`findOfficialTextBookById` ו-`_findBookInLibraryByIdThenTitle` נשארו במקומם ולא עברו לאינדקס — הם רצים פעם אחת לקליק ולא לכל מפרש. השני גם **אינו** drop-in: הוא מקבל `preferTextBook` משתנה, בעוד `resolveCommentatorBook` מקודד `true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
