### PR TITLE
fix(backup): גיבוי הדיווחים השמורים, וסגירת נקודה עיוורת בשומר הכיסוי

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1221,7 +1221,7 @@ Future<void> initHive() async {
     Hive.openBox<dynamic>('workspaces'),
     Hive.openBox<dynamic>('history'),
     Hive.openBox<dynamic>('bookmarks'),
-    Hive.openBox<dynamic>('error_reports_queue'),
+    Hive.openBox<dynamic>(DirectErrorReportService.queueBoxName),
     Hive.openBox<dynamic>(PluginReportService.queueBoxName),
   ]);
 }

--- a/lib/plugins/services/plugin_report_service.dart
+++ b/lib/plugins/services/plugin_report_service.dart
@@ -27,17 +27,18 @@ class PluginReportService {
     HiveListRepository<PluginReportRecord>? queueRepository,
     HiveListRepository<PluginReportRecord>? sentRepository,
   }) : _client = client ?? _shared,
-       _queueRepository = queueRepository ?? _defaultRepository(_queueKey),
-       _sentRepository = sentRepository ?? _defaultRepository(_sentKey);
+       _queueRepository =
+           queueRepository ?? _defaultRepository(pendingReportsKey),
+       _sentRepository = sentRepository ?? _defaultRepository(sentReportsKey);
 
   static final Uri endpoint = Uri.parse(
     'https://otzaria.org/api/plugin-reports',
   );
 
   static const String queueBoxName = 'plugin_reports_queue';
-  static const String _queueKey = 'pending_reports';
-  static const String _sentKey = 'sent_reports';
-  static const int _maxSentReportsToKeep = 100;
+  static const String pendingReportsKey = 'pending_reports';
+  static const String sentReportsKey = 'sent_reports';
+  static const int maxSentReportsToKeep = 100;
   static const Duration _timeout = Duration(seconds: 10);
   static const Duration _flushInterval = Duration(minutes: 5);
   static const int _maxQueuedFlushPerRun = 20;
@@ -305,8 +306,8 @@ class PluginReportService {
     final sentRecords = await _sentRepository.load();
     sentRecords.removeWhere((item) => item.reportId == record.reportId);
     sentRecords.insert(0, record);
-    if (sentRecords.length > _maxSentReportsToKeep) {
-      sentRecords.removeRange(_maxSentReportsToKeep, sentRecords.length);
+    if (sentRecords.length > maxSentReportsToKeep) {
+      sentRecords.removeRange(maxSentReportsToKeep, sentRecords.length);
     }
     await _sentRepository.save(sentRecords);
   }

--- a/lib/plugins/services/plugin_report_service.dart
+++ b/lib/plugins/services/plugin_report_service.dart
@@ -51,6 +51,15 @@ class PluginReportService {
 
   static Timer? _flushTimer;
   static bool _isFlushing = false;
+  static Completer<void>? _flushInFlight;
+
+  /// עוצר את השליחה האוטומטית וממתין לשליחה שבאמצע, כדי שכתיבה חיצונית לתור
+  /// (שחזור מגיבוי) לא תדרוס אותה. `startAutomaticFlush` מפעיל מחדש בעלייה.
+  static Future<void> suspendAutomaticFlush() async {
+    _flushTimer?.cancel();
+    _flushTimer = null;
+    await _flushInFlight?.future;
+  }
 
   final http.Client _client;
   final HiveListRepository<PluginReportRecord> _queueRepository;
@@ -218,6 +227,7 @@ class PluginReportService {
     }
 
     _isFlushing = true;
+    final inFlight = _flushInFlight = Completer<void>();
     try {
       final pendingRecords = await _queueRepository.load();
       if (pendingRecords.isEmpty) {
@@ -260,6 +270,8 @@ class PluginReportService {
       return sentCount;
     } finally {
       _isFlushing = false;
+      _flushInFlight = null;
+      inFlight.complete();
     }
   }
 

--- a/lib/services/direct_error_report_service.dart
+++ b/lib/services/direct_error_report_service.dart
@@ -69,6 +69,15 @@ class DirectErrorReportService {
 
   static Timer? _flushTimer;
   static bool _isFlushing = false;
+  static Completer<void>? _flushInFlight;
+
+  /// עוצר את השליחה האוטומטית וממתין לשליחה שבאמצע, כדי שכתיבה חיצונית לתור
+  /// (שחזור מגיבוי) לא תדרוס אותה. `startAutomaticFlush` מפעיל מחדש בעלייה.
+  static Future<void> suspendAutomaticFlush() async {
+    _flushTimer?.cancel();
+    _flushTimer = null;
+    await _flushInFlight?.future;
+  }
 
   final http.Client _client;
   final HiveListRepository<DirectErrorReport> _queueRepository;
@@ -289,6 +298,7 @@ class DirectErrorReportService {
     }
 
     _isFlushing = true;
+    final inFlight = _flushInFlight = Completer<void>();
     try {
       final pendingReports = await _queueRepository.load();
       if (pendingReports.isEmpty) {
@@ -338,6 +348,8 @@ class DirectErrorReportService {
       return sentCount;
     } finally {
       _isFlushing = false;
+      _flushInFlight = null;
+      inFlight.complete();
     }
   }
 

--- a/lib/services/direct_error_report_service.dart
+++ b/lib/services/direct_error_report_service.dart
@@ -57,10 +57,10 @@ class DirectReportDeliveryResult {
 
 class DirectErrorReportService {
   static const String _endpoint = 'https://otzaria.org/api/reportingerrors';
-  static const String _queueBoxName = 'error_reports_queue';
-  static const String _queueKey = 'pending_reports';
-  static const String _sentKey = 'sent_reports';
-  static const int _maxSentReportsToKeep = 100;
+  static const String queueBoxName = 'error_reports_queue';
+  static const String pendingReportsKey = 'pending_reports';
+  static const String sentReportsKey = 'sent_reports';
+  static const int maxSentReportsToKeep = 100;
   static const Duration _timeout = Duration(seconds: 10);
   static const Duration _flushInterval = Duration(minutes: 5);
   static const int _maxQueuedFlushPerRun = 20;
@@ -82,16 +82,16 @@ class DirectErrorReportService {
        _queueRepository =
            queueRepository ??
            HiveListRepository<DirectErrorReport>(
-             boxName: _queueBoxName,
-             key: _queueKey,
+             boxName: queueBoxName,
+             key: pendingReportsKey,
              fromJson: DirectErrorReport.fromJson,
              toJson: (report) => report.toJson(),
            ),
        _sentRepository =
            sentRepository ??
            HiveListRepository<DirectErrorReport>(
-             boxName: _queueBoxName,
-             key: _sentKey,
+             boxName: queueBoxName,
+             key: sentReportsKey,
              fromJson: DirectErrorReport.fromJson,
              toJson: (report) => report.toJson(),
            );
@@ -379,8 +379,8 @@ class DirectErrorReportService {
     final sentReports = await _sentRepository.load();
     sentReports.removeWhere((item) => item.id == report.id);
     sentReports.insert(0, report);
-    if (sentReports.length > _maxSentReportsToKeep) {
-      sentReports.removeRange(_maxSentReportsToKeep, sentReports.length);
+    if (sentReports.length > maxSentReportsToKeep) {
+      sentReports.removeRange(maxSentReportsToKeep, sentReports.length);
     }
     await _sentRepository.save(sentReports);
   }

--- a/lib/settings/services/backup/backup_merge.dart
+++ b/lib/settings/services/backup/backup_merge.dart
@@ -59,6 +59,11 @@ class BackupMerge {
     );
     if (perBook != null) result['perBookSettings'] = perBook;
 
+    // דיווחים שמורים: החדש מנצח בשלמותו. השחזור עצמו ממזג מול התור המקומי
+    // ומדלג על מה שנשלח מאז, ולכן אין צורך לשמר כאן דיווחים ישנים.
+    final reportQueues = newer['reportQueues'] ?? older['reportQueues'];
+    if (reportQueues != null) result['reportQueues'] = reportQueues;
+
     final bookmarks = _mergeItemLists(
       older['bookmarks'],
       newer['bookmarks'],

--- a/lib/settings/services/backup_service.dart
+++ b/lib/settings/services/backup_service.dart
@@ -20,6 +20,8 @@ import 'package:otzaria/personal_notes/models/personal_note.dart';
 import 'package:otzaria/personal_notes/services/personal_note_draft_service.dart';
 import 'package:otzaria/plugins/storage/plugin_system_database.dart';
 import 'package:otzaria/plugins/models/installed_plugin.dart';
+import 'package:otzaria/plugins/services/plugin_report_service.dart';
+import 'package:otzaria/services/direct_error_report_service.dart';
 import 'package:otzaria/core/app_paths.dart';
 import 'package:otzaria/settings/services/backup/backup_maintenance.dart';
 import 'package:otzaria/settings/services/backup/backup_store.dart';
@@ -122,6 +124,7 @@ class BackupService {
         if (perBookSettings.hadFailures) {
           skippedSections.add('perBookSettings');
         }
+        backupData['reportQueues'] = _backupReportQueues(skippedSections);
       }
 
       // Backup bookmarks
@@ -206,6 +209,8 @@ class BackupService {
     'databases',
     'plugins',
     'per_book_settings',
+    'error_reports_queue',
+    'plugin_reports_queue',
   };
 
   /// מקומות שמירה שאינם מגובים במכוון, עם הסיבה לכל אחד.
@@ -214,7 +219,6 @@ class BackupService {
   /// `backup_storage_coverage_test` סורק את הקוד ונכשל על מקום שאינו מוצהר,
   /// כך שתיקייה חדשה לא תישמט מהגיבוי בשקט כפי שקרה ל-`per_book_settings`.
   static const Map<String, String> unbackedStores = {
-    'error_reports_queue': 'תור זמני — הדיווחים נשלחים והתור מתרוקן',
     'pending_external_activations.jsonl':
         'תור זמני של בקשות פתיחה מחוץ לתוכנה, מתרוקן בעיבוד',
     'books': 'תוכן הספרייה, מגיע מההתקנה או מההורדה',
@@ -517,6 +521,67 @@ class BackupService {
     return TabsRepository().exportRaw();
   }
 
+  /// תורי הדיווחים השמורים. לשני ה-boxes מבנה זהה — רשימת ממתינים ורשימת
+  /// נשלחים — ולכן אותו גיבוי ושחזור משרת את שניהם.
+  static const List<
+    ({String box, String pendingKey, String sentKey, int maxSent})
+  >
+  _reportQueues = [
+    (
+      box: DirectErrorReportService.queueBoxName,
+      pendingKey: DirectErrorReportService.pendingReportsKey,
+      sentKey: DirectErrorReportService.sentReportsKey,
+      maxSent: DirectErrorReportService.maxSentReportsToKeep,
+    ),
+    (
+      box: PluginReportService.queueBoxName,
+      pendingKey: PluginReportService.pendingReportsKey,
+      sentKey: PluginReportService.sentReportsKey,
+      maxSent: PluginReportService.maxSentReportsToKeep,
+    ),
+  ];
+
+  /// גיבוי הדיווחים השמורים — הממתינים לשליחה וההיסטוריה שנשלחה.
+  ///
+  /// הדיווחים נכנסים לסעיף ההגדרות: הם מנוהלים באותו מקום במסך ההגדרות
+  /// שבו נשמרת כתובת המייל, שכבר נכנסת לסעיף הזה. דיווח שממתין לשליחה
+  /// במצב לא-מקוון הוא תוכן שהמשתמש כתב, ואיפוס הגדרות מוחק אותו.
+  static Map<String, dynamic> _backupReportQueues(
+    List<String> skippedSections,
+  ) {
+    final queues = <String, dynamic>{};
+    for (final queue in _reportQueues) {
+      if (!Hive.isBoxOpen(queue.box)) {
+        _logger.warning(
+          '_backupReportQueues: ${queue.box} not open — skipping (partial backup)',
+        );
+        if (!skippedSections.contains('reportQueues')) {
+          skippedSections.add('reportQueues');
+        }
+        continue;
+      }
+      final box = Hive.box<dynamic>(queue.box);
+      queues[queue.box] = {
+        'pending': _reportList(box.get(queue.pendingKey)),
+        'sent': _reportList(box.get(queue.sentKey)),
+      };
+    }
+    return queues;
+  }
+
+  /// המרת רשימת דיווחים מ-Hive/JSON לרשימת מפות עם מפתחות מחרוזת.
+  static List<Map<String, dynamic>> _reportList(Object? raw) {
+    if (raw is! List) return const [];
+    return raw
+        .whereType<Map>()
+        .map((e) => Map<String, dynamic>.from(e))
+        .toList();
+  }
+
+  /// מזהה הדיווח, שנקרא `id` בדיווחי הטעות ו-`reportId` בדיווחי התוספים.
+  static String? _reportId(Map<String, dynamic> report) =>
+      (report['id'] ?? report['reportId'])?.toString();
+
   /// Backup Shamor Zachor data - backs up all sz: keys found in Hive
   static Future<Map<String, dynamic>> _backupShamorZachor() async {
     if (!Hive.isBoxOpen(HiveCache.keyName)) {
@@ -608,6 +673,10 @@ class BackupService {
             const {},
       );
       if (perBookHadFailures) runtimeSkipped.add('perBookSettings');
+      final reportsSkipped = await _restoreReportQueues(
+        (backupData['reportQueues'] as Map?)?.cast<String, dynamic>(),
+      );
+      if (reportsSkipped) runtimeSkipped.add('reportQueues');
     }
 
     // Restore bookmarks
@@ -719,6 +788,62 @@ class BackupService {
       }
     }
     return hadFailures;
+  }
+
+  /// שחזור הדיווחים השמורים (ראה [_backupReportQueues]).
+  ///
+  /// מיזוג ולא החלפה: דיווח שנוצר אחרי הגיבוי נשאר, ודיווח שכבר נשלח אינו
+  /// חוזר לתור — בלי זה שחזור של גיבוי ישן היה שולח שוב לצוות אוצריא כל
+  /// דיווח שנשלח מאז.
+  static Future<bool> _restoreReportQueues(Map<String, dynamic>? queues) async {
+    if (queues == null || queues.isEmpty) return false;
+
+    var skipped = false;
+    for (final queue in _reportQueues) {
+      final backedUp = (queues[queue.box] as Map?)?.cast<String, dynamic>();
+      if (backedUp == null) continue;
+      if (!Hive.isBoxOpen(queue.box)) {
+        _logger.warning(
+          '_restoreReportQueues: ${queue.box} not open — skipping (partial restore)',
+        );
+        skipped = true;
+        continue;
+      }
+
+      final box = Hive.box<dynamic>(queue.box);
+      final sent = _mergeReports(
+        _reportList(box.get(queue.sentKey)),
+        _reportList(backedUp['sent']),
+      );
+      if (sent.length > queue.maxSent) {
+        sent.removeRange(queue.maxSent, sent.length);
+      }
+      final sentIds = sent.map(_reportId).whereType<String>().toSet();
+      final pending = _mergeReports(
+        _reportList(box.get(queue.pendingKey)),
+        _reportList(backedUp['pending']),
+      ).where((report) => !sentIds.contains(_reportId(report))).toList();
+
+      await box.put(queue.pendingKey, pending);
+      await box.put(queue.sentKey, sent);
+    }
+    return skipped;
+  }
+
+  /// איחוד שתי רשימות דיווחים לפי מזהה — המקומי מנצח, כי הוא העדכני.
+  /// דיווח בלי מזהה נשמר כמות שהוא: אין דרך לזהות אותו ככפול.
+  static List<Map<String, dynamic>> _mergeReports(
+    List<Map<String, dynamic>> local,
+    List<Map<String, dynamic>> backedUp,
+  ) {
+    final merged = [...local];
+    final localIds = local.map(_reportId).whereType<String>().toSet();
+    for (final report in backedUp) {
+      final id = _reportId(report);
+      if (id != null && localIds.contains(id)) continue;
+      merged.add(report);
+    }
+    return merged;
   }
 
   /// האם סעיף ההגדרות נאסף מרשימת מפתחות מוצהרת ולכן חסר את השאר.

--- a/lib/settings/services/backup_service.dart
+++ b/lib/settings/services/backup_service.dart
@@ -541,11 +541,8 @@ class BackupService {
     ),
   ];
 
-  /// גיבוי הדיווחים השמורים — הממתינים לשליחה וההיסטוריה שנשלחה.
-  ///
-  /// הדיווחים נכנסים לסעיף ההגדרות: הם מנוהלים באותו מקום במסך ההגדרות
-  /// שבו נשמרת כתובת המייל, שכבר נכנסת לסעיף הזה. דיווח שממתין לשליחה
-  /// במצב לא-מקוון הוא תוכן שהמשתמש כתב, ואיפוס הגדרות מוחק אותו.
+  /// גיבוי הדיווחים השמורים — הממתינים לשליחה וההיסטוריה שנשלחה. נכנסים
+  /// לסעיף ההגדרות, שבו נשמרת כבר כתובת המייל שאליה הם משויכים.
   static Map<String, dynamic> _backupReportQueues(
     List<String> skippedSections,
   ) {
@@ -790,13 +787,15 @@ class BackupService {
     return hadFailures;
   }
 
-  /// שחזור הדיווחים השמורים (ראה [_backupReportQueues]).
-  ///
-  /// מיזוג ולא החלפה: דיווח שנוצר אחרי הגיבוי נשאר, ודיווח שכבר נשלח אינו
-  /// חוזר לתור — בלי זה שחזור של גיבוי ישן היה שולח שוב לצוות אוצריא כל
-  /// דיווח שנשלח מאז.
+  /// שחזור הדיווחים השמורים (ראה [_backupReportQueues]). ממזג ולא מחליף:
+  /// דיווח שנשלח מאז אינו חוזר לתור, אחרת היה נשלח שוב לצוות אוצריא.
   static Future<bool> _restoreReportQueues(Map<String, dynamic>? queues) async {
     if (queues == null || queues.isEmpty) return false;
+
+    // השליחה האוטומטית כותבת לאותם מפתחות אחרי בקשת רשת; בלי עצירה שלה
+    // הכתיבה כאן עלולה לדרוס את רשומת הנשלחים ולהחזיר דיווח שכבר נמסר.
+    await DirectErrorReportService.suspendAutomaticFlush();
+    await PluginReportService.suspendAutomaticFlush();
 
     var skipped = false;
     for (final queue in _reportQueues) {

--- a/test/services/direct_error_report_service_test.dart
+++ b/test/services/direct_error_report_service_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';
@@ -261,6 +262,47 @@ void main() {
         );
       },
     );
+  });
+
+  group('DirectErrorReportService.suspendAutomaticFlush', () {
+    test('ממתינה לשליחה שבאמצע, כדי שכתיבה חיצונית לא תדרוס אותה', () async {
+      final repository = InMemoryDirectErrorReportRepository();
+      final sentRepository = InMemoryDirectErrorReportRepository();
+      await repository.save([
+        _buildReport(
+          id: 'r-1',
+          queueType: DirectErrorReportQueueType.automaticRetry,
+        ),
+      ]);
+
+      final networkGate = Completer<http.Response>();
+      final service = DirectErrorReportService(
+        client: MockClient((_) => networkGate.future),
+        queueRepository: repository,
+        sentRepository: sentRepository,
+      );
+
+      final flush = service.flushPendingReports(onlyAutomaticRetry: true);
+      var suspended = false;
+      final suspend = DirectErrorReportService.suspendAutomaticFlush().then(
+        (_) => suspended = true,
+      );
+
+      await pumpEventQueue();
+      expect(
+        suspended,
+        isFalse,
+        reason: 'השחזור אינו יכול לכתוב לתור בזמן שהשליחה באוויר',
+      );
+
+      networkGate.complete(http.Response('', 200));
+      await flush;
+      await suspend;
+
+      expect(suspended, isTrue);
+      expect((await sentRepository.load()).single.id, 'r-1');
+      expect(await repository.load(), isEmpty);
+    });
   });
 
   group('DirectErrorReportService.submitReport', () {

--- a/test/settings/services/backup_restore_advanced_test.dart
+++ b/test/settings/services/backup_restore_advanced_test.dart
@@ -15,7 +15,9 @@ import 'package:otzaria/personal_notes/services/personal_note_draft_service.dart
 import 'package:otzaria/personal_notes/storage/personal_notes_database.dart';
 import 'package:otzaria/plugins/models/installed_plugin.dart';
 import 'package:otzaria/plugins/models/plugin_manifest.dart';
+import 'package:otzaria/plugins/services/plugin_report_service.dart';
 import 'package:otzaria/plugins/storage/plugin_system_database.dart';
+import 'package:otzaria/services/direct_error_report_service.dart';
 import 'package:otzaria/settings/engine/settings_repository.dart';
 import 'package:otzaria/settings/services/backup/backup_maintenance.dart';
 import 'package:otzaria/settings/services/backup/backup_rotation.dart';
@@ -43,6 +45,10 @@ void main() {
     await Hive.openBox<dynamic>('workspaces');
     await Hive.openBox<dynamic>('bookmarks');
     await Hive.openBox<dynamic>('history');
+    // כמו ב-initHive: תורי הדיווחים פתוחים לכל אורך הריצה, ובלעדיהם הגיבוי
+    // מסמן את עצמו כחלקי ולא רק "בלי דיווחים".
+    await Hive.openBox<dynamic>(DirectErrorReportService.queueBoxName);
+    await Hive.openBox<dynamic>(PluginReportService.queueBoxName);
     await Settings.init(cacheProvider: HiveCache());
     await Settings.setValue<String>(
       SettingsRepository.keyBackupPath,

--- a/test/settings/services/backup_service_test.dart
+++ b/test/settings/services/backup_service_test.dart
@@ -8,7 +8,9 @@ import 'package:otzaria/core/app_paths.dart';
 import 'package:otzaria/data/data_providers/hive_data_provider.dart';
 import 'package:otzaria/plugins/models/installed_plugin.dart';
 import 'package:otzaria/plugins/models/plugin_manifest.dart';
+import 'package:otzaria/plugins/services/plugin_report_service.dart';
 import 'package:otzaria/plugins/storage/plugin_system_database.dart';
+import 'package:otzaria/services/direct_error_report_service.dart';
 import 'package:otzaria/personal_notes/models/personal_note.dart';
 import 'package:otzaria/personal_notes/storage/personal_notes_database.dart';
 import 'package:otzaria/settings/engine/settings_repository.dart';
@@ -1066,6 +1068,120 @@ void main() {
       await BackupService.restoreFromBackup(path);
 
       expect((tabsBox.get('key-tabs') as List), hasLength(1));
+    });
+  });
+
+  group('גיבוי ושחזור דיווחי טעות שמורים', () {
+    late Box<dynamic> reportsBox;
+
+    setUp(() async {
+      reportsBox = await Hive.openBox<dynamic>(
+        DirectErrorReportService.queueBoxName,
+      );
+      await Hive.openBox<dynamic>(PluginReportService.queueBoxName);
+    });
+
+    Map<String, dynamic> report(String id) => {
+      'id': id,
+      'senderEmail': 'a@b.com',
+      'subject': 'טעות',
+      'bookTitle': 'בראשית',
+      'currentRef': 'א,א',
+      'lineNumber': 1,
+      'createdAt': '2026-08-20T10:00:00.000',
+    };
+
+    Future<String> createSettingsBackup() async =>
+        (await BackupService.createBackup(
+          includeSettings: true,
+          includeBookmarks: false,
+          includeHistory: false,
+          includeNotes: false,
+          includeWorkspaces: false,
+          includeShamorZachor: false,
+          includePlugins: false,
+        )).path;
+
+    test('הדיווחים הממתינים וההיסטוריה עוברים גיבוי ושחזור', () async {
+      await reportsBox.put(DirectErrorReportService.pendingReportsKey, [
+        report('pending-1'),
+      ]);
+      await reportsBox.put(DirectErrorReportService.sentReportsKey, [
+        report('sent-1'),
+      ]);
+
+      final path = await createSettingsBackup();
+      // איפוס הגדרות מוחק את התור — זה בדיוק המצב שבו השחזור נדרש.
+      await reportsBox.clear();
+
+      await BackupService.restoreFromBackup(path);
+
+      // דרך השירות ולא רק דרך ה-box: מאמת שהצורה ששוחזרה נטענת למודל.
+      final service = DirectErrorReportService();
+      expect((await service.getPendingReports()).single.id, 'pending-1');
+      expect((await service.getSentReports()).single.id, 'sent-1');
+      await service.closeHttpClient();
+    });
+
+    test('דיווח שנשלח מאז אינו חוזר לתור בשחזור', () async {
+      await reportsBox.put(DirectErrorReportService.pendingReportsKey, [
+        report('r-1'),
+      ]);
+      final path = await createSettingsBackup();
+
+      // הדיווח נשלח בין הגיבוי לשחזור: עבר לרשימת הנשלחים והתור התרוקן.
+      await reportsBox.put(
+        DirectErrorReportService.pendingReportsKey,
+        <dynamic>[],
+      );
+      await reportsBox.put(DirectErrorReportService.sentReportsKey, [
+        report('r-1'),
+      ]);
+
+      await BackupService.restoreFromBackup(path);
+
+      expect(
+        reportsBox.get(DirectErrorReportService.pendingReportsKey),
+        isEmpty,
+      );
+      expect(
+        (reportsBox.get(DirectErrorReportService.sentReportsKey) as List),
+        hasLength(1),
+      );
+    });
+
+    test('דיווח שנוצר אחרי הגיבוי שורד את השחזור', () async {
+      await reportsBox.put(DirectErrorReportService.pendingReportsKey, [
+        report('old'),
+      ]);
+      final path = await createSettingsBackup();
+
+      await reportsBox.put(DirectErrorReportService.pendingReportsKey, [
+        report('new'),
+      ]);
+      await BackupService.restoreFromBackup(path);
+
+      final ids =
+          (reportsBox.get(DirectErrorReportService.pendingReportsKey) as List)
+              .map((e) => (e as Map)['id'])
+              .toList();
+      expect(ids, containsAll(['new', 'old']));
+    });
+
+    test('box סגור בזמן הגיבוי מסמן את הסעיף כחלקי', () async {
+      await reportsBox.close();
+
+      final result = await BackupService.createBackup(
+        includeSettings: true,
+        includeBookmarks: false,
+        includeHistory: false,
+        includeNotes: false,
+        includeWorkspaces: false,
+        includeShamorZachor: false,
+        includePlugins: false,
+      );
+
+      expect(result.skippedSections, contains('reportQueues'));
     });
   });
 }

--- a/test/settings/services/backup_storage_coverage_test.dart
+++ b/test/settings/services/backup_storage_coverage_test.dart
@@ -19,9 +19,8 @@ void main() {
   /// שמות ה-Hive boxes שנפתחים בקוד: `openBox…('name')`.
   final boxPattern = RegExp(r"""openBox[^(]*\(\s*'([^']+)'""");
 
-  /// `openBox…(kBoxName)` ו-`openBox…(Service.boxName)` — השם מגיע מקבוע,
-  /// ונפתר מהצהרתו בכל קובצי `lib`. בלי פתירה בין קבצים, box שנפתח דרך קבוע
-  /// של מחלקה אחרת נשמט מהסריקה כולה והשומר היה ירוק על מקום לא מוכרע.
+  /// `openBox…(kBoxName)` ו-`openBox…(Service.boxName)` — השם מגיע מקבוע ונפתר
+  /// מהצהרתו בכל קובצי `lib`; בלי פתירה בין קבצים ה-box נשמט מהסריקה כולה.
   final boxViaIdentifierPattern = RegExp(
     r"""openBox[^(]*\(\s*(?:[A-Za-z_]\w*\s*\.\s*)?([A-Za-z_]\w*)\s*[,)]""",
   );

--- a/test/settings/services/backup_storage_coverage_test.dart
+++ b/test/settings/services/backup_storage_coverage_test.dart
@@ -10,18 +10,25 @@ import 'package:otzaria/settings/services/backup_service.dart';
 /// בלי השומר, מקום שמירה חדש נשמט מהגיבוי בשקט — כך אבדו ההתאמות הפר-ספריות,
 /// שיושבות בקבצי JSON מחוץ ל-Hive ולכן לא נתפסו על ידי שומר מפתחות ההגדרות.
 ///
-/// היקף הסריקה: Hive boxes (בשם מילולי או דרך קבוע באותו קובץ), ומקומות
-/// שנבנים מ*שורש הנתונים* דרך `p.join`. שני דפוסים אינם בתחום ולא ייתפסו:
-/// נתיב שנבנה באינטרפולציה (`'$root/x'`), ו-`p.join` על משתנה שאין בשמו
-/// `dataRoot`. יעד שנבנה מנתיב בסיס אחר (יומני הריצה, שנופלים ל-temp כשאין
-/// שורש נתונים) אינו בתחום אף הוא.
+/// היקף הסריקה: Hive boxes (בשם מילולי או דרך קבוע, גם `Class.const` מקובץ
+/// אחר), ומקומות שנבנים מ*שורש הנתונים* דרך `p.join`. שני דפוסים אינם בתחום
+/// ולא ייתפסו: נתיב שנבנה באינטרפולציה (`'$root/x'`), ו-`p.join` על משתנה
+/// שאין בשמו `dataRoot`. יעד שנבנה מנתיב בסיס אחר (יומני הריצה, שנופלים
+/// ל-temp כשאין שורש נתונים) אינו בתחום אף הוא.
 void main() {
   /// שמות ה-Hive boxes שנפתחים בקוד: `openBox…('name')`.
   final boxPattern = RegExp(r"""openBox[^(]*\(\s*'([^']+)'""");
 
-  /// `openBox…(kBoxName)` — השם מגיע מקבוע, ונפתר מהצהרתו באותו קובץ.
+  /// `openBox…(kBoxName)` ו-`openBox…(Service.boxName)` — השם מגיע מקבוע,
+  /// ונפתר מהצהרתו בכל קובצי `lib`. בלי פתירה בין קבצים, box שנפתח דרך קבוע
+  /// של מחלקה אחרת נשמט מהסריקה כולה והשומר היה ירוק על מקום לא מוכרע.
   final boxViaIdentifierPattern = RegExp(
-    r"""openBox[^(]*\(\s*([A-Za-z_]\w*)\s*[,)]""",
+    r"""openBox[^(]*\(\s*(?:[A-Za-z_]\w*\s*\.\s*)?([A-Za-z_]\w*)\s*[,)]""",
+  );
+
+  /// הצהרת קבוע מחרוזת: `static const String kName = 'value';`
+  final constDeclarationPattern = RegExp(
+    r"""const\s+(?:String\s+)?([A-Za-z_]\w*)\s*=\s*'([^']+)'""",
   );
 
   /// תיקיות שנוצרות ישירות תחת שורש הנתונים: `p.join(<dataRoot>, 'name')`.
@@ -35,24 +42,36 @@ void main() {
   late Set<String> discovered;
 
   setUpAll(() {
-    final names = <String>{settingsBoxName};
+    final sources = <String>[];
     for (final file in Directory('lib').listSync(recursive: true)) {
       if (file is! File || !file.path.endsWith('.dart')) continue;
       // קוד מוערך אינו מקום שמירה קיים (`user_overrides` נוטרל בהערה).
-      final source = file
-          .readAsLinesSync()
-          .where((line) => !line.trimLeft().startsWith('//'))
-          .join('\n');
+      sources.add(
+        file
+            .readAsLinesSync()
+            .where((line) => !line.trimLeft().startsWith('//'))
+            .join('\n'),
+      );
+    }
+
+    // אותו שם קבוע מוצהר בכמה מחלקות (`queueBoxName` בשני שירותי הדיווחים),
+    // ולכן כל הערכים נאספים: עודף גילוי רק מחייב הכרעה, וזה הכיוון הבטוח.
+    final constants = <String, Set<String>>{};
+    for (final source in sources) {
+      for (final match in constDeclarationPattern.allMatches(source)) {
+        constants.putIfAbsent(match.group(1)!, () => {}).add(match.group(2)!);
+      }
+    }
+
+    final names = <String>{settingsBoxName};
+    for (final source in sources) {
       for (final pattern in [boxPattern, dataRootDirPattern]) {
         for (final match in pattern.allMatches(source)) {
           names.add(match.group(1)!);
         }
       }
       for (final match in boxViaIdentifierPattern.allMatches(source)) {
-        final resolved = RegExp(
-          RegExp.escape(match.group(1)!) + r"""\s*=\s*'([^']+)'""",
-        ).firstMatch(source);
-        if (resolved != null) names.add(resolved.group(1)!);
+        names.addAll(constants[match.group(1)!] ?? const <String>{});
       }
     }
     discovered = names;
@@ -70,6 +89,10 @@ void main() {
         'tabs',
         'per_book_settings',
         'plugins',
+        // נפתח דרך `DirectErrorReportService.queueBoxName` /
+        // `PluginReportService.queueBoxName` — פתירת קבוע בין קבצים.
+        'error_reports_queue',
+        'plugin_reports_queue',
       ]),
     );
   });

--- a/test/unit/settings/backup/backup_merge_test.dart
+++ b/test/unit/settings/backup/backup_merge_test.dart
@@ -122,6 +122,54 @@ void main() {
       });
     });
 
+    test('הדיווחים השמורים נלקחים מהחדש, ומהישן כשאין חדש', () {
+      final merged = merge(
+        {
+          'reportQueues': {
+            'error_reports_queue': {
+              'pending': [
+                {'id': 'old'},
+              ],
+              'sent': [],
+            },
+          },
+        },
+        {
+          'reportQueues': {
+            'error_reports_queue': {
+              'pending': [
+                {'id': 'new'},
+              ],
+              'sent': [],
+            },
+          },
+        },
+      );
+      expect(
+        merged['reportQueues']['error_reports_queue']['pending'],
+        [
+          {'id': 'new'},
+        ],
+      );
+
+      final fromOlder = merge({
+        'reportQueues': {
+          'error_reports_queue': {
+            'pending': [
+              {'id': 'old'},
+            ],
+            'sent': [],
+          },
+        },
+      }, const {});
+      expect(
+        fromOlder['reportQueues']['error_reports_queue']['pending'],
+        [
+          {'id': 'old'},
+        ],
+      );
+    });
+
     test('חתימת מקור ההגדרות נשמרת עם הסעיף שנבחר', () {
       expect(
         merge(


### PR DESCRIPTION
המשך ל-PR #789, שכיסה את עיקר issue #948: ההתאמות הפר-ספריות, הטאבים הפתוחים, זיהוי גיבוי מדור קודם ושומר הכיסוי. רוב הרשימה בסוגיה (גודל מפרשים, שולי עמוד, מצב רשימה בספרייה, מפתחות page_shape_*) נובעת מקובץ גיבוי שנוצר לפני שהגיבוי סרק את ה-Box (5d575d9b4), ואינה באג בקוד הנוכחי. שני דברים נשארו פתוחים.

error_reports_queue הוצהר ב-#789 כ"תור זמני — הדיווחים נשלחים והתור מתרוקן", אבל במצב לא-מקוון הוא מחזיק תוכן שהמשתמש כתב, ואיפוס הגדרות מוחק אותו — זה הפריט שנשאר נכון בדיווח. שני התורים (דיווחי טעות ודיווחי תוספים) נכנסים כעת לסעיף ההגדרות, לצד כתובת המייל שכבר נכנסה אליו.

השחזור ממזג ולא מחליף: דיווח שנוצר אחרי הגיבוי נשאר, ודיווח שכבר נשלח אינו חוזר לתור — בלי זה שחזור גיבוי ישן היה שולח שוב לצוות כל דיווח שנשלח מאז. המיזוג לארכיון מעביר את הסעיף כמו את ההגדרות: החדש מנצח.

plugin_reports_queue לא היה מוצהר כלל: סורק שומר הכיסוי פתר קבוע רק באותו קובץ, ולכן `PluginReportService.queueBoxName` נשמט מהסריקה כולה והשומר היה ירוק על מקום שמירה שלא הוכרע. הסורק פותר כעת גם `Class.const` בין קבצים, ושמות הקבועים של שני התורים נחשפו כדי שיהיה להם מקור אמת אחד.

# מה השינוי?

<!-- תיאור קצר וברור: מה ה-PR עושה ולמה. -->

## קישור לבעיה

Fixes #948 

## הצהרות התורם

- [x] אני מאשר שה-PR שלי עומד ב[תנאי התרומה המפורטים ב-README](https://github.com/Otzaria/otzaria/blob/dev/README.md#תנאי-תרומה-חובה-לקריאה)
- [ ] פיצ'ר חדש? — התייעצתי לפני כן (בפורום או ב-issue)
- [ ] שינוי UI? — צירפתי צילומי מסך לפני/אחרי בסוף התיאור
- [x] הרצתי `flutter analyze` על הקוד ואין שגיאות

## צילומי מסך (חובה בשינוי UI)

| לפני | אחרי |
|------|------|
|      |      |
