### PR TITLE
allowlist לתוספים: 6 כתובות לתוסף "עינים למקרא"

### DIFF
--- a/lib/plugins/models/plugin_network_allowlist.g.dart
+++ b/lib/plugins/models/plugin_network_allowlist.g.dart
@@ -37,4 +37,10 @@ const List<String> pluginNetworkAllowlist = <String>[
   'https://api.github.com/repos/yair-yair/mdy-images-updated',
   'https://raw.githubusercontent.com/yair-yair/mdy-images-updated',
   'https://github.com/yair-yair/mdy-images-updated',
+  'https://raw.githubusercontent.com/e0548433917-gif/madaei-hatanach/main/manifest.json',
+  'https://api.github.com/repos/e0548433917-gif/madaei-hatanach/contents/manifest.json',
+  'https://script.google.com/macros/s/AKfycbxzlCAZzhaEM68jRqqekW8InrtbSiZrtiiIjgCKOInUvyBG43wLY29MYY6PrbHijpO6/exec',
+  'https://script.googleusercontent.com/macros/echo',
+  'https://docs.google.com/forms/d/e/1FAIpQLSd7NiGDUahnwpaestosEcDxPJoAkYXzVRUa2yB5EiXkLPSWvQ/formResponse',
+  'https://he.wikipedia.org/api/rest_v1/page/summary',
 ];

--- a/plugin_network_allowlist.txt
+++ b/plugin_network_allowlist.txt
@@ -76,3 +76,15 @@ https://github.com/yair-yair/mdy-images-updated
 https://api.github.com/repos/yair-yair/mdy-images-updated
 https://raw.githubusercontent.com/yair-yair/mdy-images-updated
 https://github.com/yair-yair/mdy-images-updated
+
+# תוסף "עינים למקרא" (com.chadbedera.madaeihatanach) — חד בדרא
+# בדיקת עדכון גרסה: קריאת manifest.json של התוסף בלבד (raw, וה-API כגיבוי)
+https://raw.githubusercontent.com/e0548433917-gif/madaei-hatanach/main/manifest.json
+https://api.github.com/repos/e0548433917-gif/madaei-hatanach/contents/manifest.json
+# ממסר דיווחי הבאגים מתוך התוסף: Apps Script (יעד ה-redirect שלו בשורה שאחריו),
+# וטופס גוגל כמסלול גיבוי כשה-Apps Script חסום
+https://script.google.com/macros/s/AKfycbxzlCAZzhaEM68jRqqekW8InrtbSiZrtiiIjgCKOInUvyBG43wLY29MYY6PrbHijpO6/exec
+https://script.googleusercontent.com/macros/echo
+https://docs.google.com/forms/d/e/1FAIpQLSd7NiGDUahnwpaestosEcDxPJoAkYXzVRUa2yB5EiXkLPSWvQ/formResponse
+# תמונות חיות למדריך הצומח — תקציר ויקיפדיה לפי שם מדעי
+https://he.wikipedia.org/api/rest_v1/page/summary


### PR DESCRIPTION
## מה זה

הוספת שש כתובות ל-`plugin_network_allowlist.txt` עבור התוסף **עינים למקרא**
(`com.chadbedera.madaeihatanach`, מאת חד בדרא).

התוסף מצהיר עליהן ב-`network.allowlist` שלו, אך אף אחת אינה ברשימה הרשמית —
ולכן `PluginNetworkAccessResolver` מחזיר `403 Forbidden` לכל קריאות הרשת שלו
אצל כל המשתמשים. בדיקת העדכון וממסר דיווחי הבאגים שבתוסף אינם עובדים כלל.

## הכתובות, ומי קורא להן

| כתובת | מי קורא | מה עובר |
|---|---|---|
| `https://raw.githubusercontent.com/e0548433917-gif/madaei-hatanach/main/manifest.json` | `shell/bridge.js` | GET של `manifest.json` של התוסף עצמו בלבד, להשוואת מספר גרסה |
| `https://api.github.com/repos/e0548433917-gif/madaei-hatanach/contents/manifest.json` | `shell/bridge.js` | אותו דבר, כשה-raw חסום או נופל |
| `https://script.google.com/macros/s/AKfycbxz…/exec` | `shell/personal.js` | POST של דיווח באג שהמשתמש כתב בתוך התוסף; ה-Apps Script פותח GitHub Issue אצל המפתח |
| `https://script.googleusercontent.com/macros/echo` | (redirect) | יעד ההפניה של אותו Apps Script — בלעדיו הבקשה נחסמת באמצע ה-redirect |
| `https://docs.google.com/forms/d/e/1FAIpQLSd7…/formResponse` | `shell/personal.js` | אותו דיווח, מסלול גיבוי כשה-Apps Script חסום אצל המשתמש |
| `https://he.wikipedia.org/api/rest_v1/page/summary` | `shell/guides.js` | GET תקציר לפי שם מדעי, לתמונת כרטיס במדריך הצומח. נכשל בשקט כשאין גישה |

כל הערכים הם **נתיבים מלאים ולא דומיינים גנריים**, לפי §"חובה: כתובות מדויקות
בלבד" ב-`docs/plugin-sdk/API_REFERENCE.md`. נבדק מול `matchingNetworkAllowlistPrefix`
ששש הבקשות שהתוסף באמת שולח עוברות (כולל `?ref=main` ו-`?user_content_key=…`
שנוספים בזמן ריצה), ושכתובות כמו `https://github.com/`, ריפו אחר תחת אותם
דומיינים, `he.wikipedia.org/wiki/…` וטופס גוגל אחר נשארות חסומות.

`https://github.com/e0548433917-gif/madaei-hatanach/releases` מוצהר במניפסט של
התוסף אך **לא** נכלל כאן בכוונה: הוא נפתח דרך `app.openUrl` בדפדפן המערכת,
שאינו נבדק מול ה-allowlist.

## על השינוי עצמו

* העריכה היחידה בכתב יד היא ב-`plugin_network_allowlist.txt`.
* `lib/plugins/models/plugin_network_allowlist.g.dart` חודש ע"י
  `dart run tool/generate_plugin_network_allowlist.dart` (המנגנון שנוסף
  ב-c508f44a8), ולא נערך ידנית.
* `flutter test test/plugins/models/plugin_network_allowlist_branch_sync_test.dart` — עובר.

ריפו התוסף: <https://github.com/e0548433917-gif/madaei-hatanach>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
