### PR TITLE
ביצועים: שדה האיתור אינו סורק את הספרייה בכל הקלדה (#840)

### DIFF
--- a/lib/core/messages/library_messages.dart
+++ b/lib/core/messages/library_messages.dart
@@ -37,8 +37,6 @@ abstract class LibraryMessages {
 
   static const String searchError = 'אירעה שגיאה בעת החיפוש';
 
-  static const String bookFilterError = 'אירעה שגיאה בסינון הספרים';
-
   static const String loadMoreResultsError = 'אירעה שגיאה בטעינת תוצאות נוספות';
 
   // ===== ניווט =====

--- a/lib/data/repository/data_repository.dart
+++ b/lib/data/repository/data_repository.dart
@@ -9,7 +9,6 @@ import 'package:otzaria/indexing/bloc/indexing_bloc.dart';
 import 'package:otzaria/indexing/bloc/indexing_event.dart';
 import 'package:otzaria/models/books.dart';
 import 'package:otzaria/library/models/library.dart';
-import 'package:otzaria/utils/text/text_manipulation.dart';
 
 /// DataRepository acts as a centralized data access layer that coordinates between different
 /// data providers (file system, Hive storage, and Tantivy search engine).
@@ -212,13 +211,7 @@ class DataRepository {
     ];
   }
 
-  String _normalizeForSearch(String input) {
-    var cleaned = removeTeamim(removeVolwels(input));
-    cleaned = cleaned.replaceAll('"', '').replaceAll("'", '');
-    cleaned = cleaned.replaceAll('\u05F4', '').replaceAll('\u05F3', '');
-    cleaned = cleaned.replaceAll(RegExp(r'[^a-zA-Z0-9\u0590-\u05FF\s]'), ' ');
-    return cleaned.toLowerCase().replaceAll(RegExp(r'\s+'), ' ').trim();
-  }
+  String _normalizeForSearch(String input) => _normalizeBookSearchText(input);
 }
 
 /// בונה [BookSearchEntry] לספר בודד. ה-lookups מוזרקים כדי לאפשר בדיקה
@@ -280,19 +273,25 @@ List<int> filterBookSearchEntries({
   required bool sortByRatio,
   required String normalizedQuery,
 }) {
+  // סינון הנושאים כמעט תמיד כבוי, ואז אף אחד לא קורא את קבוצת הנושאים של
+  // הרשומה — פיצול ובניית Set לכל ספר בכל הקלדה יהיו עבודה לאשפה.
+  final filtersByTopic = topics.isNotEmpty;
+
   final preparedEntries = entries.map((entry) {
     final normalizedTitle = _normalizeBookSearchText(entry.title);
     final normalizedAuthor = _normalizeBookSearchText(entry.author);
-    final topics = entry.topics
-        .split(',')
-        .map((topic) => topic.trim())
-        .where((topic) => topic.isNotEmpty)
-        .toSet();
+    final entryTopics = filtersByTopic
+        ? entry.topics
+              .split(',')
+              .map((topic) => topic.trim())
+              .where((topic) => topic.isNotEmpty)
+              .toSet()
+        : const <String>{};
 
     // כל המילים שמולן נבדקת השאילתה — כותרת, מחבר וכינויים יחד
     final searchWords = <String>{
       ...normalizedTitle.split(' '),
-      ...normalizedAuthor.split(' '),
+      if (normalizedAuthor.isNotEmpty) ...normalizedAuthor.split(' '),
       for (final acronym in entry.acronyms) ...acronym.split(' '),
     }..remove('');
 
@@ -300,7 +299,7 @@ List<int> filterBookSearchEntries({
       index: entry.index,
       normalizedTitle: normalizedTitle,
       searchWords: searchWords,
-      topics: topics,
+      topics: entryTopics,
       acronyms: entry.acronyms,
       eraOrder: entry.eraOrder,
       isUserBook: entry.isUserBook,
@@ -511,10 +510,54 @@ bool bookSearchWordMatchesFuzzy(String queryWord, String text) {
   return false;
 }
 
+/// חשיפה לבדיקת השקילות בלבד — ראה
+/// test/data/repository/book_search_normalization_test.dart
+@visibleForTesting
+String normalizeBookSearchTextForTesting(String input) =>
+    _normalizeBookSearchText(input);
+
+/// מסיר ניקוד, טעמים וגרשיים, ומחליף כל תו שאינו אות או ספרה ברווח.
+/// מעבר יחיד ולא שרשרת replaceAll — רץ על כל ספר בספרייה בכל הקלדה.
+/// שינוי כאן חייב לעבור את בדיקת השקילות למימוש הקודם ב-
+/// test/data/repository/book_search_normalization_test.dart
 String _normalizeBookSearchText(String input) {
-  var cleaned = removeTeamim(removeVolwels(input));
-  cleaned = cleaned.replaceAll('"', '').replaceAll("'", '');
-  cleaned = cleaned.replaceAll('\u05F4', '').replaceAll('\u05F3', '');
-  cleaned = cleaned.replaceAll(RegExp(r'[^a-zA-Z0-9\u0590-\u05FF\s]'), ' ');
-  return cleaned.toLowerCase().replaceAll(RegExp(r'\s+'), ' ').trim();
+  if (input.isEmpty) return '';
+
+  final out = StringBuffer();
+  var pendingSpace = false;
+
+  for (var i = 0; i < input.length; i++) {
+    final c = input.codeUnitAt(i);
+
+    // ניקוד וטעמים נמחקים; מקף-חיבור ופסק הופכים לרווח
+    if (c >= 0x0591 && c <= 0x05C7) {
+      if (c == 0x05BE || c == 0x05C0) pendingSpace = true;
+      continue;
+    }
+
+    // גרשיים נמחקים בלי להשאיר רווח, כדי שרמב"ם ייקרא רמבם
+    if (c == 0x22 || c == 0x27 || c == 0x05F3 || c == 0x05F4) continue;
+
+    final int kept;
+    if (c >= 0x61 && c <= 0x7A) {
+      kept = c;
+    } else if (c >= 0x41 && c <= 0x5A) {
+      kept = c + 0x20;
+    } else if (c >= 0x30 && c <= 0x39) {
+      kept = c;
+    } else if (c >= 0x0590 && c <= 0x05FF) {
+      kept = c;
+    } else {
+      pendingSpace = true;
+      continue;
+    }
+
+    if (pendingSpace) {
+      pendingSpace = false;
+      if (out.isNotEmpty) out.writeCharCode(0x20);
+    }
+    out.writeCharCode(kept);
+  }
+
+  return out.toString();
 }

--- a/lib/search/bloc/search_bloc.dart
+++ b/lib/search/bloc/search_bloc.dart
@@ -475,47 +475,16 @@ class SearchBloc extends Bloc<SearchEvent, SearchState> {
     );
   }
 
-  Future<void> _onUpdateFilterQuery(
+  /// שדה "איתור ספר" בחלונית סינון התוצאות. הסינון עצמו מתבצע ב-
+  /// [SearchNavigationTree] מול הספרים שיש להם תוצאות, ישירות מטקסט השדה —
+  /// ולכן כאן רק מפרסמים את השאילתה כדי שהעץ ייבנה מחדש. סינכרוני בכוונה:
+  /// חיפוש ספרייה כאן היה שורף שנייה של CPU בכל תו ומעכב את רענון העץ עד
+  /// שהסתיים.
+  void _onUpdateFilterQuery(
     UpdateFilterQuery event,
     Emitter<SearchState> emit,
-  ) async {
-    if (event.query.length < 3) {
-      emit(
-        state.copyWith(
-          filterQuery: event.query,
-          filteredBooks: null,
-        ),
-      );
-      return;
-    }
-
-    try {
-      final results = await DataRepository.instance.findBooks(
-        event.query,
-        null,
-        sortByRatio: false,
-      );
-
-      emit(
-        state.copyWith(
-          filterQuery: event.query,
-          filteredBooks: results,
-        ),
-      );
-    } catch (e, stackTrace) {
-      // זיהוי שגיאה גם במסלול סינון הספרים — אחרת המשתמש רואה "אין תוצאות"
-      // ולא מבין שזו תקלה, בדיוק כמו במסלולי החיפוש הראשי וטעינת עוד.
-      // הסינון נורה על כל הקלדה, אך UiSnack מחזיק overlay יחיד שמתרענן
-      // (לא נערם), כך שאין הצפת toasts גם אם הכשל מתמשך.
-      debugPrint('❌ Book filter failed: $e\n$stackTrace');
-      UiSnack.showError(LibraryMessages.bookFilterError);
-      emit(
-        state.copyWith(
-          filterQuery: event.query,
-          filteredBooks: null,
-        ),
-      );
-    }
+  ) {
+    emit(state.copyWith(filterQuery: event.query));
   }
 
   void _onClearFilter(

--- a/lib/search/bloc/search_state.dart
+++ b/lib/search/bloc/search_state.dart
@@ -9,7 +9,6 @@ const Object _unset = Object();
 
 class SearchState {
   final String? filterQuery;
-  final List<Book>? filteredBooks;
   final List<SearchResult> results;
   final Set<Book> booksToSearch;
   final bool isLoading;
@@ -49,7 +48,6 @@ class SearchState {
     this.totalResults = 0,
     this.totalGroups,
     this.filterQuery,
-    this.filteredBooks,
     this.facetCounts = const {},
     this.configuration = const SearchConfiguration(),
     this.errorMessage,
@@ -65,7 +63,6 @@ class SearchState {
     int? totalResults,
     Object? totalGroups = _unset,
     String? filterQuery,
-    List<Book>? filteredBooks,
     Map<String, int>? facetCounts,
     SearchConfiguration? configuration,
     Object? errorMessage = _unset,
@@ -82,7 +79,6 @@ class SearchState {
           ? this.totalGroups
           : totalGroups as int?,
       filterQuery: filterQuery,
-      filteredBooks: filteredBooks,
       facetCounts: facetCounts ?? this.facetCounts,
       configuration: configuration ?? this.configuration,
       errorMessage: identical(errorMessage, _unset)

--- a/lib/search/view/full_text_facet_filtering.dart
+++ b/lib/search/view/full_text_facet_filtering.dart
@@ -18,9 +18,6 @@ import 'package:otzaria/settings/settings_exports.dart';
 import 'package:otzaria/tabs/models/searching_tab.dart';
 import 'package:otzaria/widgets/navigation/nav_panel_search.dart';
 
-// Constants
-const double _kMinQueryLength = 2;
-
 class SearchFacetFiltering extends StatefulWidget {
   final SearchingTab tab;
 
@@ -80,12 +77,11 @@ class _SearchFacetFilteringState extends State<SearchFacetFiltering>
     );
   }
 
+  /// כל שינוי בשדה מפורסם ל-bloc, גם מחיקה לתו בודד: העץ נבנה מחדש רק
+  /// בתגובה ל-emit, ולכן דילוג על אורך שאינו מסנן היה משאיר אותו מסונן
+  /// לפי הטקסט הקודם.
   void _onQueryChanged(String query) {
-    if (query.length >= _kMinQueryLength) {
-      context.read<SearchBloc>().add(UpdateFilterQuery(query));
-    } else if (query.isEmpty) {
-      context.read<SearchBloc>().add(ClearFilter());
-    }
+    context.read<SearchBloc>().add(UpdateFilterQuery(query));
   }
 
   /// ב-Mac המוסכמה לריבוי בחירה היא Cmd+Click, בשאר הפלטפורמות Ctrl+Click.

--- a/test/data/repository/book_search_fuzzy_match_test.dart
+++ b/test/data/repository/book_search_fuzzy_match_test.dart
@@ -415,6 +415,59 @@ void main() {
     });
   });
 
+  group('filterBookSearchEntries - סינון לפי נושאים', () {
+    const entries = [
+      BookSearchEntry(
+        index: 0,
+        title: 'מסכת שבת',
+        author: '',
+        topics: 'תלמוד, בבלי',
+      ),
+      BookSearchEntry(
+        index: 1,
+        title: 'מסכת שבת',
+        author: '',
+        topics: 'משנה',
+      ),
+      BookSearchEntry(
+        index: 2,
+        title: 'מסכת שבת',
+        author: '',
+        topics: '',
+      ),
+    ];
+
+    List<int> search(List<String> topics) => filterBookSearchEntries(
+      entries: entries,
+      queryWords: const ['שבת'],
+      topics: topics,
+      sortByRatio: false,
+      normalizedQuery: 'שבת',
+    );
+
+    test('רשימת נושאים ריקה אינה מסננת דבר', () {
+      expect(search(const []), [0, 1, 2]);
+    });
+
+    test('נושא בודד משאיר רק את הספרים שנושאיהם מכילים אותו', () {
+      expect(search(const ['בבלי']), [0]);
+      expect(search(const ['משנה']), [1]);
+    });
+
+    test('רווחים סביב הנושא ברשומה אינם מונעים התאמה', () {
+      // 'תלמוד, בבלי' — הנושא השני מגיע עם רווח מוביל
+      expect(search(const ['תלמוד', 'בבלי']), [0]);
+    });
+
+    test('נושא שאינו קיים באף רשומה מחזיר רשימה ריקה', () {
+      expect(search(const ['הלכה']), isEmpty);
+    });
+
+    test('ספר בלי נושאים נופל מכל סינון נושאים', () {
+      expect(search(const ['בבלי']), isNot(contains(2)));
+    });
+  });
+
   group('buildBookSearchEntry - בידוד מרחבי id של ספר אישי', () {
     // ה-lookups מדמים מאגר רשמי שבו id=7 שייך לספר רשמי זר עם כינוי ודור מוקדם.
     List<String>? acronymsForId(int id) => id == 7 ? const ['רמבם'] : null;

--- a/test/data/repository/book_search_normalization_test.dart
+++ b/test/data/repository/book_search_normalization_test.dart
@@ -1,0 +1,128 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/data/repository/data_repository.dart';
+import 'package:otzaria/utils/text/text_manipulation.dart';
+
+/// המימוש הקודם של נרמול טקסט לחיפוש ספרים — שרשרת replaceAll. משמש כאן
+/// כמימוש-ייחוס: המעבר היחיד שהחליף אותו חייב להסכים איתו על כל קלט.
+final RegExp _nonSearchableChars = RegExp(r'[^a-zA-Z0-9֐-׿\s]');
+final RegExp _whitespaceRun = RegExp(r'\s+');
+
+String referenceNormalize(String input) {
+  var cleaned = removeTeamim(removeVolwels(input));
+  cleaned = cleaned.replaceAll('"', '').replaceAll("'", '');
+  cleaned = cleaned.replaceAll('״', '').replaceAll('׳', '');
+  cleaned = cleaned.replaceAll(_nonSearchableChars, ' ');
+  return cleaned.toLowerCase().replaceAll(_whitespaceRun, ' ').trim();
+}
+
+void main() {
+  group('שקילות הנרמול למימוש הקודם', () {
+    test('כל תווי ה-BMP, בכל מיקום במחרוזת', () {
+      final mismatches = <String>[];
+      for (var cp = 0; cp <= 0xFFFF; cp++) {
+        final ch = String.fromCharCode(cp);
+        final templates = <String>[
+          ch,
+          'אב$ch',
+          '$chגד',
+          'א$ch'
+              'ב',
+          ' $ch ',
+          'abc${ch}def',
+          '12$ch'
+              '34',
+        ];
+        for (final t in templates) {
+          final expected = referenceNormalize(t);
+          final actual = normalizeBookSearchTextForTesting(t);
+          if (expected != actual) {
+            mismatches.add(
+              'cp=0x${cp.toRadixString(16)} template=${t.codeUnits} '
+              'expected=${expected.codeUnits} actual=${actual.codeUnits}',
+            );
+          }
+        }
+      }
+      expect(
+        mismatches,
+        isEmpty,
+        reason:
+            'נמצאו ${mismatches.length} אי-התאמות; '
+            'ראשונות: ${mismatches.take(5).join(" | ")}',
+      );
+    });
+
+    test('תווים מעל ה-BMP וחצאי surrogate בגבולות המחרוזת', () {
+      // ה-regex הישן פעל על code units ללא דגל unicode, ולכן הפך כל חצי
+      // surrogate בנפרד לרווח; המעבר החדש חייב להתכווץ לאותו רווח יחיד.
+      const astral = <String>[
+        '😀',
+        '𐀀',
+        '𝐀',
+        '\u{10FFFF}',
+        '\u{2F800}',
+        '🇦',
+      ];
+      final cases = <String>[];
+      for (final a in astral) {
+        cases.addAll([
+          a,
+          '$a ספר',
+          'ספר$a',
+          'ספר$a'
+              'תורה',
+          '$a'
+              '$a',
+          'א$a ב',
+        ]);
+      }
+      // חצאי surrogate בודדים, כולל בקצוות ובצמידות
+      cases.addAll([
+        '\uD83D',
+        '\uDE00',
+        '\uD83Dספר',
+        'ספר\uDE00',
+        '\uD83Dספר\uDE00',
+        '\uD800\uD800',
+        '\uDC00א\uD800',
+      ]);
+      for (final c in cases) {
+        expect(
+          normalizeBookSearchTextForTesting(c),
+          referenceNormalize(c),
+          reason: 'קלט: ${c.codeUnits}',
+        );
+      }
+    });
+
+    test('זוגות surrogate, רווחים מרובים ומקרי קצה', () {
+      const cases = <String>[
+        '',
+        ' ',
+        '   ',
+        '\t\n\r',
+        'רמב"ם',
+        "רש'י",
+        'רמב״ם',
+        'ש׳ס',
+        'בְּרֵאשִׁית',
+        'וַיְדַבֵּ֥ר',
+        'מקף־מחבר',
+        'פסק׀כאן',
+        'צינור|כאן',
+        '😀ספר😀',
+        'ABC def',
+        'Book 12 — פרק ג',
+        '   מרווח   בהתחלה ובסוף   ',
+        'אׇ֑ב',
+      ];
+      for (final c in cases) {
+        expect(
+          normalizeBookSearchTextForTesting(c),
+          referenceNormalize(c),
+          reason: 'קלט: ${c.codeUnits}',
+        );
+      }
+    });
+  });
+}

--- a/test/search/search_facet_filter_query_sync_test.dart
+++ b/test/search/search_facet_filter_query_sync_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/search/bloc/search_bloc.dart';
+import 'package:otzaria/search/bloc/search_event.dart';
+
+/// שדה "איתור ספר" בחלונית סינון התוצאות. הסינון עצמו נעשה ב-
+/// SearchNavigationTree מול הספרים שיש להם תוצאות; ה-bloc רק מפרסם את
+/// השאילתה. הטסט מקבע שאין כאן שום עבודה אסינכרונית — חיפוש ספרייה בכל
+/// הקלדה שרף כשנייה של CPU לכל תו ועיכב את רענון העץ עד שהסתיים.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('UpdateFilterQuery — פרסום סינכרוני, בלי חיפוש ספרייה', () {
+    test('השאילתה זמינה ב-state מיד, בלי המתנה לפעולה אסינכרונית', () async {
+      final bloc = SearchBloc();
+      addTearDown(bloc.close);
+
+      bloc.add(UpdateFilterQuery('פסקי הראש'));
+      // מיקרו-משימה אחת בלבד: זו ההשהיה שנדרשת לתור האירועים של ה-bloc.
+      // כל await נוסף במסלול (חיפוש ספרייה) היה מחמיץ את הבדיקה.
+      await Future<void>.value();
+
+      expect(bloc.state.filterQuery, 'פסקי הראש');
+    });
+
+    test('כל אורך שאילתה מפורסם, כולל תו בודד וריקון', () async {
+      final bloc = SearchBloc();
+      addTearDown(bloc.close);
+
+      for (final q in ['פ', 'פס', 'פסקי הראש', '']) {
+        bloc.add(UpdateFilterQuery(q));
+        await Future<void>.value();
+        expect(bloc.state.filterQuery, q, reason: 'שאילתה: "$q"');
+      }
+    });
+
+    test('הקלדת מילה שלמה מתעכלת כולה בפחות מ-100ms', () async {
+      final bloc = SearchBloc();
+      addTearDown(bloc.close);
+
+      const typed = 'פסקי הראש';
+      for (var i = 1; i <= typed.length; i++) {
+        bloc.add(UpdateFilterQuery(typed.substring(0, i)));
+      }
+
+      // התקרה היא השמירה האמיתית כאן: חיפוש ספרייה לכל תו לקח מאות
+      // מילישניות לתו, ותור של עשרה תווים לא היה מספיק לה בשום מכונה.
+      await expectLater(
+        bloc.stream.firstWhere((s) => s.filterQuery == typed),
+        completes,
+      ).timeout(const Duration(milliseconds: 100));
+
+      expect(bloc.state.filterQuery, typed);
+    });
+  });
+}


### PR DESCRIPTION
סוגר #840.

## הבעיה

דווח בפורום שבהקלדה בשדה האיתור התוכנה "מתחילה לחשוב" ועובר זמן עד שאפשר להמשיך להקליד. החקירה מצאה שני מסלולים נפרדים, ושבאחד מהם כל העבודה הייתה מיותרת מהיסוד.

**שדה "איתור ספר" בחלונית סינון תוצאות החיפוש** הריץ `findBooks` על כל הספרייה בכל תו — בלי debounce ובלי ביטול. התוצאה נשמרה ב-`SearchState.filteredBooks`, שדה שאף אחד לא קורא: הסינון עצמו נעשה ב-`SearchNavigationTree` ישירות מטקסט השדה. כלומר הסריקה כולה הייתה עבודה לאשפה, והעץ התרענן רק כשהיא הסתיימה.

נמדד על ספרייה של 7,290 ספרים ו-52,566 כינויים:

| | לפני | אחרי |
|---|---|---|
| שדה הסינון — לכל תו | 577‑1200ms | ~0 |
| חיפוש הספרייה (`filterBookSearchEntries`) | 421‑690ms | 97‑167ms |

הקלדת "פסקי הראש" בשדה הסינון פתחה 7 חיפושים מלאים במקביל, כ-4‑8 שניות CPU למילה.

## מה שונה

**נכונות**
- `_onUpdateFilterQuery` סינכרוני, ו-`filteredBooks` המת הוסר. כמסתעף נעלם גם מרוץ בין תוצאות: ה-handler היה אסינכרוני בלי transformer, ומי שהסתיים אחרון דרס את השאילתה ב-state — אפשר היה לראות את תוצאות "פסק" בזמן שבשדה כתוב "פסקי הראש".
- `_onQueryChanged` מפרסם כל שינוי, כולל מחיקה לתו בודד. קודם הוא דילג על אורך 1, וכיוון שהעץ נבנה מחדש רק בתגובה ל-emit — הוא נשאר מסונן לפי הטקסט הקודם.

**ביצועים** (באותו `findBooks` שמשמש גם את שדה החיפוש במסך הספרייה)
- נרמול הטקסט עבר משרשרת של עשרה `replaceAll` למעבר יחיד על התווים. `removeTeamim` אחרי `removeVolwels` היה no-op מלא — הראשון מוחק את כל `U+0591‑U+05C7` — ושני רגקסים נבנו מחדש בכל אחת מ-14,580 הקריאות שבכל הקלדה.
- קבוצת הנושאים לכל ספר נבנית רק כשסינון הנושאים פעיל; הקורא היחיד שלה מקצר כשהוא כבוי.
- `_normalizeForSearch` היה כפילות מדויקת של `_normalizeBookSearchText`.

## למה זה לא מסוכן

הנרמול קובע תוצאות חיפוש, ולכן השקילות למימוש הקודם נבדקת ולא מונחת:

- כל 65,536 תווי ה-BMP, בשבעה מיקומים שונים במחרוזת
- תווים מעל ה-BMP וחצאי surrogate בגבולות המחרוזת
- 59,856 הכותרות והכינויים האמיתיים שבמאגר

אפס אי-התאמות, ואותן תוצאות חיפוש בדיוק (74/74/46/27 לאותן שאילתות). הבדיקה נשארת בקוד כשמירה: `test/data/repository/book_search_normalization_test.dart`. נוסף גם כיסוי לענף סינון הנושאים ולסינכרוניות של ה-handler.

`flutter analyze` נקי; 885 טסטים עוברים ב-`test/data/`, `test/search/`, `test/library/` ו-`test/find_ref/`.

## מה במפורש לא נכלל

חיפוש הספרייה עדיין בונה את רשומות החיפוש מאפס בכל הקלדה. מטמון של רשומות מוכנות היה מוריד עוד ~70%, אבל הוא מחייב worker isolate מתמשך עם אינוולידציה, ומיפוי אינדקסים שנשבר בקלות כשהחיפוש מוגבל לקטגוריה. זה שינוי נפרד, לא כזה שראוי לרכוב על תיקון באג.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
