### PR TITLE
חלונית כלים: כפתור מעבר בין תצוגת רשימה לתצוגת קוביות

### DIFF
--- a/lib/settings/engine/settings_bloc.dart
+++ b/lib/settings/engine/settings_bloc.dart
@@ -49,6 +49,7 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
     on<UpdateIsFullscreen>(_onUpdateIsFullscreen);
     on<UpdateLibraryViewMode>(_onUpdateLibraryViewMode);
     on<UpdateLibraryShowPreview>(_onUpdateLibraryShowPreview);
+    on<UpdateToolsViewMode>(_onUpdateToolsViewMode);
     on<RefreshShortcuts>(_onRefreshShortcuts);
     on<ResetShortcuts>(_onResetShortcuts);
     on<UpdateShortcut>(_onUpdateShortcut);
@@ -134,6 +135,7 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
         isFullscreen: settings['isFullscreen'],
         libraryViewMode: settings['libraryViewMode'],
         libraryShowPreview: settings['libraryShowPreview'],
+        toolsViewMode: settings['toolsViewMode'],
         shortcuts: Map<String, String>.unmodifiable(
           Map<String, String>.from(settings['shortcuts'] as Map),
         ),
@@ -643,6 +645,14 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
   ) async {
     await _repository.updateLibraryShowPreview(event.libraryShowPreview);
     emit(state.copyWith(libraryShowPreview: event.libraryShowPreview));
+  }
+
+  Future<void> _onUpdateToolsViewMode(
+    UpdateToolsViewMode event,
+    Emitter<SettingsState> emit,
+  ) async {
+    await _repository.updateToolsViewMode(event.toolsViewMode);
+    emit(state.copyWith(toolsViewMode: event.toolsViewMode));
   }
 
   Future<void> _onRefreshShortcuts(

--- a/lib/settings/engine/settings_event.dart
+++ b/lib/settings/engine/settings_event.dart
@@ -317,6 +317,15 @@ class UpdateLibraryShowPreview extends SettingsEvent {
   List<Object?> get props => [libraryShowPreview];
 }
 
+class UpdateToolsViewMode extends SettingsEvent {
+  final String toolsViewMode;
+
+  const UpdateToolsViewMode(this.toolsViewMode);
+
+  @override
+  List<Object?> get props => [toolsViewMode];
+}
+
 class RefreshShortcuts extends SettingsEvent {
   const RefreshShortcuts();
 

--- a/lib/settings/engine/settings_repository.dart
+++ b/lib/settings/engine/settings_repository.dart
@@ -54,6 +54,7 @@ class SettingsRepository {
   static const String keyIsFullscreen = 'key-is-fullscreen';
   static const String keyLibraryViewMode = 'key-library-view-mode';
   static const String keyLibraryShowPreview = 'key-library-show-preview';
+  static const String keyToolsViewMode = 'key-tools-view-mode';
   static const String keyEnablePerBookSettings = 'key-enable-per-book-settings';
   static const String keyPdfBookViewByDefault = 'key-pdf-book-view-by-default';
   static const String keyTalmudBavliOpenFormat = 'key-talmud-bavli-open-format';
@@ -203,6 +204,7 @@ class SettingsRepository {
     keyIsFullscreen,
     keyLibraryViewMode,
     keyLibraryShowPreview,
+    keyToolsViewMode,
     keyEnablePerBookSettings,
     keyPdfBookViewByDefault,
     keyTalmudBavliOpenFormat,
@@ -411,6 +413,10 @@ class SettingsRepository {
       'libraryShowPreview': _settings.getValue<bool>(
         keyLibraryShowPreview,
         defaultValue: true,
+      ),
+      'toolsViewMode': _settings.getValue<String>(
+        keyToolsViewMode,
+        defaultValue: 'list',
       ),
       'shortcuts': await getShortcuts(),
       'enablePerBookSettings': _settings.getValue<bool>(
@@ -708,6 +714,10 @@ class SettingsRepository {
 
   Future<void> updateLibraryShowPreview(bool value) async {
     await _settings.setValue(keyLibraryShowPreview, value);
+  }
+
+  Future<void> updateToolsViewMode(String value) async {
+    await _settings.setValue(keyToolsViewMode, value);
   }
 
   Future<void> updateEnablePerBookSettings(bool value) async {
@@ -1108,6 +1118,7 @@ class SettingsRepository {
     await _settings.setValue(keyIsFullscreen, false);
     await _settings.setValue(keyLibraryViewMode, 'grid');
     await _settings.setValue(keyLibraryShowPreview, true);
+    await _settings.setValue(keyToolsViewMode, 'list');
     await _settings.setValue(keyEnablePerBookSettings, false);
     await _settings.setValue(keyPdfBookViewByDefault, false);
     await _settings.setValue(keyTalmudBavliOpenFormat, 'text');

--- a/lib/settings/engine/settings_state.dart
+++ b/lib/settings/engine/settings_state.dart
@@ -54,6 +54,9 @@ class SettingsState extends Equatable {
   final bool isFullscreen;
   final String libraryViewMode;
   final bool libraryShowPreview;
+
+  /// תצוגת פאנל הכלים: 'list' (שורות) או 'grid' (קוביות).
+  final String toolsViewMode;
   final Map<String, String> shortcuts;
   final bool enablePerBookSettings;
   final bool pdfBookViewByDefault;
@@ -125,6 +128,7 @@ class SettingsState extends Equatable {
     required this.isFullscreen,
     required this.libraryViewMode,
     required this.libraryShowPreview,
+    required this.toolsViewMode,
     required this.shortcuts,
     required this.enablePerBookSettings,
     required this.pdfBookViewByDefault,
@@ -182,6 +186,7 @@ class SettingsState extends Equatable {
       isFullscreen: false,
       libraryViewMode: 'grid',
       libraryShowPreview: true,
+      toolsViewMode: 'list',
       shortcuts: {},
       enablePerBookSettings: false,
       pdfBookViewByDefault: false,
@@ -230,6 +235,7 @@ class SettingsState extends Equatable {
     bool? isFullscreen,
     String? libraryViewMode,
     bool? libraryShowPreview,
+    String? toolsViewMode,
     Map<String, String>? shortcuts,
     bool? enablePerBookSettings,
     bool? pdfBookViewByDefault,
@@ -290,6 +296,7 @@ class SettingsState extends Equatable {
       isFullscreen: isFullscreen ?? this.isFullscreen,
       libraryViewMode: libraryViewMode ?? this.libraryViewMode,
       libraryShowPreview: libraryShowPreview ?? this.libraryShowPreview,
+      toolsViewMode: toolsViewMode ?? this.toolsViewMode,
       shortcuts: shortcuts ?? this.shortcuts,
       enablePerBookSettings:
           enablePerBookSettings ?? this.enablePerBookSettings,
@@ -368,6 +375,7 @@ class SettingsState extends Equatable {
     isFullscreen,
     libraryViewMode,
     libraryShowPreview,
+    toolsViewMode,
     shortcuts,
     enablePerBookSettings,
     pdfBookViewByDefault,

--- a/lib/tools/view/tools_launcher_panel.dart
+++ b/lib/tools/view/tools_launcher_panel.dart
@@ -94,6 +94,26 @@ List<ToolCatalogEntry> orderedToolEntries(List<ToolCatalogEntry> entries) => [
   for (final group in groupToolEntries(entries)) ...group.entries,
 ];
 
+/// תצוגת הפאנל: שורות עץ ניווט, או רשת קוביות בסגנון משגר אפליקציות.
+@visibleForTesting
+const String kToolsViewModeList = 'list';
+
+@visibleForTesting
+const String kToolsViewModeGrid = 'grid';
+
+/// כפתור החלפת התצוגה שבשורת החיפוש.
+@visibleForTesting
+const Key kToolsViewModeToggleKey = Key('tools-view-mode-toggle');
+
+/// רוחב היעד לקובייה — ברוחב הפאנל שבברירת מחדל נכנסות ארבע קוביות בשורה.
+@visibleForTesting
+const double kToolTileTargetWidth = 88;
+
+/// מספר העמודות ברשת לרוחב נתון.
+@visibleForTesting
+int toolGridColumns(double width) =>
+    (width / kToolTileTargetWidth).floor().clamp(2, 5);
+
 /// האינדקס המסומן הבא בניווט מקלדת. `-1` = אין סימון, והחץ הראשון מסמן את
 /// השורה הראשונה.
 @visibleForTesting
@@ -174,6 +194,11 @@ class _ToolsLauncherPanelState extends State<ToolsLauncherPanel> {
   /// `-1` = אין סימון, כדי שלא ייראה כאילו הכלי הראשון נבחר.
   int _highlightedIndex = -1;
   List<ToolCatalogEntry> _keyboardEntries = const [];
+
+  /// מספר העמודות ברשת — קובע בכמה קוביות מדלגים בחץ למעלה/למטה.
+  /// בתצוגת רשימה תמיד 1.
+  int _keyboardColumns = 1;
+  bool _isGrid = false;
 
   /// הכלי שזז אחרון ומספר ההזזה — מריצים פעימת הדגשה על השורה שזזה.
   String? _movedToolId;
@@ -260,9 +285,19 @@ class _ToolsLauncherPanelState extends State<ToolsLauncherPanel> {
         widget.onClose();
         return KeyEventResult.handled;
       case LogicalKeyboardKey.arrowDown:
-        _moveHighlight(1, entries.length);
+        _moveHighlight(_keyboardColumns, entries.length);
         return KeyEventResult.handled;
       case LogicalKeyboardKey.arrowUp:
+        _moveHighlight(-_keyboardColumns, entries.length);
+        return KeyEventResult.handled;
+      // ברשת הקובייה הבאה נמצאת משמאל ב-RTL, ולכן החיצים מתהפכים ביחס ל-LTR.
+      // ברשימה אין תזוזה אופקית.
+      case LogicalKeyboardKey.arrowLeft:
+        if (!_isGrid) return KeyEventResult.ignored;
+        _moveHighlight(1, entries.length);
+        return KeyEventResult.handled;
+      case LogicalKeyboardKey.arrowRight:
+        if (!_isGrid) return KeyEventResult.ignored;
         _moveHighlight(-1, entries.length);
         return KeyEventResult.handled;
       case LogicalKeyboardKey.enter:
@@ -488,6 +523,10 @@ class _ToolsLauncherPanelState extends State<ToolsLauncherPanel> {
     if (_highlightedIndex >= entries.length) _highlightedIndex = -1;
     final openToolIds = _openToolIds(context.watch<TabsBloc>().state);
     _keyboardEntries = entries;
+    final isGrid = settingsState.toolsViewMode == kToolsViewModeGrid;
+    _isGrid = isGrid;
+    // ברשימה אין תזוזה אופקית; ברשת הערך נקבע ב-LayoutBuilder לפי הרוחב.
+    if (!isGrid) _keyboardColumns = 1;
 
     return PluginDropZone(
       child: Column(
@@ -495,7 +534,7 @@ class _ToolsLauncherPanelState extends State<ToolsLauncherPanel> {
         children: [
           _buildHeader(),
           const SizedBox(height: AppTokens.spaceSM),
-          _buildSearchField(entries),
+          _buildSearchField(entries, isGrid),
           const SizedBox(height: AppTokens.spaceMD),
           Expanded(
             child: Stack(
@@ -506,9 +545,10 @@ class _ToolsLauncherPanelState extends State<ToolsLauncherPanel> {
                           settingsState.isOfflineMode,
                           allEntries,
                         )
-                      : _buildList(
+                      : _buildContent(
                           entries,
                           openToolIds,
+                          isGrid: isGrid,
                           bottomInset:
                               AppInputTokens.height(
                                 settingsState.compactMenuMode,
@@ -563,7 +603,7 @@ class _ToolsLauncherPanelState extends State<ToolsLauncherPanel> {
     );
   }
 
-  Widget _buildSearchField(List<ToolCatalogEntry> entries) {
+  Widget _buildSearchField(List<ToolCatalogEntry> entries, bool isGrid) {
     final field = OtzariaSearchField(
       controller: _searchController,
       focusNode: _searchFocusNode,
@@ -575,18 +615,31 @@ class _ToolsLauncherPanelState extends State<ToolsLauncherPanel> {
       onSubmitted: (_) => _activateHighlighted(entries),
     );
 
-    if (!(widget.showDevTools ?? PluginDevToolsMode.enabled)) return field;
-
     return Row(
       children: [
         Expanded(child: field),
         const SizedBox(width: AppTokens.spaceXS),
         SquareIconButton.field(
-          icon: FluentIcons.arrow_sync_24_regular,
-          tooltip: 'רענן תוספים',
-          onPressed: () =>
-              context.read<PluginSystemBloc>().add(RefreshPlugins()),
+          key: kToolsViewModeToggleKey,
+          icon: isGrid
+              ? OtzariaIcons.list_24_regular
+              : FluentIcons.grid_24_regular,
+          tooltip: isGrid ? 'תצוגת רשימה' : 'תצוגת קוביות',
+          onPressed: () => context.read<SettingsBloc>().add(
+            UpdateToolsViewMode(
+              isGrid ? kToolsViewModeList : kToolsViewModeGrid,
+            ),
+          ),
         ),
+        if (widget.showDevTools ?? PluginDevToolsMode.enabled) ...[
+          const SizedBox(width: AppTokens.spaceXS),
+          SquareIconButton.field(
+            icon: FluentIcons.arrow_sync_24_regular,
+            tooltip: 'רענן תוספים',
+            onPressed: () =>
+                context.read<PluginSystemBloc>().add(RefreshPlugins()),
+          ),
+        ],
       ],
     );
   }
@@ -613,6 +666,28 @@ class _ToolsLauncherPanelState extends State<ToolsLauncherPanel> {
     );
   }
 
+  /// עוטף את שתי התצוגות באותו טיפול מקלדת וגלילה — ההבדל ביניהן הוא בגוף
+  /// הרשימה בלבד.
+  Widget _buildContent(
+    List<ToolCatalogEntry> entries,
+    Set<String> openToolIds, {
+    required bool isGrid,
+    required double bottomInset,
+  }) {
+    return Focus(
+      autofocus: false,
+      onKeyEvent: (_, event) => _handleKey(event, entries),
+      child: NavTreeFocusGroup(
+        child: ScrollConfiguration(
+          behavior: const EdgeScrollbarBehavior.right(),
+          child: isGrid
+              ? _buildGrid(entries, openToolIds, bottomInset: bottomInset)
+              : _buildList(entries, openToolIds, bottomInset: bottomInset),
+        ),
+      ),
+    );
+  }
+
   Widget _buildList(
     List<ToolCatalogEntry> entries,
     Set<String> openToolIds, {
@@ -621,41 +696,86 @@ class _ToolsLauncherPanelState extends State<ToolsLauncherPanel> {
     final groups = groupToolEntries(entries);
     var runningIndex = 0;
 
-    return Focus(
-      autofocus: false,
-      onKeyEvent: (_, event) => _handleKey(event, entries),
-      child: NavTreeFocusGroup(
-        child: ScrollConfiguration(
-          behavior: const EdgeScrollbarBehavior.right(),
-          child: ListView(
-            controller: _listScrollController,
-            padding: kNavTreeListPadding + EdgeInsets.only(bottom: bottomInset),
-            children: [
-              for (var i = 0; i < groups.length; i++) ...[
-                // קבוצות עוקבות באותה תווית (תוספים לפני/אחרי הכלים המובנים)
-                // נראות כמקטע אחד — הכותרת מוצגת רק במעבר תווית.
-                if (i == 0 || groups[i].label != groups[i - 1].label)
-                  NavTreeHeader(title: groups[i].label),
-                for (var j = 0; j < groups[i].entries.length; j++)
-                  _buildRow(
-                    group: groups[i].entries,
-                    indexInGroup: j,
-                    flatIndex: runningIndex++,
-                    openToolIds: openToolIds,
-                  ),
-              ],
-            ],
-          ),
-        ),
-      ),
+    return ListView(
+      controller: _listScrollController,
+      padding: kNavTreeListPadding + EdgeInsets.only(bottom: bottomInset),
+      children: [
+        for (var i = 0; i < groups.length; i++) ...[
+          // קבוצות עוקבות באותה תווית (תוספים לפני/אחרי הכלים המובנים)
+          // נראות כמקטע אחד — הכותרת מוצגת רק במעבר תווית.
+          if (i == 0 || groups[i].label != groups[i - 1].label)
+            NavTreeHeader(title: groups[i].label),
+          for (var j = 0; j < groups[i].entries.length; j++)
+            _buildEntryTile(
+              group: groups[i].entries,
+              indexInGroup: j,
+              flatIndex: runningIndex++,
+              openToolIds: openToolIds,
+              isGrid: false,
+            ),
+        ],
+      ],
     );
   }
 
-  Widget _buildRow({
+  /// רשת קוביות בסגנון משגר אפליקציות: אייקון גדול, תווית מתחתיו, ורקע
+  /// שעולה רק בריחוף.
+  Widget _buildGrid(
+    List<ToolCatalogEntry> entries,
+    Set<String> openToolIds, {
+    required double bottomInset,
+  }) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final columns = toolGridColumns(
+          constraints.maxWidth - kNavTreeSideInset * 2,
+        );
+        _keyboardColumns = columns;
+        final groups = groupToolEntries(entries);
+        var runningIndex = 0;
+
+        return ListView(
+          controller: _listScrollController,
+          padding: kNavTreeListPadding + EdgeInsets.only(bottom: bottomInset),
+          children: [
+            for (var i = 0; i < groups.length; i++) ...[
+              if (i == 0 || groups[i].label != groups[i - 1].label)
+                NavTreeHeader(title: groups[i].label),
+              Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: kNavTreeSideInset,
+                ),
+                child: GridView.count(
+                  crossAxisCount: columns,
+                  shrinkWrap: true,
+                  physics: const NeverScrollableScrollPhysics(),
+                  mainAxisSpacing: AppTokens.spaceXS,
+                  crossAxisSpacing: AppTokens.spaceXS,
+                  children: [
+                    for (var j = 0; j < groups[i].entries.length; j++)
+                      _buildEntryTile(
+                        group: groups[i].entries,
+                        indexInGroup: j,
+                        flatIndex: runningIndex++,
+                        openToolIds: openToolIds,
+                        isGrid: true,
+                      ),
+                  ],
+                ),
+              ),
+            ],
+          ],
+        );
+      },
+    );
+  }
+
+  Widget _buildEntryTile({
     required List<ToolCatalogEntry> group,
     required int indexInGroup,
     required int flatIndex,
     required Set<String> openToolIds,
+    required bool isGrid,
   }) {
     final entry = group[indexInGroup];
     final canReorder = _isReorderEnabled;
@@ -673,47 +793,63 @@ class _ToolsLauncherPanelState extends State<ToolsLauncherPanel> {
           )
         : null;
 
+    final actions = _tileActions(
+      entry,
+      onMoveEarlier: moveTo(
+        indexInGroup - 1,
+        enabled: canReorder && !isFirst,
+        placeAfter: false,
+      ),
+      onMoveLater: moveTo(
+        indexInGroup + 1,
+        enabled: canReorder && !isLast,
+        placeAfter: true,
+      ),
+      onMoveToStart: moveTo(
+        0,
+        enabled: canReorder && !isFirst,
+        placeAfter: false,
+      ),
+      onMoveToEnd: moveTo(
+        group.length - 1,
+        enabled: canReorder && !isLast,
+        placeAfter: true,
+      ),
+    );
+    final isOpen = openToolIds.contains(entry.toolId);
+    final isHighlighted = flatIndex == _highlightedIndex;
+    final movePulse = entry.toolId == _movedToolId ? _moveNonce : 0;
+    // בלי זה הפוקוס נשאר על מסלול התפריט שנסגר, ומקשי הפאנל (Escape, חצים,
+    // Enter) מפסיקים לעבוד עד לחיצה על שדה החיפוש.
+    void onMenuClosed() => _searchFocusNode.requestFocus();
+
     return _ReorderableToolTile(
       key: ValueKey(entry.toolId),
       entry: entry,
       canDrag: canReorder,
       onAcceptSource: (source, {required placeAfter}) =>
           _reorder(source: source, target: entry, placeAfter: placeAfter),
-      tile: ToolTile(
-        entry: entry,
-        isOpen: openToolIds.contains(entry.toolId),
-        isHighlighted: flatIndex == _highlightedIndex,
-        isGroupStart: isFirst,
-        isGroupEnd: isLast,
-        movePulse: entry.toolId == _movedToolId ? _moveNonce : 0,
-        // בלי זה הפוקוס נשאר על מסלול התפריט שנסגר, ומקשי הפאנל (Escape,
-        // חצים, Enter) מפסיקים לעבוד עד לחיצה על שדה החיפוש.
-        onMenuClosed: () => _searchFocusNode.requestFocus(),
-        actions: _tileActions(
-          entry,
-          onMoveEarlier: moveTo(
-            indexInGroup - 1,
-            enabled: canReorder && !isFirst,
-            placeAfter: false,
-          ),
-          onMoveLater: moveTo(
-            indexInGroup + 1,
-            enabled: canReorder && !isLast,
-            placeAfter: true,
-          ),
-          onMoveToStart: moveTo(
-            0,
-            enabled: canReorder && !isFirst,
-            placeAfter: false,
-          ),
-          onMoveToEnd: moveTo(
-            group.length - 1,
-            enabled: canReorder && !isLast,
-            placeAfter: true,
-          ),
-        ),
-        onTap: () => widget.onToolSelected(entry),
-      ),
+      tile: isGrid
+          ? ToolGridTile(
+              entry: entry,
+              isOpen: isOpen,
+              isHighlighted: isHighlighted,
+              movePulse: movePulse,
+              onMenuClosed: onMenuClosed,
+              actions: actions,
+              onTap: () => widget.onToolSelected(entry),
+            )
+          : ToolTile(
+              entry: entry,
+              isOpen: isOpen,
+              isHighlighted: isHighlighted,
+              isGroupStart: isFirst,
+              isGroupEnd: isLast,
+              movePulse: movePulse,
+              onMenuClosed: onMenuClosed,
+              actions: actions,
+              onTap: () => widget.onToolSelected(entry),
+            ),
     );
   }
 }
@@ -772,7 +908,9 @@ class _PluginsToolbar extends StatelessWidget {
 /// במגע הגרירה מתחילה בלחיצה ארוכה, כדי לא לחטוף את הגלילה.
 class _ReorderableToolTile extends StatefulWidget {
   final ToolCatalogEntry entry;
-  final ToolTile tile;
+
+  /// [ToolTile] בתצוגת רשימה, [ToolGridTile] בתצוגת רשת.
+  final Widget tile;
   final bool canDrag;
   final void Function(ToolCatalogEntry source, {required bool placeAfter})
   onAcceptSource;
@@ -1074,26 +1212,49 @@ class ToolTile extends StatelessWidget {
             padding: const EdgeInsetsDirectional.only(end: AppTokens.spaceXS),
             child: _Badge(label: 'DEV', color: cs.tertiary),
           ),
-        if (actions.isNotEmpty) _buildMenuButton(cs),
+        if (actions.isNotEmpty)
+          _ToolActionsMenuButton(
+            actions: actions,
+            onMenuClosed: onMenuClosed,
+            buttonSize: menuButtonSize,
+            iconSize: menuIconSize,
+          ),
       ],
     );
   }
+}
 
-  Widget _buildMenuButton(ColorScheme cs) {
+/// כפתור ⋯ ותפריט הפעולות שלו — משותף לשורה ולקובייה.
+class _ToolActionsMenuButton extends StatelessWidget {
+  final List<ToolTileAction> actions;
+  final VoidCallback? onMenuClosed;
+  final double buttonSize;
+  final double iconSize;
+
+  const _ToolActionsMenuButton({
+    required this.actions,
+    required this.onMenuClosed,
+    required this.buttonSize,
+    required this.iconSize,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
     return SizedBox(
-      width: menuButtonSize,
-      height: menuButtonSize,
+      width: buttonSize,
+      height: buttonSize,
       child: AppPopupMenuButton<VoidCallback>(
         tooltip: 'אפשרויות נוספות',
         icon: Icon(
           FluentIcons.more_vertical_24_regular,
-          size: menuIconSize,
+          size: iconSize,
           color: cs.secondary,
         ),
         padding: EdgeInsets.zero,
-        constraints: const BoxConstraints(
-          minWidth: menuButtonSize,
-          minHeight: menuButtonSize,
+        constraints: BoxConstraints(
+          minWidth: buttonSize,
+          minHeight: buttonSize,
         ),
         onSelected: (action) => action(),
         onMenuClosed: onMenuClosed,
@@ -1143,6 +1304,175 @@ class ToolTile extends StatelessWidget {
       ),
       metrics,
       null,
+    );
+  }
+}
+
+/// קובייה ברשת הכלים: אייקון גדול, תווית מתחתיו, ורקע שעולה רק בריחוף או
+/// בסימון מקלדת. כפתור ⋯ דוהה פנימה בריחוף, כדי שהרשת תישאר נקייה.
+class ToolGridTile extends StatefulWidget {
+  static const double maxIconSize = 32;
+  static const double minIconSize = 20;
+  static const double menuButtonSize = 24;
+  static const double menuIconSize = 13;
+
+  static const double labelFontSize = 12;
+  static const double labelLineHeight = 1.25;
+  static const double labelBlockHeight = labelFontSize * labelLineHeight * 2;
+
+  /// גודל האייקון לגובה הפנוי בקובייה: כל מה שנשאר אחרי שתי שורות התווית.
+  /// כך פאנל מצומצם מקטין את האייקון במקום לחתוך את הכתב.
+  static double iconSizeFor(double availableHeight) {
+    if (!availableHeight.isFinite) return maxIconSize;
+    return (availableHeight - AppTokens.spaceXS - labelBlockHeight).clamp(
+      minIconSize,
+      maxIconSize,
+    );
+  }
+
+  final ToolCatalogEntry entry;
+  final bool isOpen;
+  final bool isHighlighted;
+  final VoidCallback onTap;
+  final List<ToolTileAction> actions;
+  final int movePulse;
+  final VoidCallback? onMenuClosed;
+
+  const ToolGridTile({
+    super.key,
+    required this.entry,
+    required this.isOpen,
+    required this.isHighlighted,
+    required this.onTap,
+    this.actions = const [],
+    this.movePulse = 0,
+    this.onMenuClosed,
+  });
+
+  @override
+  State<ToolGridTile> createState() => _ToolGridTileState();
+}
+
+class _ToolGridTileState extends State<ToolGridTile> {
+  bool _isHovered = false;
+
+  /// במגע אין ריחוף, ולכן כפתור הפעולות מוצג תמיד.
+  bool get _isTouch => switch (defaultTargetPlatform) {
+    TargetPlatform.android || TargetPlatform.iOS => true,
+    _ => false,
+  };
+
+  ToolCatalogEntry get entry => widget.entry;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final cs = theme.colorScheme;
+    final showMenuButton = _isHovered || _isTouch;
+
+    return MouseRegion(
+      onEnter: (_) => setState(() => _isHovered = true),
+      onExit: (_) => setState(() => _isHovered = false),
+      child: _MovePulse(
+        nonce: widget.movePulse,
+        child: Material(
+          color: widget.isHighlighted
+              ? AppSurfaces.selectedItem(cs)
+              : Colors.transparent,
+          surfaceTintColor: Colors.transparent,
+          borderRadius: AppTokens.borderRadiusAll,
+          clipBehavior: Clip.antiAlias,
+          child: InkWell(
+            onTap: widget.onTap,
+            mouseCursor: SystemMouseCursors.click,
+            hoverDuration: Durations.medium1,
+            child: Stack(
+              children: [
+                Center(
+                  child: Padding(
+                    padding: const EdgeInsets.all(AppTokens.spaceXS),
+                    child: LayoutBuilder(
+                      builder: (context, constraints) => Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          _buildIcon(
+                            cs,
+                            ToolGridTile.iconSizeFor(constraints.maxHeight),
+                          ),
+                          const SizedBox(height: AppTokens.spaceXS),
+                          Flexible(
+                            child: Text(
+                              entry.label,
+                              textAlign: TextAlign.center,
+                              maxLines: 2,
+                              overflow: TextOverflow.ellipsis,
+                              style: theme.textTheme.bodySmall?.copyWith(
+                                fontSize: ToolGridTile.labelFontSize,
+                                height: ToolGridTile.labelLineHeight,
+                                fontWeight: FontWeight.w600,
+                                color: cs.onSurface,
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ),
+                ),
+                if (widget.actions.isNotEmpty)
+                  PositionedDirectional(
+                    top: 0,
+                    end: 0,
+                    // דוהה ואינו מוסר מהעץ: הסרה בזמן שהתפריט פתוח הייתה הורגת
+                    // את הכפתור שמנהל אותו. נשאר לחיץ — בעכבר לחיצה תמיד באה
+                    // אחרי ריחוף, ולכן הוא כבר גלוי.
+                    child: AnimatedOpacity(
+                      opacity: showMenuButton ? 1 : 0,
+                      duration: AppTokens.animFast,
+                      child: _ToolActionsMenuButton(
+                        actions: widget.actions,
+                        onMenuClosed: widget.onMenuClosed,
+                        buttonSize: ToolGridTile.menuButtonSize,
+                        iconSize: ToolGridTile.menuIconSize,
+                      ),
+                    ),
+                  ),
+                if (entry.isDevelopment)
+                  PositionedDirectional(
+                    bottom: 2,
+                    start: 4,
+                    child: _Badge(label: 'DEV', color: cs.tertiary),
+                  ),
+                if (widget.isOpen)
+                  PositionedDirectional(
+                    top: 4,
+                    start: 4,
+                    child: Icon(
+                      FluentIcons.checkmark_circle_16_filled,
+                      size: 12,
+                      color: cs.primary,
+                    ),
+                  ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildIcon(ColorScheme cs, double iconSize) {
+    if (entry.imageIcon != null) {
+      return ImageIcon(
+        AssetImage(entry.imageIcon!),
+        size: iconSize,
+        color: cs.primary,
+      );
+    }
+    return Icon(
+      entry.icon ?? FluentIcons.puzzle_piece_24_regular,
+      size: iconSize,
+      color: cs.primary,
     );
   }
 }

--- a/test/settings/settings_bloc_test.dart
+++ b/test/settings/settings_bloc_test.dart
@@ -69,6 +69,7 @@ void main() {
         'isFullscreen': false,
         'libraryViewMode': 'grid',
         'libraryShowPreview': true,
+        'toolsViewMode': 'list',
         'enablePerBookSettings': true,
         'pdfBookViewByDefault': false,
         'shortcuts': <String, String>{},
@@ -130,6 +131,7 @@ void main() {
             isFullscreen: mockSettings['isFullscreen'] as bool,
             libraryViewMode: mockSettings['libraryViewMode'] as String,
             libraryShowPreview: mockSettings['libraryShowPreview'] as bool,
+            toolsViewMode: mockSettings['toolsViewMode'] as String,
             shortcuts: const {},
             enablePerBookSettings:
                 mockSettings['enablePerBookSettings'] as bool,

--- a/test/tools/tools_launcher_panel_test.dart
+++ b/test/tools/tools_launcher_panel_test.dart
@@ -166,6 +166,27 @@ int _selectedRowCount(WidgetTester tester) => tester
     .where((tile) => tile.isSelected)
     .length;
 
+bool _isGridTileSelected(WidgetTester tester, String label) => tester
+    .widget<ToolGridTile>(
+      find
+          .ancestor(of: find.text(label), matching: find.byType(ToolGridTile))
+          .first,
+    )
+    .isHighlighted;
+
+int _selectedGridTileCount(WidgetTester tester) => tester
+    .widgetList<ToolGridTile>(find.byType(ToolGridTile))
+    .where((tile) => tile.isHighlighted)
+    .length;
+
+/// מציאת כפתור ⋯ של קובייה לפי התווית שכתובה בה.
+Finder _gridMenuButtonOf(String label) => find.descendant(
+  of: find
+      .ancestor(of: find.text(label), matching: find.byType(ToolGridTile))
+      .first,
+  matching: find.byIcon(FluentIcons.more_vertical_24_regular),
+);
+
 /// מריץ גוף בדיקה כפלטפורמת שולחן עבודה. האיפוס חייב לקרות בתוך גוף הבדיקה,
 /// כי flutter_test מוודא שמשתני ה-debug נוקו לפני שה-tearDown רץ.
 Future<void> _asDesktop(Future<void> Function() body) async {
@@ -1718,6 +1739,201 @@ void main() {
         find.byType(ToolTile),
         findsNWidgets(kBuiltInToolsCatalog.length + 2),
       );
+    });
+  });
+
+  group('תצוגת קוביות', () {
+    late _RecordingSettingsBloc settingsBloc;
+    late _RecordingPluginSystemBloc pluginSystemBloc;
+    late _TestTabsBloc tabsBloc;
+    late List<ToolCatalogEntry> selected;
+
+    Future<void> pumpPanel(
+      WidgetTester tester, {
+      bool isGrid = true,
+      double width = 520,
+    }) async {
+      settingsBloc = _RecordingSettingsBloc(
+        SettingsState.initial().copyWith(
+          toolsViewMode: isGrid ? kToolsViewModeGrid : kToolsViewModeList,
+        ),
+      );
+      pluginSystemBloc = _RecordingPluginSystemBloc(
+        PluginSystemLoaded([_pluginEntry('com.example.a', 'תוסף א').plugin!]),
+      );
+      tabsBloc = _TestTabsBloc(TabsState.initial());
+      selected = [];
+      addTearDown(() async {
+        await settingsBloc.close();
+        await pluginSystemBloc.close();
+        await tabsBloc.close();
+      });
+
+      await tester.pumpWidget(
+        _launcherHost(
+          settingsBloc: settingsBloc,
+          pluginSystemBloc: pluginSystemBloc,
+          tabsBloc: tabsBloc,
+          onToolSelected: selected.add,
+          width: width,
+        ),
+      );
+      await tester.pump();
+    }
+
+    // ברירת המחדל אינה משתנה: מי שלא נגע בכפתור ממשיך לראות רשימה.
+    testWidgets('ברירת המחדל היא תצוגת רשימה', (tester) async {
+      expect(SettingsState.initial().toolsViewMode, kToolsViewModeList);
+
+      await pumpPanel(tester, isGrid: false);
+      expect(find.byType(NavTreeTile), findsWidgets);
+      expect(find.byType(ToolGridTile), findsNothing);
+    });
+
+    testWidgets('במצב רשת הכלים מוצגים כקוביות ולא כשורות', (tester) async {
+      await pumpPanel(tester);
+      expect(find.byType(ToolGridTile), findsWidgets);
+      expect(find.byType(NavTreeTile), findsNothing);
+    });
+
+    testWidgets('כותרות הקבוצות נשמרות גם ברשת', (tester) async {
+      await pumpPanel(tester);
+      expect(find.byType(NavTreeHeader), findsNWidgets(2));
+      expect(find.text(kBuiltInToolsGroupLabel), findsOneWidget);
+      expect(find.text(kPluginsGroupLabel), findsOneWidget);
+    });
+
+    testWidgets('הסרגל הצף התחתון מוצג גם ברשת', (tester) async {
+      await pumpPanel(tester);
+      expect(find.byTooltip('התקן תוסף חדש'), findsOneWidget);
+    });
+
+    testWidgets('הכפתור בתצוגת רשימה משגר מעבר לרשת', (tester) async {
+      await pumpPanel(tester, isGrid: false);
+      await tester.tap(find.byKey(kToolsViewModeToggleKey));
+      await tester.pump();
+
+      expect(
+        settingsBloc.recorded
+            .whereType<UpdateToolsViewMode>()
+            .single
+            .toolsViewMode,
+        kToolsViewModeGrid,
+      );
+    });
+
+    testWidgets('הכפתור בתצוגת רשת משגר חזרה לרשימה', (tester) async {
+      await pumpPanel(tester);
+      await tester.tap(find.byKey(kToolsViewModeToggleKey));
+      await tester.pump();
+
+      expect(
+        settingsBloc.recorded
+            .whereType<UpdateToolsViewMode>()
+            .single
+            .toolsViewMode,
+        kToolsViewModeList,
+      );
+    });
+
+    testWidgets('לחיצה על קובייה פותחת את הכלי', (tester) async {
+      await pumpPanel(tester);
+      await tester.tap(find.text('לוח שנה'));
+      await tester.pump();
+
+      expect(selected.single.toolId, 'builtin.calendar');
+    });
+
+    // ב-RTL הקובייה הבאה נמצאת משמאל, ולכן חץ שמאל מקדם את הסימון.
+    testWidgets('ברשת החצים האופקיים מזיזים את הסימון', (tester) async {
+      await pumpPanel(tester);
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+      await tester.pump();
+      expect(_isGridTileSelected(tester, 'לוח שנה'), isTrue);
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+      await tester.pump();
+      expect(_isGridTileSelected(tester, 'לוח שנה'), isFalse);
+      expect(_selectedGridTileCount(tester), 1);
+    });
+
+    // ברשימה חץ אופקי אינו אמור להזיז דבר — אין עמודות.
+    testWidgets('ברשימה החצים האופקיים אינם מזיזים סימון', (tester) async {
+      await pumpPanel(tester, isGrid: false);
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+      await tester.pump();
+
+      expect(_selectedRowCount(tester), 0);
+    });
+
+    // חץ למטה ברשת מדלג שורה שלמה של קוביות, לא קובייה אחת.
+    testWidgets('חץ למטה ברשת מדלג בעמודות', (tester) async {
+      await pumpPanel(tester, width: _kDefaultPanelContentWidth);
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      await tester.pump();
+      expect(_isGridTileSelected(tester, 'לוח שנה'), isTrue);
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      await tester.pump();
+      // ברוחב הזה נכנסות ארבע קוביות בשורה, ולכן הסימון עובר לחמישית.
+      expect(_isGridTileSelected(tester, 'לוח שנה'), isFalse);
+      expect(_selectedGridTileCount(tester), 1);
+    });
+
+    testWidgets('כפתור ⋯ בקובייה נראה רק בריחוף', (tester) async {
+      await _asDesktop(() async {
+        await pumpPanel(tester);
+
+        double opacityOf(String label) => tester
+            .widget<AnimatedOpacity>(
+              find
+                  .descendant(
+                    of: find.ancestor(
+                      of: find.text(label),
+                      matching: find.byType(ToolGridTile),
+                    ),
+                    matching: find.byType(AnimatedOpacity),
+                  )
+                  .first,
+            )
+            .opacity;
+        expect(opacityOf('לוח שנה'), 0);
+
+        final gesture = await tester.createGesture(
+          kind: PointerDeviceKind.mouse,
+        );
+        await gesture.addPointer(location: Offset.zero);
+        addTearDown(gesture.removePointer);
+        await gesture.moveTo(
+          tester.getCenter(
+            find
+                .ancestor(
+                  of: find.text('לוח שנה'),
+                  matching: find.byType(ToolGridTile),
+                )
+                .first,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(opacityOf('לוח שנה'), 1);
+      });
+    });
+
+    testWidgets('תפריט הקובייה נפתח ומכיל את פעולות הכלי', (tester) async {
+      await pumpPanel(tester);
+      await tester.tap(_gridMenuButtonOf('לוח שנה'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('הזזה'), findsOneWidget);
+      expect(find.text('הצמד לסרגל הניווט'), findsOneWidget);
+      expect(find.text('הסתר מהממשק'), findsOneWidget);
+    });
+
+    // הקוביות עוברות באותו עוטף סידור של השורות, ולכן הגרירה עובדת גם ברשת.
+    testWidgets('הקוביות עטופות ביעד גרירה לסידור מחדש', (tester) async {
+      await pumpPanel(tester);
+      expect(find.byType(DragTarget<ToolCatalogEntry>), findsWidgets);
     });
   });
 


### PR DESCRIPTION
## מה השינוי

חלונית הכלים קיבלה ב-#747 עיצוב מחדש לתצוגת שורות בסגנון עץ הניווט. ה-PR הזה **מוסיף לידה תצוגת קוביות** בסגנון משגר אפליקציות, וכפתור שמחליף ביניהן. תצוגת השורות נשארת ברירת המחדל — מי שלא נוגע בכפתור לא רואה שינוי.

התצוגה החדשה נותנת מבט על כל הכלים במסך אחד: אייקון גדול ותווית מתחתיו, במקום שורה לכל כלי.
בכצורה כזו החלון ניהיה דומה למסך ההתחל של ווינדוס 11

## צילומי מסך

| תצוגת רשימה (ברירת מחדל) | תצוגת קוביות (חדש) |
|---|---|
| ![רשימה — בהיר](https://raw.githubusercontent.com/Yehuda-Zakesh/otzaria/pr-screenshots/docs/pr-shots/tools_list_light.png) | ![קוביות — בהיר](https://raw.githubusercontent.com/Yehuda-Zakesh/otzaria/pr-screenshots/docs/pr-shots/tools_grid_light.png) |
| ![רשימה — כהה](https://raw.githubusercontent.com/Yehuda-Zakesh/otzaria/pr-screenshots/docs/pr-shots/tools_list_dark.png) | ![קוביות — כהה](https://raw.githubusercontent.com/Yehuda-Zakesh/otzaria/pr-screenshots/docs/pr-shots/tools_grid_dark.png) |

הכפתור שמחליף בין השתיים יושב בשורת החיפוש, לפני כפתור רענון התוספים — אייקון רשת בתצוגת רשימה, אייקון רשימה בתצוגת רשת. אותם אייקונים שמסך ההגדרות משתמש בהם עבור תצוגת הספרייה.

## פרטי המימוש

### ההעדפה נשמרת

`toolsViewMode` נוספה לשכבת ההגדרות באותה תבנית של `libraryViewMode` — מפתח, `getSettings`, `updateToolsViewMode`, אירוע, מטפל ב-bloc, `copyWith` ו-`props`. ברירת המחדל `'list'`, והמפתח נכנס גם לרשימת המפתחות המגובים ולאיפוס ההגדרות.

### הקובייה

- **המשטח שקוף במנוחה** — רקע עולה רק בריחוף או בסימון מקלדת, כך שהרשת נשארת שקטה.
- **כפתור ⋯ דוהה פנימה בריחוף בלבד.** במגע, שאין בו ריחוף, הוא מוצג תמיד.
- הכפתור **אינו מוסר מהעץ** אלא רק מתפוגג: הסרתו בזמן שהתפריט פתוח הייתה הורגת את הכפתור שמנהל אותו. הוא נשאר לחיץ — בעכבר לחיצה תמיד באה אחרי ריחוף, ולכן הוא כבר גלוי.
- גודל האייקון נגזר מהגובה הפנוי בקובייה, כך שפאנל מצומצם מקטין את האייקון במקום לחתוך את התווית.
- תג `DEV` וסימן "פתוח" נשמרו, בפינות הקובייה.

### מה משותף לשתי התצוגות

- **בונה אחד** לשורה ולקובייה (`_buildEntryTile`), כך שלוגיקת ההזזה, הסימון ופעולות התפריט אינה מוכפלת.
- **אותו עוטף גרירה** (`_ReorderableToolTile`) — הסידור מחדש בגרירה עובד ברשת בדיוק כמו ברשימה.
- **תפריט ⋯ חולץ ל-widget משותף** (`_ToolActionsMenuButton`) במקום שיישוכפל בין השורה לקובייה.

### ניווט מקלדת

ברשת החצים האופקיים מזיזים קובייה אחת (הפוך ל-RTL) והאנכיים מדלגים שורה שלמה לפי מספר העמודות שנכנסו לרוחב. ברשימה ההתנהגות לא שונתה — אנכי בלבד.

### מה לא נגעתי בו

הכותרת, שדה החיפוש, כותרות הקבוצות (`NavTreeHeader`) והסרגל הצף התחתון עם שלוש פעולות התוספים — כולם כפי שהם ב-`dev`.

## בדיקות

- `flutter analyze` — נקי.
- `test/tools/tools_launcher_panel_test.dart` — 119 עוברים: 107 הקיימים ללא שינוי התנהגות, ו-12 חדשים לתצוגת הרשת (ברירת המחדל היא רשימה, החלפה בשני הכיוונים, שימור הכותרות והסרגל הצף, פתיחת כלי מקובייה, שני כיווני ניווט המקלדת, דהיית ⋯ בריחוף מול הצגה במגע, ועטיפת יעד הגרירה).
- `test/settings/` — 614 עוברים, כולל בדיקת כיסוי הגיבוי שמוודאת שכל מפתח הגדרה מגובה.
