### PR TITLE
תיקון issue #976 — טקסט המפרשים בצורת הדף רעד בסימון הטקסט הראשי

### DIFF
--- a/lib/text_book/bloc/text_book_state.dart
+++ b/lib/text_book/bloc/text_book_state.dart
@@ -646,23 +646,3 @@ class TextBookLoaded extends TextBookState {
     permanentHighlightLine,
   ];
 }
-
-/// האם ההבדל בין שני מצבים נוגע במשהו מלבד רשימת השורות הגלויות.
-///
-/// משמש כ-`buildWhen` בעץ תצוגת הספר. `visibleIndices` מתעדכן כמעט בכל
-/// תזוזת גלילה, ואף חלק מהתצוגה אינו נגזר ממנו — מי שצריך את המיקום הנוכחי
-/// קורא אותו חי מ-`positionsListener` דרך `resolveTopmostSourceLine`.
-///
-/// [previous] ו-[current] הם המצב הקודם והנוכחי של ה-bloc.
-/// מחזיר `true` כשצריך לבנות מחדש. ההשוואה עוברת דרך `copyWith`, ולכן שדה
-/// שיתווסף ל-props ולא ל-`copyWith` יישבר כאן בשקט — ראו את בדיקת הסחיפה
-/// ב-`test/text_book/view/visible_indices_rebuild_gate_test.dart`.
-bool textBookStateDiffersBeyondVisibleIndices(
-  TextBookState previous,
-  TextBookState current,
-) {
-  if (previous is! TextBookLoaded || current is! TextBookLoaded) {
-    return true;
-  }
-  return previous.copyWith(visibleIndices: current.visibleIndices) != current;
-}

--- a/lib/text_book/utils/reader_build_policy.dart
+++ b/lib/text_book/utils/reader_build_policy.dart
@@ -1,7 +1,19 @@
 import 'package:flutter/foundation.dart' show listEquals;
 import 'package:otzaria/text_book/bloc/text_book_state.dart';
 
-/// מסנן עדכוני גלילה ומטא-בחירה שאינם משנים את עץ הקורא.
+/// מסנן עדכוני גלילה ומטא-בחירה שאינם משנים את עץ הקורא. מחזיר `true`
+/// כשצריך לבנות מחדש.
+///
+/// התנאי לשימוש: אף חלק בתת-העץ אינו נגזר מ-`visibleIndices` או משדות
+/// הבחירה. מי שצריך את מיקום הגלילה קורא אותו חי מ-`positionsListener` דרך
+/// `resolveTopmostSourceLine`.
+///
+/// חייב לעטוף גם כל פאנל מפרשים שמאזין ל-bloc בעצמו — `buildWhen` בהורה אינו
+/// מגן עליו, ובלעדיו כל תזוזת סימון בונה את כל המפרשים מחדש (issue #976).
+///
+/// ההשוואה עוברת דרך `copyWith`, ולכן שדה שיתווסף ל-props ולא ל-`copyWith`
+/// יישבר כאן בשקט — ראו את בדיקת הסחיפה
+/// ב-`test/text_book/view/visible_indices_rebuild_gate_test.dart`.
 bool shouldRebuildReader(TextBookState previous, TextBookState current) {
   if (previous is! TextBookLoaded || current is! TextBookLoaded) return true;
   if (!listEquals(previous.content, current.content)) return true;

--- a/lib/text_book/view/page_shape/page_shape_screen.dart
+++ b/lib/text_book/view/page_shape/page_shape_screen.dart
@@ -1760,6 +1760,7 @@ class _CommentaryPaneState extends State<_CommentaryPane> {
       ScrollOffsetController();
   List<Link> _relevantLinks = [];
   int? _lastSyncedIndex; // האינדקס האחרון שסונכרן
+  int? _lastSyncedMainIndex; // השורה הנבחרת שממנה נגזר הסנכרון האחרון
   int _initialSyncAttempts = 0; // ניסיונות סנכרון ראשוני עד שה-controller מחובר
   List<Link>? _lastLinks; // לדידוב: מסנן מחדש רק כשהקישורים השתנו
   StreamSubscription<TextBookState>? _blocSubscription;
@@ -1920,6 +1921,7 @@ class _CommentaryPaneState extends State<_CommentaryPane> {
       _content = content;
       _isLoading = false;
       _lastSyncedIndex = null;
+      _lastSyncedMainIndex = null;
     });
     _scheduleInitialSync();
     return true;
@@ -2100,6 +2102,7 @@ class _CommentaryPaneState extends State<_CommentaryPane> {
       _content = data.content;
       _isLoading = false;
       _lastSyncedIndex = null;
+      _lastSyncedMainIndex = null;
     });
 
     _scheduleInitialSync();
@@ -2395,10 +2398,15 @@ class _CommentaryPaneState extends State<_CommentaryPane> {
       return;
     }
 
-    // יעד שכבר סונכרנו אליו אינו נוגע במפרש שוב. בלי זה כל emission של
-    // ה-bloc (למשל חימום התוכן ברקע) היה גורר חזרה לעוגן גלילה ידנית
-    // שהמשתמש עשה בחלונית.
-    if (targetIndex == _lastSyncedIndex && state.selectedIndex == null) {
+    // יעד שכבר סונכרנו אליו אינו נוגע במפרש שוב: בלעדי זה כל emission של
+    // ה-bloc (חימום תוכן ברקע, בחירת טקסט) גורר את המפרש בחזרה מעוגן גלילה
+    // ידנית שהמשתמש עשה בחלונית.
+    if (!CommentarySyncHelper.shouldMoveCommentary(
+      targetIndex: targetIndex,
+      selectedMainIndex: state.selectedIndex,
+      lastSyncedIndex: _lastSyncedIndex,
+      lastSyncedMainIndex: _lastSyncedMainIndex,
+    )) {
       return;
     }
 
@@ -2423,6 +2431,7 @@ class _CommentaryPaneState extends State<_CommentaryPane> {
         _glideToTarget(targetIndex);
       }
       _lastSyncedIndex = targetIndex;
+      _lastSyncedMainIndex = state.selectedIndex;
     }
   }
 
@@ -2492,7 +2501,7 @@ class _CommentaryPaneState extends State<_CommentaryPane> {
     }
 
     return TextBookStateBuilder(
-      buildWhen: textBookStateDiffersBeyondVisibleIndices,
+      buildWhen: shouldRebuildReader,
       loadingWidget: const SizedBox(),
       builder: (context, state) {
         return BlocBuilder<SettingsBloc, SettingsState>(

--- a/lib/text_book/view/page_shape/utils/commentary_sync_helper.dart
+++ b/lib/text_book/view/page_shape/utils/commentary_sync_helper.dart
@@ -96,4 +96,24 @@ class CommentarySyncHelper {
     }
     return delta;
   }
+
+  /// האם להזיז את המפרש אל [targetIndex], בהינתן הסנכרון האחרון.
+  ///
+  /// המפרש זז רק כשהיעד או השורה הנבחרת שממנה הוא נגזר השתנו. הבדיקה היא על
+  /// *שינוי* השורה הנבחרת ולא על עצם קיומה: בחירת טקסט פולטת מצב בכל תזוזת
+  /// עכבר, ואנימציית הגלילה שנורית מחדש בכל אחת מהן מרעידה את המפרש
+  /// (issue #976).
+  ///
+  /// [targetIndex] - אינדקס היעד במפרש
+  /// [selectedMainIndex] - השורה הנבחרת בטקסט הראשי, או null כשאין
+  /// [lastSyncedIndex] / [lastSyncedMainIndex] - מה שסונכרן בפעם הקודמת
+  static bool shouldMoveCommentary({
+    required int targetIndex,
+    required int? selectedMainIndex,
+    required int? lastSyncedIndex,
+    required int? lastSyncedMainIndex,
+  }) {
+    return targetIndex != lastSyncedIndex ||
+        selectedMainIndex != lastSyncedMainIndex;
+  }
 }

--- a/lib/text_book/view/tabbed_commentary_panel.dart
+++ b/lib/text_book/view/tabbed_commentary_panel.dart
@@ -7,6 +7,7 @@ import 'package:otzaria/tabs/models/tab.dart';
 import 'package:otzaria/text_book/bloc/text_book_bloc.dart';
 import 'package:otzaria/text_book/bloc/text_book_state.dart';
 import 'package:otzaria/text_book/bloc/text_book_event.dart';
+import 'package:otzaria/text_book/utils/reader_build_policy.dart';
 import 'package:otzaria/text_book/view/selected_line_links_view.dart';
 import 'package:otzaria/personal_notes/widgets/personal_notes_sidebar.dart';
 import 'package:otzaria/personal_notes/repository/personal_notes_repository.dart';
@@ -140,6 +141,7 @@ class _TabbedCommentaryPanelState extends State<TabbedCommentaryPanel>
   @override
   Widget build(BuildContext context) {
     return TextBookStateBuilder(
+      buildWhen: shouldRebuildReader,
       builder: (context, state) {
         return Column(
           children: [

--- a/test/text_book/view/page_shape/commentary_sync_helper_test.dart
+++ b/test/text_book/view/page_shape/commentary_sync_helper_test.dart
@@ -267,6 +267,84 @@ void main() {
     });
   });
 
+  group('shouldMoveCommentary', () {
+    test('בחירת טקסט על אותה שורה נבחרת אינה מזיזה את המפרש', () {
+      // ‏UpdateSelectedTextForNote נפלט בכל תזוזת עכבר בזמן גרירת סימון. תזוזה
+      // בכל אחת מהן הרעידה את המפרשים בצורת הדף (issue #976).
+      expect(
+        CommentarySyncHelper.shouldMoveCommentary(
+          targetIndex: 12,
+          selectedMainIndex: 5,
+          lastSyncedIndex: 12,
+          lastSyncedMainIndex: 5,
+        ),
+        isFalse,
+      );
+    });
+
+    test('לחיצה על שורה אחרת שממופה לאותו יעד כן מזיזה', () {
+      // המפרש נצמד לקישור הקודם, ולכן שורות סמוכות חולקות יעד. לחיצה חדשה
+      // צריכה להחזיר את המפרש למקומו גם אחרי שהמשתמש גלל בו ידנית.
+      expect(
+        CommentarySyncHelper.shouldMoveCommentary(
+          targetIndex: 12,
+          selectedMainIndex: 6,
+          lastSyncedIndex: 12,
+          lastSyncedMainIndex: 5,
+        ),
+        isTrue,
+      );
+    });
+
+    test('יעד חדש מזיז את המפרש', () {
+      expect(
+        CommentarySyncHelper.shouldMoveCommentary(
+          targetIndex: 20,
+          selectedMainIndex: 5,
+          lastSyncedIndex: 12,
+          lastSyncedMainIndex: 5,
+        ),
+        isTrue,
+      );
+    });
+
+    test('גלילה ללא בחירה על יעד שסונכרן אינה מזיזה', () {
+      expect(
+        CommentarySyncHelper.shouldMoveCommentary(
+          targetIndex: 12,
+          selectedMainIndex: null,
+          lastSyncedIndex: 12,
+          lastSyncedMainIndex: null,
+        ),
+        isFalse,
+      );
+    });
+
+    test('ביטול הבחירה על אותו יעד מזיז — הגלילה חוזרת לעקוב אחר הנראה', () {
+      expect(
+        CommentarySyncHelper.shouldMoveCommentary(
+          targetIndex: 12,
+          selectedMainIndex: null,
+          lastSyncedIndex: 12,
+          lastSyncedMainIndex: 5,
+        ),
+        isTrue,
+      );
+    });
+
+    test('סנכרון ראשוני תמיד מזיז', () {
+      expect(
+        CommentarySyncHelper.shouldMoveCommentary(
+          targetIndex: 0,
+          selectedMainIndex: null,
+          lastSyncedIndex: null,
+          lastSyncedMainIndex: null,
+        ),
+        isTrue,
+      );
+    });
+  });
+
   group('isHeaderLine', () {
     test('מזהה כותרות בכל הרמות', () {
       for (final level in [1, 2, 3, 4, 5, 6]) {

--- a/test/text_book/view/tabbed_commentary_panel_test.dart
+++ b/test/text_book/view/tabbed_commentary_panel_test.dart
@@ -36,10 +36,13 @@ void main() {
     TextBookTab? tab,
     _RecordingTabsBloc? tabsBloc,
     List<String> activeCommentators = const [],
+    _TestTextBookBloc? textBookBlocOverride,
   }) {
-    final textBookBloc = _TestTextBookBloc(
-      _loadedState(activeCommentators: activeCommentators),
-    );
+    final textBookBloc =
+        textBookBlocOverride ??
+        _TestTextBookBloc(
+          _loadedState(activeCommentators: activeCommentators),
+        );
     final personalNotesBloc = _TestPersonalNotesBloc(
       const PersonalNotesState.initial(),
     );
@@ -67,6 +70,50 @@ void main() {
       ),
     );
   }
+
+  testWidgets('סימון טקסט בטקסט הראשי אינו בונה מחדש את חלונית המפרשים', (
+    tester,
+  ) async {
+    // הסימון מתעדכן בכל תזוזת עכבר בזמן גרירה, והחלונית מאזינה ל-bloc בעצמה:
+    // בלי שער כל תזוזה בונה את כל המפרשים מחדש (issue #976).
+    final initial = _loadedState();
+    final textBookBloc = _TestTextBookBloc(initial);
+    await tester.pumpWidget(buildPanel(textBookBlocOverride: textBookBloc));
+    await tester.pump();
+
+    final before = tester.widget(find.byType(TabBarView));
+
+    for (var i = 0; i < 3; i++) {
+      textBookBloc.emitState(
+        initial.copyWith(
+          selectedTextForNote: 'טקסט $i',
+          selectedTextSectionIndex: 0,
+          selectedTextStart: i,
+          selectedTextEnd: i + 4,
+        ),
+      );
+      await tester.pump();
+      await tester.pump();
+    }
+
+    expect(
+      identical(tester.widget(find.byType(TabBarView)), before),
+      isTrue,
+      reason: 'החלונית לא נבנתה מחדש בגלל עדכוני סימון',
+    );
+
+    textBookBloc.emitState(
+      initial.copyWith(activeCommentators: const ['רש"י']),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    expect(
+      identical(tester.widget(find.byType(TabBarView)), before),
+      isFalse,
+      reason: 'שינוי אמיתי במפרשים הפעילים כן בונה מחדש',
+    );
+  });
 
   testWidgets('מציג את שלושת הכרטיסיות', (tester) async {
     await tester.pumpWidget(buildPanel());
@@ -308,6 +355,8 @@ class _TestTextBookBloc extends Bloc<TextBookEvent, TextBookState>
   _TestTextBookBloc(super.initialState) {
     on<TextBookEvent>((event, emit) {});
   }
+
+  void emitState(TextBookState next) => emit(next);
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);

--- a/test/text_book/view/visible_indices_rebuild_gate_test.dart
+++ b/test/text_book/view/visible_indices_rebuild_gate_test.dart
@@ -5,6 +5,7 @@ import 'package:otzaria/models/books.dart';
 import 'package:otzaria/models/links.dart';
 import 'package:otzaria/search/models/search_configuration.dart';
 import 'package:otzaria/text_book/bloc/text_book_state.dart';
+import 'package:otzaria/text_book/utils/reader_build_policy.dart';
 import 'package:otzaria/text_book/utils/reading_segments.dart';
 import 'package:otzaria_search_engine/otzaria_search_engine.dart'
     show SearchScope;
@@ -15,19 +16,19 @@ import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
 /// המלכוד המרכזי: `buildWhen` על ווידג'ט פנימי אינו מונע בנייה כשההורה
 /// נבנה — הוא רק מקפיא את המצב שנמסר. לכן השער חייב לשבת גם בשורש העץ.
 void main() {
-  group('textBookStateDiffersBeyondVisibleIndices', () {
+  group('shouldRebuildReader', () {
     test('תזוזת גלילה בלבד אינה מצדיקה בנייה מחדש', () {
       final before = _loaded();
       final after = before.copyWith(visibleIndices: const [7, 8, 9]);
 
-      expect(textBookStateDiffersBeyondVisibleIndices(before, after), isFalse);
+      expect(shouldRebuildReader(before, after), isFalse);
     });
 
     test('רשימת שורות גלויות זהה בערכה אינה מצדיקה בנייה', () {
       final before = _loaded();
       final after = before.copyWith(visibleIndices: [...before.visibleIndices]);
 
-      expect(textBookStateDiffersBeyondVisibleIndices(before, after), isFalse);
+      expect(shouldRebuildReader(before, after), isFalse);
     });
 
     test('כותרת שהשתנתה עם הגלילה כן מצדיקה בנייה מחדש', () {
@@ -39,14 +40,35 @@ void main() {
         currentTitle: 'סימן אחר',
       );
 
-      expect(textBookStateDiffersBeyondVisibleIndices(before, after), isTrue);
+      expect(shouldRebuildReader(before, after), isTrue);
+    });
+
+    test('עדכון הטקסט המסומן אינו מצדיק בנייה מחדש', () {
+      // הסימון מתעדכן בכל תזוזת עכבר בזמן גרירה, ואף חלק מהתצוגה אינו נגזר
+      // ממנו — בנייה בגללו מרעידה את כל המפרשים בצורת הדף (issue #976).
+      final before = _loaded();
+      final after = before.copyWith(
+        selectedTextForNote: 'טקסט אחר',
+        selectedTextSectionIndex: 2,
+        selectedTextStart: 7,
+        selectedTextEnd: 11,
+      );
+
+      expect(shouldRebuildReader(before, after), isFalse);
+    });
+
+    test('ניקוי הטקסט המסומן אינו מצדיק בנייה מחדש', () {
+      final before = _loaded();
+      final after = before.copyWith(clearSelectedText: true);
+
+      expect(shouldRebuildReader(before, after), isFalse);
     });
 
     test('בחירת שורה מצדיקה בנייה מחדש', () {
       final before = _loaded();
 
       expect(
-        textBookStateDiffersBeyondVisibleIndices(
+        shouldRebuildReader(
           before,
           before.copyWith(selectedIndex: before.selectedIndex! + 1),
         ),
@@ -61,7 +83,7 @@ void main() {
         visibleIndices: const [3],
       );
 
-      expect(textBookStateDiffersBeyondVisibleIndices(before, after), isTrue);
+      expect(shouldRebuildReader(before, after), isTrue);
     });
 
     test('גרסת תוכן חדשה מצדיקה בנייה גם כשאורך התוכן זהה', () {
@@ -74,7 +96,7 @@ void main() {
         visibleIndices: const [5],
       );
 
-      expect(textBookStateDiffersBeyondVisibleIndices(before, after), isTrue);
+      expect(shouldRebuildReader(before, after), isTrue);
     });
 
     test('סיום טעינת הקישורים מצדיק בנייה מחדש', () {
@@ -84,7 +106,7 @@ void main() {
         visibleIndices: const [9],
       );
 
-      expect(textBookStateDiffersBeyondVisibleIndices(before, after), isTrue);
+      expect(shouldRebuildReader(before, after), isTrue);
     });
 
     test('מצב שאינו טעון תמיד נבנה', () {
@@ -96,10 +118,10 @@ void main() {
         const [],
       );
 
-      expect(textBookStateDiffersBeyondVisibleIndices(initial, loaded), isTrue);
-      expect(textBookStateDiffersBeyondVisibleIndices(loaded, initial), isTrue);
+      expect(shouldRebuildReader(initial, loaded), isTrue);
+      expect(shouldRebuildReader(loaded, initial), isTrue);
       expect(
-        textBookStateDiffersBeyondVisibleIndices(initial, initial),
+        shouldRebuildReader(initial, initial),
         isTrue,
       );
     });
@@ -236,6 +258,39 @@ void main() {
       await cubit.close();
     });
 
+    testWidgets('סימון טקסט אינו בונה מחדש פאנל מפרשים שמאזין ל-bloc בעצמו', (
+      tester,
+    ) async {
+      // מבנה צורת הדף: שער בשורש, וכל פאנל מפרשים הוא BlocBuilder נפרד. שער
+      // ההורה אינו מגן עליו, ולכן השער שלו חייב לחסום גם את עדכוני הסימון.
+      final cubit = _StateCubit(_loaded());
+      var leafBuilds = 0;
+
+      await tester.pumpWidget(
+        _tree(
+          cubit,
+          guardRoot: true,
+          onLeaf: (_) {
+            leafBuilds++;
+          },
+        ),
+      );
+
+      final baseline = leafBuilds;
+      for (var i = 0; i < 5; i++) {
+        cubit.selectText('טקסט $i', i);
+        await tester.pump();
+      }
+
+      expect(
+        leafBuilds,
+        baseline,
+        reason: 'גרירת סימון אינה בונה מחדש את פאנל המפרשים',
+      );
+
+      await cubit.close();
+    });
+
     testWidgets('רצף חסימות אינו צובר פער — המצב מתעדכן בשינוי הבא', (
       tester,
     ) async {
@@ -279,11 +334,11 @@ Widget _tree(
     home: BlocProvider.value(
       value: cubit,
       child: BlocBuilder<_StateCubit, TextBookState>(
-        buildWhen: guardRoot ? textBookStateDiffersBeyondVisibleIndices : null,
+        buildWhen: guardRoot ? shouldRebuildReader : null,
         builder: (context, _) {
           onRoot?.call();
           return BlocBuilder<_StateCubit, TextBookState>(
-            buildWhen: textBookStateDiffersBeyondVisibleIndices,
+            buildWhen: shouldRebuildReader,
             builder: (context, state) {
               onLeaf(state as TextBookLoaded);
               return const SizedBox();
@@ -304,6 +359,16 @@ class _StateCubit extends Cubit<TextBookState> {
 
   void retitle(String title) {
     emit((state as TextBookLoaded).copyWith(currentTitle: title));
+  }
+
+  void selectText(String text, int start) {
+    emit(
+      (state as TextBookLoaded).copyWith(
+        selectedTextForNote: text,
+        selectedTextStart: start,
+        selectedTextEnd: start + text.length,
+      ),
+    );
   }
 }
 


### PR DESCRIPTION
﻿סוגר issue #976.

## התסמין
בצורת הדף, גרירת סימון על הטקסט הראשי הרעידה את כל חלוניות המפרשים.

## הסיבה
סימון טקסט פולט `UpdateSelectedTextForNote` בכל תזוזת עכבר, ושני מסלולים בחלוניות המפרשים הגיבו לכל אחת מהן.

**התזוזה עצמה** — `_CommentaryPaneState` פותח מנוי גולמי ל-stream של ה-bloc, מסלול ש-`buildWhen` אינו נוגע בו. שער הדידוב ב-`_syncWithMainText` היה:

```dart
if (targetIndex == _lastSyncedIndex && state.selectedIndex == null) return;
```

הוא בודק את *עצם קיומה* של שורה נבחרת ולא את *שינויה*. אחרי שהמשתמש לוחץ על שורה בטקסט הראשי `selectedIndex != null`, ולכן כל פליטת מצב עברה את השער והגיעה ל-`scrollTo(duration: 300ms)`. אנימציית easing שנורית מחדש כ-60 פעם בשנייה, בכל חלונית מפרש בנפרד — זה הרעד.

**בנוסף** — כל פאנל מפרשים נבנה מחדש בכל תזוזת סימון. השער בשורש עץ צורת הדף (`shouldRebuildReader`) אינו מגן על ילד שמאזין ל-bloc בעצמו, ושם `textBookStateDiffersBeyondVisibleIndices` ניטרל רק את `visibleIndices` ולא את שדות הבחירה, ול-`TabbedCommentaryPanel` לא היה `buildWhen` כלל. זה מסביר גם למה רק המפרשים רעדו והטקסט הראשי לא — הוא כן היה מוגן.

## התיקון
- הדידוב עובר ל-`CommentarySyncHelper.shouldMoveCommentary`, שמשווה גם את השורה הנבחרת שממנה נגזר הסנכרון האחרון. ההתנהגות שהשער נועד לשמר נשמרת: לחיצה על שורה אחרת שממופה לאותו יעד עדיין מחזירה את המפרש למקומו גם אחרי גלילה ידנית בחלונית, וביטול בחירה מחזיר אותו לעקוב אחרי הנראה.
- `textBookStateDiffersBeyondVisibleIndices` נמחקה, ושני הצרכנים עברו ל-`shouldRebuildReader` שמנטרל את שני הצירים — שתי פונקציות `buildWhen` כמעט זהות שאחת מהן שגויה, במקום להוסיף שלישית.

## אימות
- טסטים חדשים: 6 ל-`shouldMoveCommentary` (כולל שני מקרי ההתנהגות שנשמרת), 3 לשער הבנייה — אחד מהם טסט widget מקצה לקצה על `TabbedCommentaryPanel` שאומת כנכשל בלי התיקון.
- `flutter test test/text_book/` — 1467 עוברים.
- `flutter analyze` על כל הפרויקט — נקי. `dart format` — נקי.

## נותר פתוח (מחוץ להיקף)
`CommentatorsListView` (`lib/text_book/view/commentators_list_screen.dart:35`) הוא `TextBookStateBuilder` ללא `buildWhen` כלל, ומחשב `commentatorsByType(state.links)` בכל תזוזת סימון. אינו גורם רעד, ולא נוגע בו כאן — הוא תלוי בגלילה ולכן צריך `buildWhen` ייעודי ולא את זה.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
