### PR TITLE
גופנים לתוספים: בולד אמיתי, כל המשפחות, וגופן ממשק נפרד מגופן הקריאה

### DIFF
--- a/docs/plugin-sdk/API_REFERENCE.md
+++ b/docs/plugin-sdk/API_REFERENCE.md
@@ -294,11 +294,12 @@ const { data } = await Otzaria.call('app.getTheme');
 //     ... (תפקידי הצבע העיקריים — ראה otzaria_plugin.d.ts → ColorScheme)
 //   },
 //   typography: {
-//     fontFamily:             "Frank Ruhl Libre",
+//     fontFamily:             "FrankRuhlCLM",   // גופן הקריאה — לטקסט הספר בלבד
 //     fontSize:               25,    // לפי הגדרת המשתמש — אל תניח ערך קבוע!
 //     lineHeight:             1.5,
-//     commentatorsFontFamily: "Shofar",
+//     commentatorsFontFamily: "NotoRashiHebrew",
 //     commentatorsFontSize:   22,
+//     uiFontFamily:           "Rubik",           // גופן הממשק — כפתורים ותפריטים
 //   }
 // }
 ```
@@ -308,7 +309,7 @@ const { data } = await Otzaria.call('app.getTheme');
 
 > **`surfaceContainerHigh` — רקע פס הכותרת שלך.** התוסף נפתח כטאב קריאה ואוצריא אינה מציירת כותרת מעל ה-WebView; שם התוסף חייב להופיע בפס עליון קבוע בצבע הזה, כדי שיתיישר עם הסרגל העליון של מסכי הספרים. ראה [DESIGN\_GUIDE.md § סרגל כותרת התוסף](DESIGN_GUIDE.md#סרגל-כותרת-התוסף-top-bar).
 
-> **גופנים מוטמעים אוטומטית:** השמות שמגיעים ב-`typography.fontFamily` ו-`typography.commentatorsFontFamily` (כגון `FrankRuhlCLM`, `Shofar`, `NotoRashiHebrew`) נטענים אוטומטית ב-WebView של התוסף כ-`@font-face` עוד לפני ה-`plugin.boot`. אין צורך לארוז את קבצי הגופן בתוסף — מספיק להפנות לשם שהתקבל ב-CSS: `font-family: 'FrankRuhlCLM', serif;`. אם המשתמש בחר גופן מערכת (לא מובנה), ההזרקה האוטומטית מדלגת עליו וה-WebView ייפול חזרה ל-fallback של מערכת ההפעלה.
+> **גופנים מוטמעים אוטומטית:** כל הגופנים המובנים של אוצריא (`FrankRuhlCLM`, `TaameyDavidCLM`, `Shofar`, `NotoRashiHebrew`, `KeterYG`, `NotoSerifHebrew`, `Tinos`, `Rubik`, `TaameyAshkenaz`) נטענים ב-WebView של התוסף כ-`@font-face` עוד לפני ה-`plugin.boot`, ואיתם גם גופן מערכת שהמשתמש בחר בהגדרות. אין צורך לארוז קבצי גופן — מספיק `font-family: 'FrankRuhlCLM', serif;`. כל משפחה נשלחת עם ה-face הבולד האמיתי שלה (או עם טווח משקלים בגופן משתנה), כך ש-`font-weight: bold` מקבל ציור אות אמיתי ולא עיבוי מלאכותי. לממשק עצמו השתמש ב-`uiFontFamily` ולא בגופן הקריאה — גופן ספרים בכפתור בן 12px נראה מטושטש.
 
 ### `app.getLocale`
 מחזיר את שפת הממשק שבחר המשתמש (או שפת המערכת, בזיהוי אוטומטי) ואת כיוון

--- a/docs/plugin-sdk/DESIGN_GUIDE.md
+++ b/docs/plugin-sdk/DESIGN_GUIDE.md
@@ -72,18 +72,21 @@ applyTheme(theme);
     surfaceTint:             "#...", // גוון העלאה (elevation tint)
   },
   typography: {
-    fontFamily:             "Frank Ruhl Libre", // גופן ראשי (טקסטים עבריים)
+    fontFamily:             "FrankRuhlCLM",     // גופן הקריאה — לטקסט הספר בלבד
     fontSize:               25,                 // גודל גופן בסיסי (px) — לפי הגדרת המשתמש
     lineHeight:             1.5,                // גובה שורה
-    commentatorsFontFamily: "Shofar",           // גופן מפרשים
+    commentatorsFontFamily: "NotoRashiHebrew",  // גופן מפרשים
     commentatorsFontSize:   22,                 // גודל גופן מפרשים (px)
+    uiFontFamily:           "Rubik",            // גופן הממשק — כפתורים, תפריטים, שדות
   }
 }
 ```
 
 > **שים לב:** `fontSize` שונה ממשתמש למשתמש (טווח רגיל: 16–36). עצב את הפריסה כך שתעבוד בכל גודל.
 
-> **הגופנים זמינים אוטומטית ב-WebView:** הגופנים המובנים של אוצריא (`FrankRuhlCLM`, `TaameyDavidCLM`, `Shofar`, `NotoRashiHebrew`, `KeterYG`, `NotoSerifHebrew`, `Tinos`, `Rubik`, `TaameyAshkenaz`) מוזרקים כ-`@font-face` ל-WebView עוד לפני ה-`plugin.boot`, עבור הגופן הראשי וגופן המפרשים שנבחרו בהגדרות. אין צורך לארוז קבצי גופן בתוסף — מספיק להגדיר `font-family: 'FrankRuhlCLM', 'David', serif;` ב-CSS, ולעדכן בזמן אמת מתוך `theme.typography.fontFamily`. גופני מערכת שהמשתמש בחר ידנית (מתוך גופני ההפעלה) אינם מוזרקים — במצב כזה ה-WebView ייפול חזרה ל-fallback שמוגדר ב-CSS, כך שכדאי לשמור `'David', serif` בסוף השרשרת.
+> **גופן ממשק ≠ גופן קריאה — אל תערבב:** `fontFamily` הוא הגופן שהמשתמש בחר ל**קריאת ספרים** — גופן עם תגיות, מצויר ל-25px. החלתו על כפתור או תפריט בן 11-12px מולידה טקסט מטושטש ומרוח. לממשק יש `uiFontFamily` — sans שנשאר חד בקטן. שני משתנים נפרדים, ולא אחד: `--font-ui` לכפתורים/תפריטים/שדות, ו-`--font-main` רק לטקסט הספר עצמו.
+
+> **הגופנים זמינים אוטומטית ב-WebView:** כל הגופנים המובנים של אוצריא (`FrankRuhlCLM`, `TaameyDavidCLM`, `Shofar`, `NotoRashiHebrew`, `KeterYG`, `NotoSerifHebrew`, `Tinos`, `Rubik`, `TaameyAshkenaz`) מוזרקים כ-`@font-face` עוד לפני ה-`plugin.boot`, ואיתם גם גופן מערכת שהמשתמש בחר בהגדרות. אין צורך לארוז קבצי גופן בתוסף — מספיק `font-family: 'FrankRuhlCLM', 'David', serif;` ב-CSS. כל משפחה נשלחת עם ה-face הבולד האמיתי שלה (או עם טווח משקלים בגופן משתנה), כך ש-`font-weight: bold` מקבל ציור אות אמיתי ולא עיבוי מלאכותי.
 
 ---
 
@@ -114,7 +117,8 @@ applyTheme(theme);
   --color-secondary-subtle: rgba(98, 91, 113, 0.12);  /* secondary בשקיפות */
 
   /* --- Typography --- */
-  --font-main:     'Frank Ruhl Libre', 'David', serif;
+  --font-ui:       'Rubik', system-ui, sans-serif;  /* ממשק */
+  --font-main:     'FrankRuhlCLM', 'David', serif;  /* טקסט קריאה */
   --font-size-base: 18px;
   --line-height:    1.5;
 
@@ -160,6 +164,10 @@ function applyTheme(theme) {
 
   if (theme.typography) {
     const t = theme.typography;
+    // מארח ישן אינו שולח uiFontFamily — אז הברירת מחדל שב-CSS נשמרת.
+    if (t.uiFontFamily) {
+      root.style.setProperty('--font-ui', `'${t.uiFontFamily}', system-ui, sans-serif`);
+    }
     root.style.setProperty('--font-main', `'${t.fontFamily}', 'David', serif`);
     root.style.setProperty('--font-size-base', `${t.fontSize}px`);
     root.style.setProperty('--line-height', String(t.lineHeight));
@@ -302,7 +310,7 @@ body.dark-mode .card {
   border: none;
   border-radius: var(--radius-sm);
   padding: 9px 20px;
-  font-family: var(--font-main);
+  font-family: var(--font-ui);
   font-size: 0.95rem;
   font-weight: 600;
   cursor: pointer;
@@ -322,7 +330,7 @@ body.dark-mode .card {
   border: 1px solid var(--color-outline);
   border-radius: var(--radius-sm);
   padding: 9px 20px;
-  font-family: var(--font-main);
+  font-family: var(--font-ui);
   font-size: 0.95rem;
   font-weight: 600;
   cursor: pointer;
@@ -341,7 +349,7 @@ body.dark-mode .card {
   padding: 9px 12px;
   border: 1.5px solid var(--color-outline);
   border-radius: var(--radius-sm);
-  font-family: var(--font-main);
+  font-family: var(--font-ui);
   font-size: 0.95rem;
   color: var(--color-on-surface);
   background: var(--color-surface);
@@ -386,7 +394,7 @@ searchInput.focus();
 
 ```css
 body {
-  font-family: var(--font-main);
+  font-family: var(--font-ui);
   font-size: var(--font-size-base);
   line-height: var(--line-height);
   direction: rtl;
@@ -561,7 +569,8 @@ body { overflow: hidden; }   /* הגלילה קורית בתוכן, לא בעמ�
       --color-outline: #79747E;
       --color-primary-subtle: rgba(103,80,164,0.12);
       --color-secondary-subtle: rgba(98,91,113,0.12);
-      --font-main: 'Frank Ruhl Libre', 'David', serif;
+      --font-ui: 'Rubik', system-ui, sans-serif;
+      --font-main: 'FrankRuhlCLM', 'David', serif;
       --font-size-base: 18px;
       --line-height: 1.5;
       --radius-sm: 8px; --radius-md: 12px;
@@ -571,7 +580,7 @@ body { overflow: hidden; }   /* הגלילה קורית בתוכן, לא בעמ�
     html, body { height: 100%; }
 
     body {
-      font-family: var(--font-main);
+      font-family: var(--font-ui);
       font-size: var(--font-size-base);
       line-height: var(--line-height);
       background: var(--color-surface);
@@ -631,6 +640,9 @@ body { overflow: hidden; }   /* הגלילה קורית בתוכן, לא בעמ�
       r.style.setProperty('--color-outline',  cs.outline);
       document.body.classList.toggle('dark-mode', theme.mode === 'dark');
       if (theme.typography) {
+        if (theme.typography.uiFontFamily) {
+          r.style.setProperty('--font-ui', `'${theme.typography.uiFontFamily}', system-ui, sans-serif`);
+        }
         r.style.setProperty('--font-main', `'${theme.typography.fontFamily}', 'David', serif`);
         r.style.setProperty('--font-size-base', `${theme.typography.fontSize}px`);
         r.style.setProperty('--line-height', String(theme.typography.lineHeight));

--- a/docs/plugin-sdk/otzaria_plugin.d.ts
+++ b/docs/plugin-sdk/otzaria_plugin.d.ts
@@ -97,11 +97,15 @@ export interface ColorScheme {
 }
 
 export interface Typography {
+  /** גופן הקריאה — לטקסט הספר/המסמך בלבד. אסור להחיל על הממשק. */
   fontFamily: string;
   fontSize: number;
   lineHeight: number;
   commentatorsFontFamily: string;
   commentatorsFontSize: number;
+  /** גופן הממשק — כפתורים, תפריטים, שדות. נשאר חד בגדלים קטנים.
+   *  קיים מ-0.9.97; במארח ישן חסר — שמרו fallback ב-CSS. */
+  uiFontFamily?: string;
 }
 
 export interface ThemePayload {

--- a/lib/plugins/bridge/plugin_bridge_adapter.dart
+++ b/lib/plugins/bridge/plugin_bridge_adapter.dart
@@ -109,6 +109,11 @@ import 'package:otzaria/plugins/services/text_source_map_service.dart';
 import 'package:otzaria/search/utils/facet_helper.dart';
 import 'package:otzaria/widgets/smart_text/render_settings.dart';
 
+/// גופן הממשק שאוצריא מוסרת לתוספים: sans מובנה שנשאר חד ב-11-12px.
+/// גופן הקריאה (`fontFamily`) אינו תחליף לו — הוא מצויר ל-25px,
+/// והתגיות שלו נמרחות בכפתור או בתפריט.
+const String kPluginUiFont = 'Rubik';
+
 // ===================================================================
 // Helper: build the main colorScheme roles + typography from Flutter theme
 // ===================================================================
@@ -133,10 +138,10 @@ Map<String, dynamic> buildThemePayloadFromScheme(
 
   final fontFamily =
       Settings.getValue<String>(SettingsRepository.keyFontFamily) ??
-      'Frank Ruhl Libre';
+      AppFonts.defaultFont;
   final commentatorsFontFamily =
       Settings.getValue<String>(SettingsRepository.keyCommentatorsFontFamily) ??
-      'Shofar';
+      AppFonts.defaultCommentatorsFont;
   final fontSize =
       Settings.getValue<double>(SettingsRepository.keyFontSize) ?? 25.0;
   final commentatorsFontSize =
@@ -183,6 +188,7 @@ Map<String, dynamic> buildThemePayloadFromScheme(
     },
     'typography': {
       'fontFamily': fontFamily,
+      'uiFontFamily': kPluginUiFont,
       'fontSize': fontSize,
       'lineHeight': lineHeight,
       'commentatorsFontFamily': commentatorsFontFamily,
@@ -200,34 +206,84 @@ Map<String, dynamic> buildThemePayloadFromScheme(
 // ===================================================================
 final Map<String, String> _fontFaceCache = {};
 
+/// \u05db\u05dc\u05dc `@font-face` \u05d9\u05d7\u05d9\u05d3. [weight] \u05d4\u05d5\u05d0 \u05d3\u05e1\u05e7\u05e8\u05d9\u05e4\u05d8\u05d5\u05e8 \u05d4-CSS: \u05de\u05e9\u05e7\u05dc \u05d1\u05d5\u05d3\u05d3
+/// ("700") \u05d0\u05d5 \u05d8\u05d5\u05d5\u05d7 \u05dc\u05d2\u05d5\u05e4\u05df \u05de\u05e9\u05ea\u05e0\u05d4 ("100 900").
+String _fontFaceRule(String family, Uint8List bytes, String weight) {
+  final b64 = base64Encode(bytes);
+  return "@font-face{font-family:'$family';font-style:normal;"
+      "font-weight:$weight;"
+      "src:url(data:font/ttf;base64,$b64) format('truetype');"
+      'font-display:block;}';
+}
+
+/// \u05d4-faces \u05e9\u05dc \u05d2\u05d5\u05e4\u05df \u05de\u05d5\u05d1\u05e0\u05d4: \u05d4-regular, \u05d5\u05d1\u05de\u05e9\u05e4\u05d7\u05d4 \u05e2\u05dd \u05e7\u05d5\u05d1\u05e5 \u05d1\u05d5\u05dc\u05d3 \u05e0\u05e4\u05e8\u05d3 \u05d2\u05dd \u05d4\u05d5\u05d0.
+/// \u05d2\u05d5\u05e4\u05df \u05de\u05e9\u05ea\u05e0\u05d4 \u05de\u05e7\u05d1\u05dc \u05d8\u05d5\u05d5\u05d7 \u05de\u05e9\u05e7\u05dc\u05d9\u05dd \u2014 \u05d1\u05dc\u05e2\u05d3\u05d9\u05d5 \u05d4-WebView \u05e0\u05e2\u05d5\u05dc \u05e2\u05dc \u05de\u05d5\u05e4\u05e2
+/// \u05d1\u05e8\u05d9\u05e8\u05ea \u05d4\u05de\u05d7\u05d3\u05dc \u05d5\u05de\u05e1\u05e0\u05ea\u05d6 \u05d1\u05d5\u05dc\u05d3 \u05de\u05dc\u05d0\u05db\u05d5\u05ea\u05d9 \u05d5\u05de\u05e8\u05d5\u05d7 \u05d1\u05de\u05e7\u05d5\u05dd \u05dc\u05d4\u05e9\u05ea\u05de\u05e9 \u05d1\u05e6\u05d9\u05e8 \u05d4-wght.
+Future<String> _bundledFontFaceCss(String family) async {
+  final assetPath = AppFonts.fontPaths[family];
+  if (assetPath == null) return '';
+  final isVariable = AppFonts.variableWeightFonts.contains(family);
+  final regular = await rootBundle.load(assetPath);
+  final parts = <String>[
+    _fontFaceRule(
+      family,
+      regular.buffer.asUint8List(),
+      isVariable ? '100 900' : '400',
+    ),
+  ];
+  final boldPath = AppFonts.boldFontPaths[family];
+  if (boldPath != null) {
+    final bold = await rootBundle.load(boldPath);
+    parts.add(_fontFaceRule(family, bold.buffer.asUint8List(), '700'));
+  }
+  return parts.join('\n');
+}
+
+/// \u05d4-faces \u05e9\u05dc \u05d2\u05d5\u05e4\u05df \u05de\u05e2\u05e8\u05db\u05ea \u05e9\u05e0\u05d1\u05d7\u05e8 \u05d1\u05d4\u05d2\u05d3\u05e8\u05d5\u05ea. \u05d0\u05d9\u05e0\u05d5 \u05de\u05d5\u05d1\u05e0\u05d4, \u05d5\u05dc\u05db\u05df \u05d4-WebView
+/// \u05d0\u05d9\u05e0\u05d5 \u05d9\u05db\u05d5\u05dc \u05dc\u05e4\u05ea\u05d5\u05e8 \u05d0\u05ea \u05e9\u05de\u05d5 \u05d0\u05dc\u05d0 \u05d0\u05dd \u05d4\u05d1\u05d9\u05d9\u05d8\u05d9\u05dd \u05e9\u05dc\u05d5 \u05e0\u05e9\u05dc\u05d7\u05d9\u05dd \u05d0\u05d9\u05ea\u05d5.
+Future<String> _systemFontFaceCss(String family) async {
+  await AppFonts.warmUpSystemFontsCache();
+  final faces = AppFonts.systemFamilyFaces(family);
+  if (faces == null) return '';
+  final regular = AppFonts.readFontBytes(faces.regularPath);
+  if (regular == null) return '';
+  final parts = <String>[
+    _fontFaceRule(family, regular, faces.hasWeightAxis ? '100 900' : '400'),
+  ];
+  final boldPath = faces.boldPath;
+  if (boldPath != null) {
+    final bold = AppFonts.readFontBytes(boldPath);
+    if (bold != null) parts.add(_fontFaceRule(family, bold, '700'));
+  }
+  return parts.join('\n');
+}
+
 Future<String> _loadFontFaceCss(String fontFamily) async {
   if (fontFamily.isEmpty) return '';
   final cached = _fontFaceCache[fontFamily];
   if (cached != null) return cached;
-  final assetPath = AppFonts.fontPaths[fontFamily];
-  if (assetPath == null) return '';
   try {
-    final bytes = await rootBundle.load(assetPath);
-    final b64 = base64Encode(bytes.buffer.asUint8List());
-    final css =
-        "@font-face{font-family:'$fontFamily';src:url(data:font/ttf;base64,$b64) format('truetype');font-display:block;}";
-    _fontFaceCache[fontFamily] = css;
+    final css = AppFonts.fontPaths.containsKey(fontFamily)
+        ? await _bundledFontFaceCss(fontFamily)
+        : await _systemFontFaceCss(fontFamily);
+    if (css.isNotEmpty) _fontFaceCache[fontFamily] = css;
     return css;
   } catch (_) {
     return '';
   }
 }
 
-/// בונה בלוק CSS עם `@font-face` עבור הגופנים המובנים שנבחרו בהגדרות,
-/// כך שתוספים שמשתמשים בשמות הגופנים שמגיעים ב-theme יוכלו להציגם.
+/// \u05d1\u05d5\u05e0\u05d4 \u05d1\u05dc\u05d5\u05e7 CSS \u05e2\u05dd `@font-face` \u05dc\u05db\u05dc \u05d4\u05d2\u05d5\u05e4\u05e0\u05d9\u05dd \u05e9\u05ea\u05d5\u05e1\u05e3 \u05d9\u05db\u05d5\u05dc \u05dc\u05e0\u05e7\u05d5\u05d1 \u05d1\u05e9\u05de\u05dd:
+/// \u05d4\u05de\u05d5\u05d1\u05e0\u05d9\u05dd \u05e9\u05dc \u05d0\u05d5\u05e6\u05e8\u05d9\u05d0, \u05d5\u05d1\u05e0\u05d5\u05e1\u05e3 \u05d2\u05d5\u05e4\u05df \u05de\u05e2\u05e8\u05db\u05ea \u05e9\u05e0\u05d1\u05d7\u05e8 \u05d1\u05d4\u05d2\u05d3\u05e8\u05d5\u05ea. \u05de\u05e9\u05e4\u05d7\u05d4
+/// \u05e9\u05d0\u05d9\u05e0\u05d4 \u05e0\u05e9\u05dc\u05d7\u05ea \u05e0\u05d5\u05e4\u05dc\u05ea \u05d1-WebView \u05dc-fallback \u05e9\u05dc \u05d4\u05de\u05e2\u05e8\u05db\u05ea \u05d5\u05de\u05d5\u05e6\u05d2\u05ea \u05d1\u05d2\u05d5\u05e4\u05df \u05d0\u05d7\u05e8.
 Future<String> buildPluginFontFaceCss() async {
-  final fontFamily =
-      Settings.getValue<String>(SettingsRepository.keyFontFamily) ??
-      AppFonts.defaultFont;
-  final commentatorsFontFamily =
-      Settings.getValue<String>(SettingsRepository.keyCommentatorsFontFamily) ??
-      AppFonts.defaultCommentatorsFont;
-  final families = <String>{fontFamily, commentatorsFontFamily};
+  final families = <String>{
+    ...AppFonts.fontPaths.keys,
+    Settings.getValue<String>(SettingsRepository.keyFontFamily) ??
+        AppFonts.defaultFont,
+    Settings.getValue<String>(SettingsRepository.keyCommentatorsFontFamily) ??
+        AppFonts.defaultCommentatorsFont,
+  };
   final parts = <String>[];
   for (final family in families) {
     final css = await _loadFontFaceCss(family);
@@ -3051,7 +3107,9 @@ class PluginBridgeAdapter {
     // שהגשר כבר אכף.
     final access = args['access'] as String? ?? 'read';
     if (access != 'read' && access != 'readwrite') {
-      throw Exception("error.invalid_params: access must be 'read' or 'readwrite'");
+      throw Exception(
+        "error.invalid_params: access must be 'read' or 'readwrite'",
+      );
     }
     final writable = access == 'readwrite';
     if (writable && !await _hasWritePermission()) {
@@ -3177,7 +3235,8 @@ class PluginBridgeAdapter {
       // נתיב, ולקבוע לאן הוא ייפתח — בניגוד לכלל שאין דרך להזין נתיב מה-JS.
       final rawExtension = (args['extension'] as String?)?.toLowerCase().trim();
       final extension =
-          rawExtension != null && RegExp(r'^\.?[a-z0-9]{1,10}$').hasMatch(rawExtension)
+          rawExtension != null &&
+              RegExp(r'^\.?[a-z0-9]{1,10}$').hasMatch(rawExtension)
           ? rawExtension.replaceAll('.', '')
           : null;
       final suggested = _suggestedSaveName(
@@ -3309,9 +3368,10 @@ class PluginBridgeAdapter {
   /// suffix אקראי ולא חתימת זמן: שתי שמירות באותה מיקרו-שנייה היו מתנגשות.
   String _randomSuffix() {
     final random = math.Random.secure();
-    return List<int>.generate(8, (_) => random.nextInt(256))
-        .map((b) => b.toRadixString(16).padLeft(2, '0'))
-        .join();
+    return List<int>.generate(
+      8,
+      (_) => random.nextInt(256),
+    ).map((b) => b.toRadixString(16).padLeft(2, '0')).join();
   }
 
   /// מוחק קובצי staging נטושים בתיקיית היעד.

--- a/lib/theme/app_fonts.dart
+++ b/lib/theme/app_fonts.dart
@@ -563,6 +563,20 @@ class AppFonts {
     'Rubik': 'fonts/Rubik-VariableFont_wght.ttf',
   };
 
+  /// קובץ ה-face הבולד של גופן מובנה, למשפחות שנרשמו ב-pubspec עם קובץ נפרד.
+  /// צרכן חיצוני שמקבל רק את ה-regular (WebView של תוסף) מסנתז בולד מרוח.
+  static const Map<String, String> boldFontPaths = {
+    'FrankRuhlCLM': 'fonts/FrankRuehlCLM-Bold.ttf',
+  };
+
+  /// ה-faces של גופן מערכת שאותר בסריקה, או null כשאינו מוכר.
+  /// דורש שהקאש יהיה חם — ראו [warmUpSystemFontsCache].
+  static SystemFontFamilyFaces? systemFamilyFaces(String fontFamily) =>
+      _systemFamiliesCache?[fontFamily];
+
+  /// בייטים של קובץ גופן מהדיסק, או null כשאינו קריא.
+  static Uint8List? readFontBytes(String path) => _readFontBytesSync(path);
+
   /// מיפוי גופנים לשמות בעברית (לשימוש בהדפסה)
   /// מחושב אוטומטית מ-availableFonts, רק עבור גופנים עם קבצים
   static Map<String, String> get fontLabels => {

--- a/test/plugins/bridge/plugin_font_face_css_test.dart
+++ b/test/plugins/bridge/plugin_font_face_css_test.dart
@@ -1,0 +1,109 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_settings_screens/flutter_settings_screens.dart';
+import 'package:otzaria/plugins/bridge/plugin_bridge_adapter.dart';
+import 'package:otzaria/settings/engine/settings_repository.dart';
+import 'package:otzaria/theme/app_fonts.dart';
+import 'package:otzaria/theme/app_theme_data.dart';
+import 'package:flutter/material.dart';
+
+import '../../test_helpers/memory_cache_provider.dart';
+
+/// ה-`@font-face` שאוצריא מזריקה ל-WebView של תוסף. משפחה חסרה, face בולד
+/// חסר או טווח משקלים חסר — כולם מתבטאים אצל המשתמש כגופן שגוי או מרוח.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    await Settings.init(cacheProvider: MemoryCacheProvider());
+  });
+
+  group('buildPluginFontFaceCss', () {
+    test('כל הגופנים המובנים נשלחים, לא רק שני הנבחרים בהגדרות', () async {
+      final css = await buildPluginFontFaceCss();
+      for (final family in AppFonts.fontPaths.keys) {
+        expect(
+          css,
+          contains("font-family:'$family'"),
+          reason: 'התוסף יכול לנקוב ב-$family, ובלי face הוא ייפול ל-fallback',
+        );
+      }
+    });
+
+    test('גופן עם קובץ בולד נפרד מקבל גם face של 700', () async {
+      final css = await buildPluginFontFaceCss();
+      final rules = css
+          .split('\n')
+          .where((r) => r.contains("font-family:'FrankRuhlCLM'"))
+          .toList();
+      expect(rules.length, 2);
+      expect(rules.where((r) => r.contains('font-weight:400')), hasLength(1));
+      expect(rules.where((r) => r.contains('font-weight:700')), hasLength(1));
+    });
+
+    test('גופן משתנה מקבל טווח משקלים ולא משקל בודד', () async {
+      final css = await buildPluginFontFaceCss();
+      for (final family in AppFonts.variableWeightFonts) {
+        if (!AppFonts.fontPaths.containsKey(family)) continue;
+        final rule = css
+            .split('\n')
+            .firstWhere((r) => r.contains("font-family:'$family'"));
+        expect(rule, contains('font-weight:100 900'));
+      }
+    });
+
+    test('גופן שאינו משתנה ואין לו קובץ בולד מקבל face יחיד', () async {
+      final css = await buildPluginFontFaceCss();
+      final rules = css
+          .split('\n')
+          .where((r) => r.contains("font-family:'Shofar'"))
+          .toList();
+      expect(rules, hasLength(1));
+      expect(rules.single, contains('font-weight:400'));
+    });
+  });
+
+  group('typography ב-theme payload', () {
+    test('ברירת המחדל היא משפחה שנשלחת בפועל כ-@font-face', () async {
+      final css = await buildPluginFontFaceCss();
+      final typography = _typography();
+      expect(css, contains("font-family:'${typography['fontFamily']}'"));
+      expect(
+        css,
+        contains("font-family:'${typography['commentatorsFontFamily']}'"),
+      );
+    });
+
+    test('גופן הממשק נפרד מגופן הקריאה ונשלח כ-@font-face', () async {
+      // בלי שדה נפרד, כותב תוסף מחיל את גופן הקריאה על כפתורים בני 12px,
+      // וגופן ספרים בגודל כזה נמרח.
+      final typography = _typography();
+      expect(typography['uiFontFamily'], isNot(typography['fontFamily']));
+      expect(
+        await buildPluginFontFaceCss(),
+        contains("font-family:'${typography['uiFontFamily']}'"),
+      );
+    });
+
+    test('גופן שנבחר בהגדרות הוא זה שמגיע ב-payload', () async {
+      await Settings.setValue<String>(
+        SettingsRepository.keyFontFamily,
+        'TaameyDavidCLM',
+      );
+      addTearDown(
+        () => Settings.setValue<String>(
+          SettingsRepository.keyFontFamily,
+          AppFonts.defaultFont,
+        ),
+      );
+      final typography = _typography();
+      expect(typography['fontFamily'], 'TaameyDavidCLM');
+    });
+  });
+}
+
+Map<String, dynamic> _typography() =>
+    buildThemePayloadFromScheme(
+          AppThemeData.createColorScheme(Colors.blue, Brightness.light),
+          isDark: false,
+        )['typography']
+        as Map<String, dynamic>;


### PR DESCRIPTION
## הרקע

דווח שהכתב בכפתורי תוסף עורך ה-Word נראה מטושטש. החקירה העלתה חמישה ליקויים ב-`@font-face` שאוצריא מזריקה ל-WebView, ואת מקור התקלה עצמה — בתיעוד של אוצריא.

## הליקויים

**1. הבולד נעלם.** ל-`FrankRuhlCLM` יש קובץ בולד נפרד, רשום ב-`pubspec.yaml`, אבל `AppFonts.fontPaths` מחזיקה קובץ אחד למשפחה — ה-Medium. התוסף קיבל `@font-face` יחיד **בלי דסקריפטור `font-weight` כלל**, ולכן כל טקסט מודגש עבר סינתוז מלאכותי של הדפדפן: ציור מרוח במקום ציור האות הבולד. בעורך Word זה כל טקסט מודגש במסמך.

**2. גופן משתנה ננעל על מופע אחד.** `Rubik`, `NotoRashiHebrew` ו-`NotoSerifHebrew` הם Variable Fonts עם ציר `wght`, אבל לא הוצהר עליהם `font-weight`. בלי טווח אין ל-WebView דרך להשתמש בציר — ושוב בולד מסונתז.

**3. נשלחו שתי משפחות מתוך תשע.** רק הראשי והמפרשים שנבחרו בהגדרות. תוסף שנוקב בשם משפחה אחרת קיבל fallback של מערכת ההפעלה בשקט. בורר הגופנים של עורך ה-Word מציע שש.

**4. גופן מערכת לא נשלח כלל.** `fontPaths` מכסה רק את המובנים, ואוצריא מאפשרת לבחור כל גופן עברי מותקן. במצב כזה נשלח שם משפחה בלי בייטים, וה-WebView לא יכול לפתור אותו.

**5. שם ברירת מחדל שגוי.** `buildThemePayloadFromScheme` נפל ל-`'Frank Ruhl Libre'` ול-`'Shofar'` במקום ל-`AppFonts.defaultFont` / `defaultCommentatorsFont`, כך שבפרופיל נקי השם שנשלח לא תאם את הגופן שהוזרק.

## הליקוי השישי — התיעוד לימד את הבאג

`docs/plugin-sdk/DESIGN_GUIDE.md` הראה:

```js
root.style.setProperty('--font-main', `'${t.fontFamily}', 'David', serif`);
```

ומיד אחר כך החיל `var(--font-main)` על `.btn-primary`, `.btn-secondary`, `.input` ו-`body`. כלומר גופן ספרים שמצויר לגוף טקסט, בכפתור בן 12px — שם הקווים הדקים שלו יוצאים דקים מפיקסל ונצבעים אפור. **תוסף שעקב אחרי המדריך הרשמי קיבל ממשק מטושטש.** זה בדיוק מה שקרה בעורך ה-Word ([Y-PLONI/otzaria-word-editor#4](https://github.com/Y-PLONI/otzaria-word-editor/pull/4)).

## התיקון

- כל המשפחות המובנות נשלחות, כל אחת עם ה-face הבולד האמיתי שלה או עם `font-weight: 100 900` בגופן משתנה.
- גופן מערכת שנבחר בהגדרות נשלח עם הבייטים שלו (רגיל + בולד).
- ברירות המחדל יושרו ל-`AppFonts`.
- `typography` מוסר גם `uiFontFamily` (`Rubik` — sans מובנה שנשאר חד בקטן). **אופציונלי**, כדי שמארח ישן לא ישבור טיפוסים בתוספים.
- המדריך מפריד `--font-ui` מ-`--font-main`, כל דוגמאות ה-chrome עברו ל-`--font-ui`, ונוספה אזהרה מפורשת „גופן ממשק ≠ גופן קריאה”.
- עודכנו שתי הערות תיעוד שכבר לא תאמו את המימוש.

## בדיקות

`test/plugins/bridge/plugin_font_face_css_test.dart` — 7 בדיקות שנועלות: כל המשפחות נשלחות, face בולד לגופן עם קובץ נפרד, טווח משקלים לגופן משתנה, face יחיד לגופן שאין לו בולד, וגופן הממשק נפרד מגופן הקריאה ונשלח בפועל.

| | |
|---|---|
| `flutter analyze lib/plugins/ lib/theme/ test/plugins/` | No issues found |
| `flutter test test/plugins/ test/theme/ test/settings/` | 2435 עוברות |

## הסתייגויות

**כשל אחד בהרצה, קדם לשינוי.** `test/settings/services/custom_folders/custom_folder_model_test.dart` נכשל על מפריד נתיב (`\` מול `/`) — כשל תלוי-פלטפורמה בווינדוס. אימתתי בהחסנה שהוא נכשל גם על `dev` נקי בלי השינוי הזה.

**משקל ההזרקה גדל.** נשלחות כעת כל המשפחות במקום שתיים — כ-2MB base64, מחושב פעם אחת לתהליך ונשמר בקאש. ה-WebView מפענח גופן רק בשימוש בפועל, כך שהעלות בזיכרון נשארת נמוכה. אם עדיף לצמצם, הכיוון הנכון הוא API שבו התוסף מבקש משפחות לפי צורך דרך `PluginFileServer` הקיים — שינוי נפרד.

**לא נבדק חזותית.** ההסקה מהקוד ומהבדיקות.

**אין issue פתוח תואם.** נסרקו 28 ה-issues הפתוחים; אף אחד אינו נוגע בגופני תוספים. התקלה עלתה מדיווח משתמש.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
