### PR TITLE
תיקון ניגודיות בערכת "לבן": כתב בהיר על רקעים כהים של primaryContainer

### DIFF
--- a/lib/text_book/view/text_book_search_screen.dart
+++ b/lib/text_book/view/text_book_search_screen.dart
@@ -1124,8 +1124,10 @@ class TextBookSearchViewState extends State<TextBookSearchView>
           child: Icon(
             icon,
             size: 16,
+            // בערכת "לבן" רקע הכפתור (primaryContainer) כהה במיוחד — החץ
+            // חייב להיות onPrimaryContainer (בהיר) כדי להיראות עליו.
             color: isEnabled
-                ? colorScheme.primary
+                ? colorScheme.onPrimaryContainer
                 : colorScheme.onSurfaceVariant,
           ),
         ),

--- a/lib/text_book/view/text_book_search_screen.dart
+++ b/lib/text_book/view/text_book_search_screen.dart
@@ -400,10 +400,7 @@ class TextBookSearchViewState extends State<TextBookSearchView>
 
       final effectiveResults = widget.simpleSearchRunner != null
           ? await widget.simpleSearchRunner!(content, query)
-          : await searchInContent(
-              content: content,
-              query: query,
-            );
+          : await searchInContent(content: content, query: query);
 
       if (mounted && requestId == _activeSearchRequestId) {
         _applySearchResults(effectiveResults);
@@ -1068,11 +1065,7 @@ class TextBookSearchViewState extends State<TextBookSearchView>
         (_selectedSearchResultIndex ?? 0) >= searchResults.length - 1;
 
     return Padding(
-      padding: const EdgeInsetsDirectional.only(
-        start: 12,
-        end: 12,
-        bottom: 2,
-      ),
+      padding: const EdgeInsetsDirectional.only(start: 12, end: 12, bottom: 2),
       child: Align(
         alignment: AlignmentDirectional.centerEnd,
         child: Row(
@@ -1124,8 +1117,6 @@ class TextBookSearchViewState extends State<TextBookSearchView>
           child: Icon(
             icon,
             size: 16,
-            // בערכת "לבן" רקע הכפתור (primaryContainer) כהה במיוחד — החץ
-            // חייב להיות onPrimaryContainer (בהיר) כדי להיראות עליו.
             color: isEnabled
                 ? colorScheme.onPrimaryContainer
                 : colorScheme.onSurfaceVariant,

--- a/lib/tools/calendar/widgets/calendar_day_cell.dart
+++ b/lib/tools/calendar/widgets/calendar_day_cell.dart
@@ -189,6 +189,7 @@ Widget buildDayCell(
                                   : (compactCell ? 1 : 2),
                               compact: compactCell,
                               additionalInfoLines: additionalInfoLines,
+                              isSelected: isSelected,
                             ),
                           ),
                         ),
@@ -213,6 +214,11 @@ class DayExtras extends StatelessWidget {
   final bool compact;
   final List<String> additionalInfoLines;
 
+  /// האם התא נבחר — אז הוא צבוע ב-primaryContainer, וכל שורות הטקסט בתוכו
+  /// חייבות לעבור ל-onPrimaryContainer (בערכות monochrome כמו "לבן" הרקע
+  /// כהה במיוחד וכתב onSurface היה נעלם עליו).
+  final bool isSelected;
+
   const DayExtras({
     super.key,
     required this.jewishCalendar,
@@ -220,6 +226,7 @@ class DayExtras extends StatelessWidget {
     this.maxVisibleItems = 2,
     this.compact = false,
     this.additionalInfoLines = const [],
+    this.isSelected = false,
   });
 
   @override
@@ -228,6 +235,7 @@ class DayExtras extends StatelessWidget {
       return const SizedBox.shrink();
     }
 
+    final cs = Theme.of(context).colorScheme;
     final cubit = context.read<CalendarCubit>();
     final events = cubit.eventsForDate(date);
     final List<Widget> lines = [];
@@ -242,7 +250,7 @@ class DayExtras extends StatelessWidget {
           overflow: TextOverflow.ellipsis,
           style: TextStyle(
             fontSize: compact ? 10 : 11,
-            color: Theme.of(context).colorScheme.onSurface,
+            color: isSelected ? cs.onPrimaryContainer : cs.onSurface,
             fontWeight: FontWeight.w500,
           ),
         ),
@@ -254,7 +262,7 @@ class DayExtras extends StatelessWidget {
     for (final e in events.take(remainingSlots.clamp(0, maxVisibleItems))) {
       final dotColor =
           CalendarEventColors.colorForIndex(e.displayColorIndex, brightness) ??
-          Theme.of(context).colorScheme.onSurfaceVariant;
+          cs.onSurfaceVariant;
       visibleItems.add(
         Text.rich(
           TextSpan(
@@ -270,7 +278,9 @@ class DayExtras extends StatelessWidget {
           overflow: TextOverflow.ellipsis,
           style: TextStyle(
             fontSize: compact ? 9 : 10,
-            color: Theme.of(context).colorScheme.onSurfaceVariant,
+            color: isSelected
+                ? cs.onPrimaryContainer.withValues(alpha: 0.85)
+                : cs.onSurfaceVariant,
           ),
         ),
       );
@@ -287,7 +297,7 @@ class DayExtras extends StatelessWidget {
           overflow: TextOverflow.ellipsis,
           style: TextStyle(
             fontSize: compact ? 9 : 10,
-            color: Theme.of(context).colorScheme.primary,
+            color: isSelected ? cs.onPrimaryContainer : cs.primary,
             fontWeight: FontWeight.w600,
           ),
         ),

--- a/lib/tools/calendar/widgets/calendar_day_cell.dart
+++ b/lib/tools/calendar/widgets/calendar_day_cell.dart
@@ -214,9 +214,7 @@ class DayExtras extends StatelessWidget {
   final bool compact;
   final List<String> additionalInfoLines;
 
-  /// האם התא נבחר — אז הוא צבוע ב-primaryContainer, וכל שורות הטקסט בתוכו
-  /// חייבות לעבור ל-onPrimaryContainer (בערכות monochrome כמו "לבן" הרקע
-  /// כהה במיוחד וכתב onSurface היה נעלם עליו).
+  /// האם התא נבחר, ולכן התוכן משתמש ב-onPrimaryContainer.
   final bool isSelected;
 
   const DayExtras({
@@ -257,12 +255,15 @@ class DayExtras extends StatelessWidget {
       );
     }
 
-    final brightness = Theme.of(context).brightness;
     var remainingSlots = maxVisibleItems - visibleItems.length;
     for (final e in events.take(remainingSlots.clamp(0, maxVisibleItems))) {
-      final dotColor =
-          CalendarEventColors.colorForIndex(e.displayColorIndex, brightness) ??
-          cs.onSurfaceVariant;
+      final dotColor = isSelected
+          ? cs.onPrimaryContainer
+          : CalendarEventColors.colorForIndex(
+                  e.displayColorIndex,
+                  Theme.of(context).brightness,
+                ) ??
+                cs.onSurfaceVariant;
       visibleItems.add(
         Text.rich(
           TextSpan(
@@ -278,9 +279,7 @@ class DayExtras extends StatelessWidget {
           overflow: TextOverflow.ellipsis,
           style: TextStyle(
             fontSize: compact ? 9 : 10,
-            color: isSelected
-                ? cs.onPrimaryContainer.withValues(alpha: 0.85)
-                : cs.onSurfaceVariant,
+            color: isSelected ? cs.onPrimaryContainer : cs.onSurfaceVariant,
           ),
         ),
       );

--- a/lib/widgets/smart_text/raised_markers.dart
+++ b/lib/widgets/smart_text/raised_markers.dart
@@ -319,10 +319,7 @@ class RaisedMarkerOverlay extends SingleChildRenderObjectWidget {
   /// רקע הציור של אות מפרש פעילה ([RaisedMarker.active]).
   final Color? activeBackground;
 
-  /// צבע הכתב של אות מפרש פעילה — מנוגד ל-[activeBackground] (בד"כ
-  /// onPrimaryContainer). בערכות monochrome (כמו "לבן") primaryContainer עלול
-  /// להיות כהה, ולכן הכתב חייב להיגזר ממנו ולא מצבע הקישור. null — נופל
-  /// לצבע הקישור.
+  /// צבע האות הפעילה; ברירת המחדל היא onPrimaryContainer.
   final Color? activeForeground;
 
   const RaisedMarkerOverlay({
@@ -533,8 +530,6 @@ class RenderRaisedMarkerOverlay extends RenderProxyBox {
           fontWeight: FontWeight.bold,
           fontVariations: AppFonts.boldFontVariations(style.fontFamily),
           backgroundColor: _activeBackground,
-          // אות פעילה על רקע כהה חייבת כתב בהיר (onPrimaryContainer),
-          // אחרת היא נבלעת ברקע בערכות monochrome כמו "לבן".
           color: _activeForeground ?? style.color,
         );
       } else if (marker.active) {
@@ -585,10 +580,9 @@ class RenderRaisedMarkerOverlay extends RenderProxyBox {
     super.paint(context, offset);
     if (child == null || _markers.isEmpty) return;
     for (final placement in _resolvePlacements()) {
-      _painterFor(placement.marker).paint(
-        context.canvas,
-        offset + placement.paintRect.topLeft,
-      );
+      _painterFor(
+        placement.marker,
+      ).paint(context.canvas, offset + placement.paintRect.topLeft);
     }
   }
 

--- a/lib/widgets/smart_text/raised_markers.dart
+++ b/lib/widgets/smart_text/raised_markers.dart
@@ -319,12 +319,19 @@ class RaisedMarkerOverlay extends SingleChildRenderObjectWidget {
   /// רקע הציור של אות מפרש פעילה ([RaisedMarker.active]).
   final Color? activeBackground;
 
+  /// צבע הכתב של אות מפרש פעילה — מנוגד ל-[activeBackground] (בד"כ
+  /// onPrimaryContainer). בערכות monochrome (כמו "לבן") primaryContainer עלול
+  /// להיות כהה, ולכן הכתב חייב להיגזר ממנו ולא מצבע הקישור. null — נופל
+  /// לצבע הקישור.
+  final Color? activeForeground;
+
   const RaisedMarkerOverlay({
     super.key,
     required this.markers,
     required this.baseStyle,
     this.linkColor,
     this.activeBackground,
+    this.activeForeground,
     required super.child,
   });
 
@@ -341,6 +348,7 @@ class RaisedMarkerOverlay extends SingleChildRenderObjectWidget {
     required Widget child,
     Color? linkColor,
     Color? activeBackground,
+    Color? activeForeground,
   }) {
     if (markers.isEmpty) return child;
     final colorScheme = Theme.of(context).colorScheme;
@@ -356,6 +364,7 @@ class RaisedMarkerOverlay extends SingleChildRenderObjectWidget {
       baseStyle: style,
       linkColor: linkColor ?? colorScheme.primary,
       activeBackground: activeBackground ?? colorScheme.primaryContainer,
+      activeForeground: activeForeground ?? colorScheme.onPrimaryContainer,
       child: child,
     );
   }
@@ -367,6 +376,7 @@ class RaisedMarkerOverlay extends SingleChildRenderObjectWidget {
         baseStyle,
         linkColor,
         activeBackground,
+        activeForeground,
       );
 
   @override
@@ -378,7 +388,8 @@ class RaisedMarkerOverlay extends SingleChildRenderObjectWidget {
       ..markers = markers
       ..baseStyle = baseStyle
       ..linkColor = linkColor
-      ..activeBackground = activeBackground;
+      ..activeBackground = activeBackground
+      ..activeForeground = activeForeground;
   }
 }
 
@@ -408,12 +419,14 @@ class RenderRaisedMarkerOverlay extends RenderProxyBox {
     this._baseStyle,
     this._linkColor,
     this._activeBackground,
+    this._activeForeground,
   ) : _hasClickableMarkers = _markers.any((marker) => marker.clickable);
 
   List<RaisedMarker> _markers;
   TextStyle _baseStyle;
   Color? _linkColor;
   Color? _activeBackground;
+  Color? _activeForeground;
 
   // מחושב פעם אחת: קטע בלי סימונים לחיצים לא משלם דבר על hit-test.
   bool _hasClickableMarkers;
@@ -455,6 +468,13 @@ class RenderRaisedMarkerOverlay extends RenderProxyBox {
   set activeBackground(Color? value) {
     if (value == _activeBackground) return;
     _activeBackground = value;
+    _disposePainters();
+    markNeedsPaint();
+  }
+
+  set activeForeground(Color? value) {
+    if (value == _activeForeground) return;
+    _activeForeground = value;
     _disposePainters();
     markNeedsPaint();
   }
@@ -508,11 +528,19 @@ class RenderRaisedMarkerOverlay extends RenderProxyBox {
       if (marker.useLinkColor && _linkColor != null) {
         style = style.copyWith(color: _linkColor);
       }
-      if (marker.active) {
+      if (marker.active && _activeBackground != null) {
         style = style.copyWith(
           fontWeight: FontWeight.bold,
           fontVariations: AppFonts.boldFontVariations(style.fontFamily),
           backgroundColor: _activeBackground,
+          // אות פעילה על רקע כהה חייבת כתב בהיר (onPrimaryContainer),
+          // אחרת היא נבלעת ברקע בערכות monochrome כמו "לבן".
+          color: _activeForeground ?? style.color,
+        );
+      } else if (marker.active) {
+        style = style.copyWith(
+          fontWeight: FontWeight.bold,
+          fontVariations: AppFonts.boldFontVariations(style.fontFamily),
         );
       }
       final painter = TextPainter(

--- a/test/theme/app_theme_data_test.dart
+++ b/test/theme/app_theme_data_test.dart
@@ -7,9 +7,8 @@ import 'package:otzaria/theme/app_theme_data.dart';
 
 /// ניגודיות WCAG בין שני צבעים (יחס בהירות).
 double _contrastRatio(Color a, Color b) {
-  double linear(double v) => v <= 0.03928
-      ? v / 12.92
-      : math.pow((v + 0.055) / 1.055, 2.4).toDouble();
+  double linear(double v) =>
+      v <= 0.03928 ? v / 12.92 : math.pow((v + 0.055) / 1.055, 2.4).toDouble();
   final la = 0.2126 * linear(a.r) + 0.7152 * linear(a.g) + 0.0722 * linear(a.b);
   final lb = 0.2126 * linear(b.r) + 0.7152 * linear(b.g) + 0.0722 * linear(b.b);
   final lighter = math.max(la, lb);
@@ -73,16 +72,10 @@ void main() {
     });
 
     test('primaryContainer/onPrimaryContainer תמיד קריאים (ניגודיות WCAG)', () {
-      // השורה הנבחרת באיתור, חצי דפדוף תוצאות ואות המפרש הפעילה צובעים
-      // רקע ב-primaryContainer וכתב ב-onPrimaryContainer. בערכת "לבן"
-      // (ו-monochrome בכלל) primaryContainer כהה במיוחד במצב בהיר, ולכן
-      // חייבים לוודא שהזיווג נשאר קריא בכל הצבעים ובשני המצבים.
+      // רכיבים נבחרים משתמשים בזוג צבעים זה.
       for (final option in AppSeedColors.options) {
         for (final brightness in Brightness.values) {
-          final cs = AppThemeData.createColorScheme(
-            option.color,
-            brightness,
-          );
+          final cs = AppThemeData.createColorScheme(option.color, brightness);
           final ratio = _contrastRatio(
             cs.primaryContainer,
             cs.onPrimaryContainer,
@@ -100,9 +93,7 @@ void main() {
     });
 
     test('הזיווג primaryContainer/onSurface כהה-על-כהה אסור בערכת "לבן"', () {
-      // ערכת "לבן" במצב בהיר נותנת primaryContainer כהה (#3B3B3B) — לכן אסור
-      // לצבוע עליו טקסט ב-onSurface (שחור). זה התרחיש שתוקן באיתור ובחצי
-      // הדפדוף: הכתב חייב לעבור ל-onPrimaryContainer.
+      // בערכת "לבן" הבהירה onSurface אינו צבע קדמי מתאים לרקע זה.
       final cs = AppThemeData.createColorScheme(
         AppSeedColors.white,
         Brightness.light,
@@ -118,16 +109,10 @@ void main() {
     });
 
     test('secondaryContainer עם onSurface/onSurfaceVariant תמיד קריא', () {
-      // סריקת כל הצבעים והמצבים מראה ש-secondaryContainer הוא תמיד בהיר
-      // במצב בהיר וכהה במצב כהה (בניגוד ל-primaryContainer בערכות monochrome),
-      // ולכן כתב עליו ב-onSurface/onSurfaceVariant נשאר קריא בכל הצבעים —
-      // אין צורך להמירו ל-onSecondaryContainer.
+      // רכיבים על secondaryContainer משתמשים בזוגות צבעים אלה.
       for (final option in AppSeedColors.options) {
         for (final brightness in Brightness.values) {
-          final cs = AppThemeData.createColorScheme(
-            option.color,
-            brightness,
-          );
+          final cs = AppThemeData.createColorScheme(option.color, brightness);
           for (final pair in [
             (cs.secondaryContainer, cs.onSurface),
             (cs.secondaryContainer, cs.onSurfaceVariant),

--- a/test/theme/app_theme_data_test.dart
+++ b/test/theme/app_theme_data_test.dart
@@ -1,7 +1,21 @@
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:otzaria/theme/app_seed_colors.dart';
 import 'package:otzaria/theme/app_theme_data.dart';
+
+/// ניגודיות WCAG בין שני צבעים (יחס בהירות).
+double _contrastRatio(Color a, Color b) {
+  double linear(double v) => v <= 0.03928
+      ? v / 12.92
+      : math.pow((v + 0.055) / 1.055, 2.4).toDouble();
+  final la = 0.2126 * linear(a.r) + 0.7152 * linear(a.g) + 0.0722 * linear(a.b);
+  final lb = 0.2126 * linear(b.r) + 0.7152 * linear(b.g) + 0.0722 * linear(b.b);
+  final lighter = math.max(la, lb);
+  final darker = math.min(la, lb);
+  return (lighter + 0.05) / (darker + 0.05);
+}
 
 void main() {
   for (final brightness in Brightness.values) {
@@ -55,6 +69,79 @@ void main() {
           Brightness.light,
         );
         expect(cs.surface, isNot(Colors.white), reason: option.name);
+      }
+    });
+
+    test('primaryContainer/onPrimaryContainer תמיד קריאים (ניגודיות WCAG)', () {
+      // השורה הנבחרת באיתור, חצי דפדוף תוצאות ואות המפרש הפעילה צובעים
+      // רקע ב-primaryContainer וכתב ב-onPrimaryContainer. בערכת "לבן"
+      // (ו-monochrome בכלל) primaryContainer כהה במיוחד במצב בהיר, ולכן
+      // חייבים לוודא שהזיווג נשאר קריא בכל הצבעים ובשני המצבים.
+      for (final option in AppSeedColors.options) {
+        for (final brightness in Brightness.values) {
+          final cs = AppThemeData.createColorScheme(
+            option.color,
+            brightness,
+          );
+          final ratio = _contrastRatio(
+            cs.primaryContainer,
+            cs.onPrimaryContainer,
+          );
+          expect(
+            ratio,
+            greaterThanOrEqualTo(4.5),
+            reason:
+                '${option.name} $brightness: primaryContainer '
+                '${cs.primaryContainer} מול onPrimaryContainer '
+                '${cs.onPrimaryContainer} — ניגודיות $ratio',
+          );
+        }
+      }
+    });
+
+    test('הזיווג primaryContainer/onSurface כהה-על-כהה אסור בערכת "לבן"', () {
+      // ערכת "לבן" במצב בהיר נותנת primaryContainer כהה (#3B3B3B) — לכן אסור
+      // לצבוע עליו טקסט ב-onSurface (שחור). זה התרחיש שתוקן באיתור ובחצי
+      // הדפדוף: הכתב חייב לעבור ל-onPrimaryContainer.
+      final cs = AppThemeData.createColorScheme(
+        AppSeedColors.white,
+        Brightness.light,
+      );
+      final ratio = _contrastRatio(cs.primaryContainer, cs.onSurface);
+      expect(
+        ratio,
+        lessThan(3.0),
+        reason:
+            'primaryContainer ${cs.primaryContainer} עם onSurface '
+            '${cs.onSurface} חייב להישאר בלתי-קריא כדי למנוע שימוש בטעות',
+      );
+    });
+
+    test('secondaryContainer עם onSurface/onSurfaceVariant תמיד קריא', () {
+      // סריקת כל הצבעים והמצבים מראה ש-secondaryContainer הוא תמיד בהיר
+      // במצב בהיר וכהה במצב כהה (בניגוד ל-primaryContainer בערכות monochrome),
+      // ולכן כתב עליו ב-onSurface/onSurfaceVariant נשאר קריא בכל הצבעים —
+      // אין צורך להמירו ל-onSecondaryContainer.
+      for (final option in AppSeedColors.options) {
+        for (final brightness in Brightness.values) {
+          final cs = AppThemeData.createColorScheme(
+            option.color,
+            brightness,
+          );
+          for (final pair in [
+            (cs.secondaryContainer, cs.onSurface),
+            (cs.secondaryContainer, cs.onSurfaceVariant),
+          ]) {
+            final ratio = _contrastRatio(pair.$1, pair.$2);
+            expect(
+              ratio,
+              greaterThanOrEqualTo(4.5),
+              reason:
+                  '${option.name} $brightness: secondaryContainer '
+                  '${pair.$1} מול ${pair.$2} — ניגודיות $ratio',
+            );
+          }
+        }
       }
     });
   });

--- a/test/tools/calendar/widgets/calendar_events_order_test.dart
+++ b/test/tools/calendar/widgets/calendar_events_order_test.dart
@@ -7,6 +7,8 @@ import 'package:flutter_settings_screens/flutter_settings_screens.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:kosher_dart/kosher_dart.dart';
 import 'package:otzaria/settings/settings_exports.dart';
+import 'package:otzaria/theme/app_seed_colors.dart';
+import 'package:otzaria/theme/app_theme_data.dart';
 import 'package:otzaria/tools/calendar/services/google_calendar_service.dart';
 import 'package:otzaria/tools/calendar/services/notification_service.dart';
 import 'package:otzaria/tools/calendar/utils/calendar_cubit.dart';
@@ -216,10 +218,11 @@ void main() {
 
       await pumpEventsPanel(tester);
 
-      expect(
-        _verticalOrder(tester, ['מחר בבוקר', 'היום בערב', 'היום בבוקר']),
-        ['היום בבוקר', 'היום בערב', 'מחר בבוקר'],
-      );
+      expect(_verticalOrder(tester, ['מחר בבוקר', 'היום בערב', 'היום בבוקר']), [
+        'היום בבוקר',
+        'היום בערב',
+        'מחר בבוקר',
+      ]);
     });
   });
 
@@ -261,6 +264,48 @@ void main() {
   });
 
   group('DayExtras — אירועי תא היום', () {
+    testWidgets('בתא נבחר נקודת אירוע נשארת קריאה', (tester) async {
+      await cubit.addEvent(
+        title: 'אירוע צבעוני',
+        baseGregorianDate: _date,
+        recurrenceType: RecurrenceType.none,
+        colorIndex: 2,
+      );
+
+      final colorScheme = AppThemeData.createColorScheme(
+        AppSeedColors.white,
+        Brightness.dark,
+      );
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: AppThemeData.dark(colorScheme, compactMenuMode: false),
+          home: BlocProvider.value(
+            value: cubit,
+            child: Scaffold(
+              body: DayExtras(
+                jewishCalendar: JewishCalendar.fromDateTime(_date)
+                  ..inIsrael = true,
+                date: _date,
+                maxVisibleItems: 1,
+                isSelected: true,
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final eventSpan = tester
+          .widgetList<RichText>(find.byType(RichText))
+          .map((richText) => richText.text as TextSpan)
+          .singleWhere((span) => span.toPlainText().contains('אירוע צבעוני'));
+      final contentSpan = eventSpan.children!.single as TextSpan;
+      final dot = contentSpan.children!.whereType<TextSpan>().singleWhere(
+        (span) => span.text == '• ',
+      );
+      expect(dot.style?.color, colorScheme.onPrimaryContainer);
+    });
+
     testWidgets('כשיש יותר אירועים מהמקום — מוצגים המוקדמים בזמן', (
       tester,
     ) async {


### PR DESCRIPTION
משלים את PR #809 (ערכת הצבעים "לבן") — החלק שהיה חסר שם: **כתב בהיר על רקעים כהים של `primaryContainer`**.

### הבעיה
בערכת "לבן" (מונוכרום) הרקע `primaryContainer` יוצא **אפור כהה (#3B3B3B)** במצב בהיר (במקום גוון בהיר רגיל), ובכמה מקומות נצבע עליו כתב/אייקונים בשחור (`onSurface`/`primary`) — טקסט שחור על רקע כהה, בלתי קריא.

### התיקונים (commit `fc82534f`)
1. **מסך האיתור** — השורה הנבחרת: שני הטקסטים (הכותרת והנתיב), אייקון ה-PDF ואייקון המפרשים עוברים ל-`onPrimaryContainer`.
2. **חיצי הדפדוף** בתוצאות חיפוש בתוך ספר — החץ הפעיל עובר ל-`onPrimaryContainer`.
3. **אות המפרש הפעילה** (`RaisedMarkerOverlay`) — פרמטר חדש `activeForeground` (ברירת מחדל `onPrimaryContainer`), בשימוש רק כשיש רקע פעיל.
4. **לוח שנה** — שורות האירועים בתא היום הנבחר עוברות ל-`onPrimaryContainer` (דגל חדש `isSelected` ב-`DayExtras`).

### בדיקות רגרסיה (`test/theme/app_theme_data_test.dart`)
- ניגודיות WCAG AA (≥ 4.5) של הזיווג `primaryContainer`/`onPrimaryContainer` בכל 14 צבעי הזרע ובשני המצבים — הזיווג שהתיקונים נשענים עליו.
- תיעוד שזיווג `primaryContainer`/`onSurface` בערכת "לבן" בהירה נשאר < 3.0 — כדי שאף אחד לא יחזיר את הכתב השחור.
- תיעוד ש-`secondaryContainer` תמיד קריא (≥ 4.5 עם `onSurface`) בכל הצבעים — לכן שם לא נדרש תיקון.

כל הבדיקות עוברות (`flutter analyze` נקי).