### PR TITLE
מיון הספרים בספרייה לפי הא"ב ללא הפרדה בין תיקיות לספרים בודדים

### DIFF
--- a/lib/library/view/library_browser.dart
+++ b/lib/library/view/library_browser.dart
@@ -129,7 +129,6 @@ List<FlatLibraryRow> buildFlatLibraryRows({
   required Category category,
   required Set<String> expandedPaths,
   required int Function(Category) topCategoryOrder,
-  required int Function(int) normalizeOrder,
   Set<String> talmudTextTitles = const {},
 }) {
   final rows = <FlatLibraryRow>[];
@@ -141,41 +140,41 @@ List<FlatLibraryRow> buildFlatLibraryRows({
               (b) => !isTalmudBavliPdfLibraryDuplicate(b, talmudTextTitles),
             )
             .toList()
-          ..sort((a, b) => a.order.compareTo(b.order));
-    final subs = current.subCategories.where((c) => c.hasBooks).toList();
-    if (current is Library) {
-      subs.sort((a, b) => topCategoryOrder(a).compareTo(topCategoryOrder(b)));
-    } else {
-      subs.sort(
-        (a, b) => normalizeOrder(a.order).compareTo(normalizeOrder(b.order)),
-      );
-    }
+          ..sort((a, b) => a.title.compareTo(b.title));
+    final entries = orderedCategoryChildren(
+      category: current,
+      books: books,
+      topCategoryOrder: topCategoryOrder,
+    );
 
-    for (final sub in subs) {
-      rows.add(
-        FlatLibraryRow(
-          kind: FlatLibraryRowKind.categoryHeader,
-          category: sub,
-          level: level,
-          parentPath: current.path,
-          isGroupStart: level == 0,
-        ),
-      );
-      if (expandedPaths.contains(sub.path)) {
-        collect(sub, level + 1);
+    var shownBooks = 0;
+    for (final entry in entries) {
+      if (entry is Category) {
+        rows.add(
+          FlatLibraryRow(
+            kind: FlatLibraryRowKind.categoryHeader,
+            category: entry,
+            level: level,
+            parentPath: current.path,
+            isGroupStart: level == 0,
+          ),
+        );
+        if (expandedPaths.contains(entry.path)) {
+          collect(entry, level + 1);
+        }
+        if (level == 0) {
+          rows.last.isGroupEnd = true;
+        }
+        continue;
       }
-      if (level == 0) {
-        rows.last.isGroupEnd = true;
-      }
-    }
-
-    for (int i = 0; i < books.length && i < _kCategoryBooksCap; i++) {
+      if (shownBooks >= _kCategoryBooksCap) continue;
+      shownBooks++;
       rows.add(
         FlatLibraryRow(
           kind: level == 0
               ? FlatLibraryRowKind.rootBook
               : FlatLibraryRowKind.book,
-          book: books[i],
+          book: entry as Book,
           level: level,
           parentPath: current.path,
         ),
@@ -196,6 +195,29 @@ List<FlatLibraryRow> buildFlatLibraryRows({
   collect(category, 0);
   return rows;
 }
+
+/// מאחד ספרים ותת-קטגוריות של קטגוריה אחת לרשימת פריטים מוינת אחת: בשורש
+/// הספרייה תתי-הקטגוריות שומרות על הסדר המסורתי הקבוע; בכל קטגוריה אחרת
+/// הפריטים ממוינים יחד לפי הא"ב של הכותרת, בלי הבדל בין תיקייה לספר בודד.
+@visibleForTesting
+List<Object> orderedCategoryChildren({
+  required Category category,
+  required List<Book> books,
+  required int Function(Category) topCategoryOrder,
+}) {
+  final subs = category.subCategories.where((c) => c.hasBooks).toList();
+  if (category is Library) {
+    subs.sort((a, b) => topCategoryOrder(a).compareTo(topCategoryOrder(b)));
+    final sortedBooks = books.toList()
+      ..sort((a, b) => a.order.compareTo(b.order));
+    return [...subs, ...sortedBooks];
+  }
+  return <Object>[...books, ...subs]
+    ..sort((a, b) => _categoryChildTitle(a).compareTo(_categoryChildTitle(b)));
+}
+
+String _categoryChildTitle(Object child) =>
+    child is Book ? child.title : (child as Category).title;
 
 /// מחשב רוחב תקין לחלונית התצוגה המקדימה לפי הרוחב הפנוי בספרייה.
 @visibleForTesting
@@ -1351,44 +1373,34 @@ class _LibraryBrowserState extends State<LibraryBrowser>
   }
 
   List<Widget> _buildCategoryContent(Category category) {
-    final List<Widget> items = [];
-    final filteredBooks = _visibleBooks(category.books);
-    final filteredSubCategories = category.subCategories
-        .where((c) => c.hasBooks)
-        .toList();
-    filteredBooks.sort((a, b) => a.order.compareTo(b.order));
-    if (category is Library) {
-      filteredSubCategories.sort(
-        (a, b) => _getTopCategoryOrder(a).compareTo(_getTopCategoryOrder(b)),
-      );
-    } else {
-      filteredSubCategories.sort(
-        (a, b) => _normalizeOrder(a.order).compareTo(_normalizeOrder(b.order)),
-      );
-    }
+    final filteredBooks = _visibleBooks(category.books)
+      ..sort((a, b) => a.title.compareTo(b.title));
+    final entries = orderedCategoryChildren(
+      category: category,
+      books: filteredBooks,
+      topCategoryOrder: _getTopCategoryOrder,
+    );
 
     // הפריט הראשון ברשת מקבל את צומת הפוקוס — כניסה מהחיפוש ב-Tab/חץ-מטה.
-    final allItems = <Widget>[
-      ...filteredSubCategories.indexed.map(
-        ((int, Category) entry) => KeyedSubtree(
-          key: _tourCategoryKeys.putIfAbsent(entry.$2.path, GlobalKey.new),
-          child: CategoryGridItem(
-            category: entry.$2,
-            onCategoryClickCallback: () => _openCategory(entry.$2),
-            focusNode: entry.$1 == 0 ? _firstGridItemFocusNode : null,
-          ),
-        ),
-      ),
-    ];
-
+    final allItems = <Widget>[];
     var attachedTourKey = false;
-    for (final (bookIndex, book) in filteredBooks.indexed) {
-      final item = _buildBookItem(
-        book,
-        focusNode: filteredSubCategories.isEmpty && bookIndex == 0
-            ? _firstGridItemFocusNode
-            : null,
-      );
+    for (final (index, entry) in entries.indexed) {
+      final focusNode = index == 0 ? _firstGridItemFocusNode : null;
+      if (entry is Category) {
+        allItems.add(
+          KeyedSubtree(
+            key: _tourCategoryKeys.putIfAbsent(entry.path, GlobalKey.new),
+            child: CategoryGridItem(
+              category: entry,
+              onCategoryClickCallback: () => _openCategory(entry),
+              focusNode: focusNode,
+            ),
+          ),
+        );
+        continue;
+      }
+      final book = entry as Book;
+      final item = _buildBookItem(book, focusNode: focusNode);
       final isTourBook =
           _tourPreviewBook != null &&
           !attachedTourKey &&
@@ -1405,13 +1417,12 @@ class _LibraryBrowserState extends State<LibraryBrowser>
         attachedTourKey = true;
       }
     }
-    items.add(
+    return [
       MyGridView(
         items: allItems,
         onExitTop: () => _refocusSearchBar(selectAll: true),
       ),
-    );
-    return items;
+    ];
   }
 
   Widget _buildBookItem(
@@ -1506,7 +1517,6 @@ class _LibraryBrowserState extends State<LibraryBrowser>
         category: category,
         expandedPaths: _expandedCategories,
         topCategoryOrder: _getTopCategoryOrder,
-        normalizeOrder: _normalizeOrder,
         talmudTextTitles: _talmudTextTitles(),
       );
 
@@ -1596,46 +1606,45 @@ class _LibraryBrowserState extends State<LibraryBrowser>
   }
 
   List<Widget> _buildCategoryTree(Category category, int level) {
-    final List<Widget> widgets = [];
+    final widgets = <Widget>[];
     final filteredBooks = _visibleBooks(category.books)
-      ..sort((a, b) => a.order.compareTo(b.order));
-    final filteredSubs = category.subCategories
-        .where((c) => c.hasBooks)
-        .toList();
-    if (category is Library) {
-      filteredSubs.sort(
-        (a, b) => _getTopCategoryOrder(a).compareTo(_getTopCategoryOrder(b)),
-      );
-    } else {
-      filteredSubs.sort(
-        (a, b) => _normalizeOrder(a.order).compareTo(_normalizeOrder(b.order)),
-      );
-    }
-    for (final sub in filteredSubs) {
-      final isExpanded = _expandedCategories.contains(sub.path);
-      final subChildren = isExpanded
-          ? _buildCategoryTree(sub, level + 1)
-          : <Widget>[];
-      if (level == 0) {
+      ..sort((a, b) => a.title.compareTo(b.title));
+    final entries = orderedCategoryChildren(
+      category: category,
+      books: filteredBooks,
+      topCategoryOrder: _getTopCategoryOrder,
+    );
+
+    var shownBooks = 0;
+    for (final entry in entries) {
+      if (entry is Category) {
+        final isExpanded = _expandedCategories.contains(entry.path);
+        final subChildren = isExpanded
+            ? _buildCategoryTree(entry, level + 1)
+            : <Widget>[];
         widgets.add(
-          ExpandableCard(
-            key: ValueKey(sub.path),
-            header: _buildCategoryHeaderRow(sub, level, isExpanded),
-            isExpanded: isExpanded,
-            margin: const EdgeInsets.symmetric(vertical: 2),
-            children: subChildren,
-          ),
+          level == 0
+              ? ExpandableCard(
+                  key: ValueKey(entry.path),
+                  header: _buildCategoryHeaderRow(entry, level, isExpanded),
+                  isExpanded: isExpanded,
+                  margin: const EdgeInsets.symmetric(vertical: 2),
+                  children: subChildren,
+                )
+              : _buildNestedCategorySection(
+                  entry,
+                  level,
+                  isExpanded,
+                  subChildren,
+                ),
         );
-      } else {
-        widgets.add(
-          _buildNestedCategorySection(sub, level, isExpanded, subChildren),
-        );
+        continue;
       }
-    }
-    for (int i = 0; i < filteredBooks.length && i < _kCategoryBooksCap; i++) {
+      if (shownBooks >= _kCategoryBooksCap) continue;
+      shownBooks++;
       widgets.add(
         _buildListBookItem(
-          filteredBooks[i],
+          entry as Book,
           level,
           itemStyle: level == 0
               ? _LibraryListItemStyle.root
@@ -2100,21 +2109,15 @@ class _LibraryBrowserState extends State<LibraryBrowser>
   /// מחזיר את הספר הראשון שיוצג בפועל בקטגוריה, לפי אותו סדר תצוגה כמו _buildCategoryContent
   Book? _getFirstDisplayedBook(Category category) {
     final books = _visibleBooks(category.books)
-      ..sort((a, b) => a.order.compareTo(b.order));
-    if (books.isNotEmpty) return books.first;
-
-    final subs = category.subCategories.toList();
-    if (category is Library) {
-      subs.sort(
-        (a, b) => _getTopCategoryOrder(a).compareTo(_getTopCategoryOrder(b)),
-      );
-    } else {
-      subs.sort(
-        (a, b) => _normalizeOrder(a.order).compareTo(_normalizeOrder(b.order)),
-      );
-    }
-    for (final sub in subs) {
-      final book = _getFirstDisplayedBook(sub);
+      ..sort((a, b) => a.title.compareTo(b.title));
+    final entries = orderedCategoryChildren(
+      category: category,
+      books: books,
+      topCategoryOrder: _getTopCategoryOrder,
+    );
+    for (final entry in entries) {
+      if (entry is Book) return entry;
+      final book = _getFirstDisplayedBook(entry as Category);
       if (book != null) return book;
     }
     return null;

--- a/test/library/view/library_browser_flat_tree_test.dart
+++ b/test/library/view/library_browser_flat_tree_test.dart
@@ -42,8 +42,6 @@ int Function(Category) _topOrderOf(List<String> orderedTitles) => (category) {
   return idx >= 0 ? idx : orderedTitles.length + category.order;
 };
 
-int _normalizeOrder(int order) => order >= 0 ? order : 1000 + order.abs();
-
 List<FlatLibraryRow> _rows(
   Category root, {
   Set<String> expanded = const {},
@@ -53,7 +51,6 @@ List<FlatLibraryRow> _rows(
   category: root,
   expandedPaths: expanded,
   topCategoryOrder: _topOrderOf(topOrder),
-  normalizeOrder: _normalizeOrder,
   talmudTextTitles: talmudTextTitles,
 );
 
@@ -98,7 +95,7 @@ void main() {
     });
 
     test(
-      'קטגוריה מורחבת: תת-קטגוריות לפני ספרים, ממוינים, ודגלי קצה נכונים',
+      'קטגוריה מורחבת: ספרים ותתי-קטגוריות ממוינים יחד לפי הא"ב, ודגלי קצה נכונים',
       () {
         final expanded = _category(
           'הלכה',
@@ -119,16 +116,19 @@ void main() {
           rows.map((r) => r.kind).toList(),
           [
             FlatLibraryRowKind.categoryHeader, // הלכה
-            FlatLibraryRowKind.categoryHeader, // פסק (order 1)
-            FlatLibraryRowKind.categoryHeader, // שו"ת (order 2)
-            FlatLibraryRowKind.book, // ספר מוקדם
             FlatLibraryRowKind.book, // ספר מאוחר
+            FlatLibraryRowKind.book, // ספר מוקדם
+            FlatLibraryRowKind.categoryHeader, // פסק
+            FlatLibraryRowKind.categoryHeader, // שו"ת
           ],
+          reason:
+              'הסדר לפי הא"ב של הכותרת — "order" הכתוב היה נותן פסק לפני שו"ת '
+              'וספר מוקדם לפני ספר מאוחר, ולא זה הסדר שהתקבל',
         );
-        expect(rows[1].category!.title, 'פסק');
-        expect(rows[2].category!.title, 'שו"ת');
-        expect(rows[3].book!.title, 'ספר מוקדם');
-        expect(rows[4].book!.title, 'ספר מאוחר');
+        expect(rows[1].book!.title, 'ספר מאוחר');
+        expect(rows[2].book!.title, 'ספר מוקדם');
+        expect(rows[3].category!.title, 'פסק');
+        expect(rows[4].category!.title, 'שו"ת');
 
         expect(rows.first.isGroupStart, isTrue);
         expect(rows.first.isGroupEnd, isFalse);
@@ -169,20 +169,23 @@ void main() {
       final root = _library([big]);
 
       final rows = _rows(root, expanded: {big.path});
+      final sortedTitles = books.map((b) => b.title).toList()..sort();
 
       final bookRows = rows
           .where((r) => r.kind == FlatLibraryRowKind.book)
           .toList();
       expect(bookRows, hasLength(500));
-      expect(bookRows.first.book!.title, 'ספר 0');
-      expect(bookRows.last.book!.title, 'ספר 499');
+      expect(
+        bookRows.map((r) => r.book!.title).toList(),
+        sortedTitles.take(500),
+      );
 
       final showMore = rows.last;
       expect(showMore.kind, FlatLibraryRowKind.showMore);
       expect(
-        showMore.showMoreBooks,
-        hasLength(502),
-        reason: 'דיאלוג "הצג עוד" מקבל את הרשימה המלאה',
+        showMore.showMoreBooks!.map((b) => b.title).toList(),
+        sortedTitles,
+        reason: 'דיאלוג "הצג עוד" מקבל את הרשימה המלאה, ממוינת לפי הא"ב',
       );
       expect(
         showMore.isGroupEnd,


### PR DESCRIPTION
## מה השתנה

במסך הספרייה, ספרים ותת-קטגוריות (תיקיות) בכל קטגוריה מוינו עד כה בנפרד: כל תת-הקטגוריות הוצגו לפני כל הספרים, כל קבוצה ממוינת בנפרד לפי שדה `order` פנימי. השינוי מאחד את שני הסוגים לרשימת תצוגה אחת, ממוינת לפי א"ב הכותרת — בלי הבדל בין תיקייה לספר בודד. לדוגמה, הספר "משנה ברורה" יופיע כעת לפני התיקייה "פלתי", כי מ' קודמת ל-פ'.

הקטגוריות העליונות בשורש הספרייה (תנ"ך / משנה / תלמוד וכו') ממשיכות לשמור על הסדר המסורתי הקבוע כרגיל — השינוי חל רק בתוך קטגוריה ספציפית.

## איך זה עובד

נוספה פונקציית עזר משותפת `orderedCategoryChildren` ב-`lib/library/view/library_browser.dart`, שמאחדת ספרים ותת-קטגוריות של קטגוריה נתונה לרשימה אחת ממוינת. שלוש תצוגות הספרייה (רשת, עץ מקונן, עץ משוטח) ופונקציית איתור הספר הראשון להצגה משתמשות בה כעת במקום במיון נפרד לכל סוג.

## בדיקות

- `flutter analyze` — ללא שגיאות.
- `flutter test test/library/view/library_browser_flat_tree_test.dart test/library/view/library_grid_keyboard_navigation_test.dart test/library/view/grid_items_test.dart` — כל 40 הבדיקות עברו. הבדיקות שהניחו סדר "תיקיות לפני ספרים" לפי `order` עודכנו למיון א"ב מאוחד.

🤖 Generated with [Claude Code](https://claude.com/claude-code)