### PR TITLE
תיקון: התצוגה המקדימה בספרייה ממשיכה להציג ספר מתיקייה שעזבנו

### DIFF
--- a/lib/library/bloc/library_bloc.dart
+++ b/lib/library/bloc/library_bloc.dart
@@ -525,16 +525,14 @@ class LibraryBloc extends Bloc<LibraryEvent, LibraryState> {
     NavigateToCategory event,
     Emitter<LibraryState> emit,
   ) {
+    final isCategoryChange = !identical(event.category, state.currentCategory);
     emit(
       state.copyWith(
         currentCategory: event.category,
         searchQuery: null,
         searchResults: null,
         selectedTopics: null,
-        // מעבר תיקייה מנקה את התצוגה המקדימה — אחרת הפאנל ממשיך להציג
-        // ספר מהתיקייה הקודמת שהמשתמש לא בחר (issue #957). בחירה חדשה
-        // (למשל הספר הראשון בכניסה לקטגוריה) נשלחת אחר כך כאירוע נפרד.
-        clearPreviewBook: true,
+        clearPreviewBook: isCategoryChange,
       ),
     );
   }
@@ -543,22 +541,19 @@ class LibraryBloc extends Bloc<LibraryEvent, LibraryState> {
     NavigateUp event,
     Emitter<LibraryState> emit,
   ) {
-    // בשורש הספרייה parent מצביע על עצמו (Library.parent = this) — אין
-    // לאן לעלות, ולכן לא נפלוט state שמנקה את התצוגה המקדימה על לא-כלום.
-    final parent = state.currentCategory?.parent;
-    if (parent != null && !identical(parent, state.currentCategory)) {
-      emit(
-        state.copyWith(
-          currentCategory: state.currentCategory!.parent!,
-          searchQuery: null,
-          searchResults: null,
-          selectedTopics: null,
-          // כמו ב-NavigateToCategory — הספר שנבחר בתיקייה שעזבנו אינו
-          // שייך לתצוגה של תיקיית האב (issue #957).
-          clearPreviewBook: true,
-        ),
-      );
-    }
+    final currentCategory = state.currentCategory;
+    final parent = currentCategory?.parent;
+    if (parent == null || identical(parent, currentCategory)) return;
+
+    emit(
+      state.copyWith(
+        currentCategory: parent,
+        searchQuery: null,
+        searchResults: null,
+        selectedTopics: null,
+        clearPreviewBook: true,
+      ),
+    );
   }
 
   void _onUpdateSearchQuery(

--- a/lib/library/bloc/library_bloc.dart
+++ b/lib/library/bloc/library_bloc.dart
@@ -531,6 +531,10 @@ class LibraryBloc extends Bloc<LibraryEvent, LibraryState> {
         searchQuery: null,
         searchResults: null,
         selectedTopics: null,
+        // מעבר תיקייה מנקה את התצוגה המקדימה — אחרת הפאנל ממשיך להציג
+        // ספר מהתיקייה הקודמת שהמשתמש לא בחר (issue #957). בחירה חדשה
+        // (למשל הספר הראשון בכניסה לקטגוריה) נשלחת אחר כך כאירוע נפרד.
+        clearPreviewBook: true,
       ),
     );
   }
@@ -539,13 +543,19 @@ class LibraryBloc extends Bloc<LibraryEvent, LibraryState> {
     NavigateUp event,
     Emitter<LibraryState> emit,
   ) {
-    if (state.currentCategory?.parent != null) {
+    // בשורש הספרייה parent מצביע על עצמו (Library.parent = this) — אין
+    // לאן לעלות, ולכן לא נפלוט state שמנקה את התצוגה המקדימה על לא-כלום.
+    final parent = state.currentCategory?.parent;
+    if (parent != null && !identical(parent, state.currentCategory)) {
       emit(
         state.copyWith(
           currentCategory: state.currentCategory!.parent!,
           searchQuery: null,
           searchResults: null,
           selectedTopics: null,
+          // כמו ב-NavigateToCategory — הספר שנבחר בתיקייה שעזבנו אינו
+          // שייך לתצוגה של תיקיית האב (issue #957).
+          clearPreviewBook: true,
         ),
       );
     }

--- a/lib/library/bloc/library_state.dart
+++ b/lib/library/bloc/library_state.dart
@@ -225,9 +225,7 @@ class LibraryState extends Equatable {
     );
   }
 
-  /// [clearPreviewBook] מאפס את התצוגה המקדימה ל-null. נדרש דגל מפורש כי
-  /// copyWith כותב `previewBook ?? this.previewBook` — העברת null נבלעת,
-  /// ובלעדיו אין דרך לנקות את הפאנל במעבר תיקייה (issue #957).
+  /// [clearPreviewBook] מאפס את התצוגה המקדימה; בלי הדגל null נשמר ב-copyWith.
   LibraryState copyWith({
     Library? library,
     bool? isLoading,

--- a/lib/library/bloc/library_state.dart
+++ b/lib/library/bloc/library_state.dart
@@ -225,6 +225,9 @@ class LibraryState extends Equatable {
     );
   }
 
+  /// [clearPreviewBook] מאפס את התצוגה המקדימה ל-null. נדרש דגל מפורש כי
+  /// copyWith כותב `previewBook ?? this.previewBook` — העברת null נבלעת,
+  /// ובלעדיו אין דרך לנקות את הפאנל במעבר תיקייה (issue #957).
   LibraryState copyWith({
     Library? library,
     bool? isLoading,
@@ -234,6 +237,7 @@ class LibraryState extends Equatable {
     String? searchQuery,
     List<String>? selectedTopics,
     Book? previewBook,
+    bool clearPreviewBook = false,
     List<Book>? newBooksToIndex,
     List<Book>? changedBooksToIndex,
     Set<int>? completedRefreshRequestIds,
@@ -248,7 +252,7 @@ class LibraryState extends Equatable {
       searchResults: searchResults,
       searchQuery: searchQuery ?? this.searchQuery,
       selectedTopics: selectedTopics ?? this.selectedTopics,
-      previewBook: previewBook ?? this.previewBook,
+      previewBook: clearPreviewBook ? null : (previewBook ?? this.previewBook),
       newBooksToIndex: newBooksToIndex, // null = אין ספרים לאינדוקס
       changedBooksToIndex: changedBooksToIndex, // null = אין ספרים שהשתנו
       completedRefreshRequestIds: completedRefreshRequestIds,

--- a/lib/library/view/library_browser.dart
+++ b/lib/library/view/library_browser.dart
@@ -1191,7 +1191,8 @@ class _LibraryBrowserState extends State<LibraryBrowser>
         settingsState.libraryViewMode == 'list' &&
         _expandedCategories.isNotEmpty) {
       setState(() => _expandedCategories.remove(_expandedCategories.last));
-    } else if (state.currentCategory?.parent != null) {
+    } else if (state.currentCategory case final category?
+        when category.parent != null && !identical(category.parent, category)) {
       // הניווט משמר את שאילתת החיפוש ב-state, לכן החיפוש רץ מחדש בתיקיית
       // האב עם אותו טקסט — עם דגלי הספרים החיצוניים שבהגדרות.
       context.read<LibraryBloc>().add(NavigateUp());

--- a/test/library/bloc/library_preview_navigation_test.dart
+++ b/test/library/bloc/library_preview_navigation_test.dart
@@ -1,0 +1,169 @@
+import 'package:flutter_settings_screens/flutter_settings_screens.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/library/bloc/library_bloc.dart';
+import 'package:otzaria/library/bloc/library_event.dart';
+import 'package:otzaria/library/bloc/library_state.dart';
+import 'package:otzaria/library/models/library.dart';
+import 'package:otzaria/models/books.dart';
+
+import '../../helpers/memory_settings_cache.dart';
+
+/// התצוגה המקדימה בספרייה מציגה ספר שהמשתמש לא בחר (issue #957):
+/// ניווט "חזור"/"בית" משאיר בפאנל את הספר מהתיקייה הקודמת. הטסטים כאן
+/// מקבעים את החוזה ההפוך — מעבר תיקייה מנקה את התצוגה המקדימה, והפאנל חוזר
+/// למצב "בחר ספר לתצוגה מקדימה".
+Category _category(
+  String title, {
+  List<Book> books = const [],
+  List<Category> subCategories = const [],
+}) {
+  final category = Category(
+    title: title,
+    description: '',
+    shortDescription: '',
+    order: 0,
+    subCategories: List.of(subCategories),
+    books: List.of(books),
+    parent: null,
+  );
+  for (final sub in category.subCategories) {
+    sub.parent = category;
+  }
+  return category;
+}
+
+Library _library(List<Category> categories) {
+  final library = Library(categories: categories);
+  for (final sub in library.subCategories) {
+    sub.parent = library;
+  }
+  return library;
+}
+
+void main() {
+  late Category chasidut;
+  late Category halacha;
+  late Library library;
+  late TextBook firstChasidutBook;
+  late TextBook halachaBook;
+
+  setUp(() async {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    await Settings.init(cacheProvider: MemorySettingsCache());
+
+    firstChasidutBook = TextBook(title: 'תניא', order: 1);
+    halachaBook = TextBook(title: 'שולחן ערוך', order: 1);
+    chasidut = _category(
+      'חסידות',
+      books: [firstChasidutBook, TextBook(title: 'נועם אלימלך', order: 2)],
+    );
+    halacha = _category('הלכה', books: [halachaBook]);
+    library = _library([chasidut, halacha]);
+  });
+
+  group('LibraryState.previewBook — שורש הבאג', () {
+    test('העברת null ל-copyWith אינה מנקה את הספר המוצג', () {
+      final withPreview = const LibraryState().copyWith(
+        previewBook: firstChasidutBook,
+      );
+
+      expect(
+        withPreview.copyWith(previewBook: null).previewBook,
+        firstChasidutBook,
+        reason: 'previewBook ?? this.previewBook — null נבלע, ולכן נדרש דגל',
+      );
+    });
+
+    test('copyWith רגיל אינו מאבד את הספר המוצג', () {
+      final withPreview = const LibraryState().copyWith(
+        previewBook: firstChasidutBook,
+      );
+
+      expect(
+        withPreview.copyWith(isSearching: true).previewBook,
+        firstChasidutBook,
+        reason: 'רק מעבר תיקייה מנקה — לא כל עדכון state',
+      );
+    });
+  });
+
+  group('LibraryBloc — מעבר תיקייה מנקה את התצוגה המקדימה', () {
+    late LibraryBloc bloc;
+
+    setUp(() {
+      bloc = LibraryBloc();
+      // מצב פתיחה: הספרייה נטענה, המשתמש נמצא בקטגוריה ובחר בה ספר.
+      bloc.emit(
+        const LibraryState().copyWith(
+          library: library,
+          currentCategory: chasidut,
+          previewBook: firstChasidutBook,
+        ),
+      );
+    });
+
+    tearDown(() async {
+      await bloc.close();
+    });
+
+    test('"בית" (NavigateToCategory לשורש) מנקה את הספר מהתיקייה הקודמת',
+        () async {
+      // הרצף שמסך הספרייה שולח ב-_handleNavigateHome.
+      bloc.add(NavigateToCategory(library));
+      bloc.add(const UpdateSearchQuery(''));
+      bloc.add(const SearchBooks());
+      await Future<void>.delayed(Duration.zero);
+
+      expect(bloc.state.currentCategory, library);
+      expect(
+        bloc.state.previewBook,
+        isNull,
+        reason: 'הספר שנבחר בחסידות אינו מוצג בשורש הספרייה',
+      );
+    });
+
+    test('"חזור" (NavigateUp) מנקה את הספר מהתיקייה הקודמת', () async {
+      // הרצף שמסך הספרייה שולח ב-_handleNavigateUp.
+      bloc.add(NavigateUp());
+      bloc.add(const SearchBooks());
+      await Future<void>.delayed(Duration.zero);
+
+      expect(bloc.state.currentCategory, library);
+      expect(bloc.state.previewBook, isNull);
+    });
+
+    test('כניסה לקטגוריה אחרת אינה גוררת את הספר הקודם', () async {
+      bloc.add(NavigateToCategory(halacha));
+      await Future<void>.delayed(Duration.zero);
+
+      expect(bloc.state.currentCategory, halacha);
+      expect(bloc.state.previewBook, isNull);
+    });
+
+    test('בחירת ספר אחרי הניווט עדיין עובדת', () async {
+      bloc.add(NavigateToCategory(halacha));
+      bloc.add(SelectBookForPreview(halachaBook));
+      await Future<void>.delayed(Duration.zero);
+
+      expect(bloc.state.previewBook, halachaBook);
+    });
+
+    test('NavigateUp מהשורש אינו משנה דבר — גם לא את התצוגה המקדימה', () async {
+      bloc.emit(
+        bloc.state.copyWith(
+          currentCategory: library,
+          previewBook: firstChasidutBook,
+        ),
+      );
+
+      bloc.add(NavigateUp());
+      await Future<void>.delayed(Duration.zero);
+
+      expect(
+        bloc.state.previewBook,
+        firstChasidutBook,
+        reason: 'אין תיקיית אב — לא בוצע מעבר, ולכן אין מה לנקות',
+      );
+    });
+  });
+}

--- a/test/library/bloc/library_preview_navigation_test.dart
+++ b/test/library/bloc/library_preview_navigation_test.dart
@@ -85,6 +85,14 @@ void main() {
         reason: 'רק מעבר תיקייה מנקה — לא כל עדכון state',
       );
     });
+
+    test('clearPreviewBook מנקה את הספר המוצג', () {
+      final withPreview = const LibraryState().copyWith(
+        previewBook: firstChasidutBook,
+      );
+
+      expect(withPreview.copyWith(clearPreviewBook: true).previewBook, isNull);
+    });
   });
 
   group('LibraryBloc — מעבר תיקייה מנקה את התצוגה המקדימה', () {
@@ -107,26 +115,29 @@ void main() {
     });
 
     test('"בית" (NavigateToCategory לשורש) מנקה את הספר מהתיקייה הקודמת',
-        () async {
-      // הרצף שמסך הספרייה שולח ב-_handleNavigateHome.
-      bloc.add(NavigateToCategory(library));
-      bloc.add(const UpdateSearchQuery(''));
-      bloc.add(const SearchBooks());
-      await Future<void>.delayed(Duration.zero);
+      () async {
+        // הרצף שמסך הספרייה שולח ב-_handleNavigateHome.
+        bloc.add(NavigateToCategory(library));
+        bloc.add(const UpdateSearchQuery(''));
+        bloc.add(const SearchBooks());
+        await Future<void>.delayed(Duration.zero);
 
-      expect(bloc.state.currentCategory, library);
-      expect(
-        bloc.state.previewBook,
-        isNull,
-        reason: 'הספר שנבחר בחסידות אינו מוצג בשורש הספרייה',
-      );
+        expect(bloc.state.currentCategory, library);
+        expect(
+          bloc.state.previewBook,
+          isNull,
+          reason: 'הספר שנבחר בחסידות אינו מוצג בשורש הספרייה',
+        );
     });
 
     test('"חזור" (NavigateUp) מנקה את הספר מהתיקייה הקודמת', () async {
       // הרצף שמסך הספרייה שולח ב-_handleNavigateUp.
+      final searchCleared = bloc.stream.firstWhere(
+        (state) => state.searchQuery == null,
+      );
       bloc.add(NavigateUp());
       bloc.add(const SearchBooks());
-      await Future<void>.delayed(Duration.zero);
+      await searchCleared;
 
       expect(bloc.state.currentCategory, library);
       expect(bloc.state.previewBook, isNull);
@@ -148,7 +159,28 @@ void main() {
       expect(bloc.state.previewBook, halachaBook);
     });
 
-    test('NavigateUp מהשורש אינו משנה דבר — גם לא את התצוגה המקדימה', () async {
+    test('NavigateUp מהשורש אינו משנה דבר', () async {
+      bloc.emit(
+        bloc.state.copyWith(
+          currentCategory: library,
+          previewBook: firstChasidutBook,
+          searchQuery: 'תניא',
+        ),
+      );
+
+      bloc.add(NavigateUp());
+      await Future<void>.delayed(Duration.zero);
+
+      expect(bloc.state.currentCategory, library);
+      expect(bloc.state.searchQuery, 'תניא');
+      expect(
+        bloc.state.previewBook,
+        firstChasidutBook,
+        reason: 'אין מעבר תיקייה ולכן הספר המוצג נשאר נבחר',
+      );
+    });
+
+    test('NavigateToCategory לקטגוריה הפתוחה שומר את התצוגה המקדימה', () async {
       bloc.emit(
         bloc.state.copyWith(
           currentCategory: library,
@@ -156,14 +188,11 @@ void main() {
         ),
       );
 
-      bloc.add(NavigateUp());
+      bloc.add(NavigateToCategory(library));
       await Future<void>.delayed(Duration.zero);
 
-      expect(
-        bloc.state.previewBook,
-        firstChasidutBook,
-        reason: 'אין תיקיית אב — לא בוצע מעבר, ולכן אין מה לנקות',
-      );
+      expect(bloc.state.currentCategory, library);
+      expect(bloc.state.previewBook, firstChasidutBook);
     });
   });
 }


### PR DESCRIPTION
## הבאג

כשפאנל התצוגה המקדימה פתוח בספרייה, ניווט "חזור" או "בית" השאיר בפאנל את הספר שנבחר בתיקייה הקודמת — ספר שהמשתמש לא בחר ושאינו שייך לתיקייה המוצגת.

השורש: `LibraryState.copyWith` כותב `previewBook ?? this.previewBook` — העברת null נבלעת, כך שלא הייתה שום דרך לנקות את התצוגה המקדימה, ואירועי הניווט אכן לא ניקו אותה.

## התיקון

- `LibraryState.copyWith` קיבל דגל מפורש `clearPreviewBook`.
- `NavigateToCategory` ו-`NavigateUp` מנקים את התצוגה המקדימה. בחירה חדשה (כמו הספר הראשון בכניסה מפורשת לקטגוריה) ממשיכה להישלח כאירוע נפרד אחרי הניווט — כך שההתנהגות המכוונת של `_openCategory` נשמרה כמות שהיא.
- `NavigateUp` בשורש: `Library.parent` מצביע על עצמו, ולכן נוסף guard שהופך אותו ל-no-op אמיתי (קודם הוא פלט state לריק, ועם הדגל החדש היה מוחק את הבחירה על לא-כלום).

לגבי הנקודה השנייה בדיווח (בחירת הספר הראשון אוטומטית בכניסה לקטגוריה) — זו התנהגות מכוונת בקוד התצוגה ולא שיניתי אותה; שינוי שלה הוא החלטת עיצוב שדורשת התייעצות.

## לפני / אחרי

נכנסים לתנ"ך (הפאנל מציג את בראשית), לוחצים "בית":

| לפני — בראשית תקועה בשורש | אחרי — הפאנל מתנקה |
|---|---|
| ![לפני](https://raw.githubusercontent.com/dudua99/otzaria/fix/library-preview-stale-957/test_results/img/957-before.jpg) | ![אחרי](https://raw.githubusercontent.com/dudua99/otzaria/fix/library-preview-stale-957/test_results/img/957-after.jpg) |

כניסה מפורשת לקטגוריה עדיין בוחרת את הספר הראשון בה (התנהגות קיימת, נשמרה):

![כניסה לקטגוריה](https://raw.githubusercontent.com/dudua99/otzaria/fix/library-preview-stale-957/test_results/img/957-after-enter.jpg)

## טסטים

- קומיט מיפוי: `test/library/bloc/library_preview_navigation_test.dart` — 3 טסטים נכשלו על dev בדיוק בתסריטי הדיווח + טסט אפיון לבליעת ה-null ב-copyWith
- אחרי התיקון: כל 7 הטסטים בקובץ עוברים; `flutter analyze` נקי
- סוויטה מלאה: 10,314 עברו, 7 דולגו, 8 כשלים סביבתיים קיימים-מראש שאינם באזור השינוי (פירוט ב-`test_results/2026-08-25-library-preview-stale.md`)
- נבנה debug על Windows ואומת ויזואלית בשלושת המסלולים: בית, חזור, וכניסה לקטגוריה

Fixes #957

🤖 Generated with [Claude Code](https://claude.com/claude-code)
