### PR TITLE
חיווי למשתמש כשיצירת ה-WebView של תוסף נכשלת (issue #1015)

### DIFF
--- a/lib/plugins/view/plugin_tab_page.dart
+++ b/lib/plugins/view/plugin_tab_page.dart
@@ -118,6 +118,24 @@ const String _sdkStub = r'''
 
 /// הגדרות ה-WebView של טאב תוסף.
 @visibleForTesting
+/// האם אירוע כשל היצירה שייך לטאב הזה.
+///
+/// ה-stream של הפלאגין גלובלי, וכמה WebViewים נוצרים במקביל (מארח הרקע
+/// וטאבים) — בלי התאמה לפי [failureUrl] כשל של מופע אחד היה מחליף במסך
+/// שגיאה טאב שיצירתו עדיין עשויה להצליח. אירוע בלי URL (מקור לא ידוע)
+/// עדיין מטופל, כדי לא לאבד את החיווי שבגללו נוסף המנגנון.
+@visibleForTesting
+bool shouldHandleCreationFailure({
+  required String? failureUrl,
+  required String expectedUrl,
+  required bool isCreated,
+  required bool alreadyFailed,
+}) {
+  if (isCreated || alreadyFailed) return false;
+  if (failureUrl == null || failureUrl.isEmpty) return true;
+  return failureUrl == expectedUrl;
+}
+
 InAppWebViewSettings buildPluginTabWebViewSettings({
   required bool isDevelopment,
 }) {
@@ -428,10 +446,14 @@ class _PluginTabPageState extends State<PluginTabPage> {
     }
   }
 
-  /// האירוע גלובלי ולא נושא מזהה תוסף — רק טאב שעדיין ממתין ליצירה מגיב לו,
-  /// כדי שכשל בטאב אחד לא יחליף תוסף שכבר רץ במסך שגיאה.
   void _onCreationFailure(WindowsWebViewCreationFailure failure) {
-    if (!mounted || webViewController != null || _creationFailure != null) {
+    if (!mounted ||
+        !shouldHandleCreationFailure(
+          failureUrl: failure.requestedUrl,
+          expectedUrl: _expectedCreationUrl(),
+          isCreated: webViewController != null,
+          alreadyFailed: _creationFailure != null,
+        )) {
       return;
     }
     _creationWatchdog?.cancel();
@@ -447,6 +469,11 @@ class _PluginTabPageState extends State<PluginTabPage> {
     );
     setState(() => _creationFailure = failure.error.toString());
   }
+
+  /// ה-URL שהטאב הזה ביקש ליצור — מפתח ההתאמה מול אירוע כשל.
+  String _expectedCreationUrl() => widget.plugin.isLocalhostDev
+      ? WebUri(localHtmlPath).toString()
+      : WebUri.uri(Uri.file(localHtmlPath)).toString();
 
   Future<void> _ensurePackageInfo() async {
     _cachedPackageInfo ??= await PackageInfo.fromPlatform();

--- a/lib/plugins/view/plugin_tab_page.dart
+++ b/lib/plugins/view/plugin_tab_page.dart
@@ -116,22 +116,18 @@ const String _sdkStub = r'''
 })();
 ''';
 
-/// הגדרות ה-WebView של טאב תוסף.
-@visibleForTesting
 /// האם אירוע כשל היצירה שייך לטאב הזה.
-///
-/// ה-stream של הפלאגין גלובלי, וכמה WebViewים נוצרים במקביל (מארח הרקע
-/// וטאבים) — בלי התאמה לפי [failureUrl] כשל של מופע אחד היה מחליף במסך
-/// שגיאה טאב שיצירתו עדיין עשויה להצליח. אירוע בלי URL (מקור לא ידוע)
-/// עדיין מטופל, כדי לא לאבד את החיווי שבגללו נוסף המנגנון.
 @visibleForTesting
 bool shouldHandleCreationFailure({
+  required Key? failureKey,
+  required Key expectedKey,
   required String? failureUrl,
   required String expectedUrl,
   required bool isCreated,
   required bool alreadyFailed,
 }) {
   if (isCreated || alreadyFailed) return false;
+  if (failureKey != null) return failureKey == expectedKey;
   if (failureUrl == null || failureUrl.isEmpty) return true;
   return failureUrl == expectedUrl;
 }
@@ -449,6 +445,8 @@ class _PluginTabPageState extends State<PluginTabPage> {
   void _onCreationFailure(WindowsWebViewCreationFailure failure) {
     if (!mounted ||
         !shouldHandleCreationFailure(
+          failureKey: failure.creationKey,
+          expectedKey: _webViewKey,
           failureUrl: failure.requestedUrl,
           expectedUrl: _expectedCreationUrl(),
           isCreated: webViewController != null,

--- a/lib/plugins/view/plugin_tab_page.dart
+++ b/lib/plugins/view/plugin_tab_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+import 'package:flutter_inappwebview_windows/flutter_inappwebview_windows.dart';
 import 'package:flutter_settings_screens/flutter_settings_screens.dart';
 import 'package:otzaria/core/connectivity_status_service.dart';
 import 'package:otzaria/plugins/models/installed_plugin.dart';
@@ -43,6 +44,8 @@ import 'package:otzaria/plugins/services/plugin_webview_failure_log.dart';
 import 'package:otzaria/plugins/services/plugin_network_gate.dart';
 import 'package:otzaria/plugins/view/plugin_crashed_view.dart';
 import 'package:otzaria/plugins/view/plugin_webview2_missing_view.dart';
+import 'package:otzaria/plugins/view/plugin_webview_failed_view.dart';
+import 'package:otzaria/plugins/services/windows_arch_info.dart';
 import 'package:otzaria/plugins/view/plugin_drop_guard_script.dart';
 import 'package:otzaria/plugins/services/plugin_file_server.dart';
 import 'package:otzaria/plugins/services/plugin_download_handler.dart';
@@ -191,6 +194,10 @@ class _PluginTabPageState extends State<PluginTabPage> {
   // כשל יצירה native לא מפעיל אף callback ב-Dart — נשאר רק מסך ריק.
   // השעון נדרך בבניית ה-WebView ומבוטל ב-onWebViewCreated, כדי לרשום ללוג.
   Timer? _creationWatchdog;
+
+  // כשל היצירה מגיע מהפלאגין כאירוע גלובלי (אין callback על ה-widget).
+  StreamSubscription<WindowsWebViewCreationFailure>? _creationFailureSub;
+  String? _creationFailure;
 
   // Cache PackageInfo so the async gap in onLoadStop never crosses a dispose
   static PackageInfo? _cachedPackageInfo;
@@ -421,6 +428,26 @@ class _PluginTabPageState extends State<PluginTabPage> {
     }
   }
 
+  /// האירוע גלובלי ולא נושא מזהה תוסף — רק טאב שעדיין ממתין ליצירה מגיב לו,
+  /// כדי שכשל בטאב אחד לא יחליף תוסף שכבר רץ במסך שגיאה.
+  void _onCreationFailure(WindowsWebViewCreationFailure failure) {
+    if (!mounted || webViewController != null || _creationFailure != null) {
+      return;
+    }
+    _creationWatchdog?.cancel();
+    _creationWatchdog = null;
+    logPluginWebViewFailure(
+      'Plugin WebView creation failed',
+      failure.error,
+      stackTrace: failure.stackTrace,
+      details: {
+        'Plugin': widget.plugin.pluginId,
+        'EmulatedOnArm': WindowsArchInfo.isEmulatedOnArm ? 'true' : 'false',
+      },
+    );
+    setState(() => _creationFailure = failure.error.toString());
+  }
+
   Future<void> _ensurePackageInfo() async {
     _cachedPackageInfo ??= await PackageInfo.fromPlatform();
   }
@@ -435,6 +462,7 @@ class _PluginTabPageState extends State<PluginTabPage> {
       owner: widget.instanceId,
     );
     _creationWatchdog?.cancel();
+    unawaited(_creationFailureSub?.cancel());
     final pluginId = widget.plugin.pluginId;
     final instanceId = widget.instanceId;
     final controller = webViewController;
@@ -568,6 +596,18 @@ class _PluginTabPageState extends State<PluginTabPage> {
   );
 
   Widget _buildWebView() {
+    if (_creationFailure != null) {
+      return PluginWebViewFailedView(
+        pluginName: widget.plugin.name,
+        errorDetails: _creationFailure,
+        isEmulatedOnArm: WindowsArchInfo.isEmulatedOnArm,
+        onRetry: () {
+          if (!mounted) return;
+          setState(() => _creationFailure = null);
+        },
+      );
+    }
+
     if (_creationWatchdog == null && webViewController == null) {
       _creationWatchdog = Timer(const Duration(seconds: 20), () {
         logPluginWebViewFailure(
@@ -576,6 +616,9 @@ class _PluginTabPageState extends State<PluginTabPage> {
           details: {'Plugin': widget.plugin.pluginId},
         );
       });
+      _creationFailureSub ??= WindowsWebViewCreationFailures.stream.listen(
+        _onCreationFailure,
+      );
     }
     final initialUrl = widget.plugin.isLocalhostDev
         ? WebUri(localHtmlPath)
@@ -598,6 +641,8 @@ class _PluginTabPageState extends State<PluginTabPage> {
       ]),
       onWebViewCreated: (controller) {
         _creationWatchdog?.cancel();
+        unawaited(_creationFailureSub?.cancel());
+        _creationFailureSub = null;
         // מסמנים שמתחיל ניסיון טעינה. שימוש בגרסה הסינכרונית מבטיח שהקובץ
         // מתעדכן מיד (לפני שיש הזדמנות ל-dispose לרוץ ולנקות ריק) — אחרת
         // קיים race שבו סגירה מהירה של הטאב לפני שה-Future של ה-async

--- a/lib/plugins/view/plugin_webview_failed_view.dart
+++ b/lib/plugins/view/plugin_webview_failed_view.dart
@@ -1,0 +1,128 @@
+import 'package:flutter/material.dart';
+import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:otzaria/theme/app_tokens.dart';
+
+import 'package:otzaria/widgets/controls/action_buttons.dart';
+import 'package:otzaria/widgets/layout/centered_scrollable_state.dart';
+
+/// תצוגה שמופיעה במקום ה-WebView כשיצירת רכיב הדפדפן נכשלה — מצב שעד כה
+/// הסתיים במסך ריק בלי שום הסבר. [isEmulatedOnArm] מחליף את ההסבר הכללי
+/// בהסבר הספציפי למחשבי ARM, שם התקלה ידועה ואין למשתמש מה לתקן.
+class PluginWebViewFailedView extends StatelessWidget {
+  final String? pluginName;
+
+  /// פרטי השגיאה מהשכבה הנייטיבית (כולל HRESULT) — להצגה מכווצת לדיווח.
+  final String? errorDetails;
+
+  final bool isEmulatedOnArm;
+
+  final VoidCallback onRetry;
+
+  const PluginWebViewFailedView({
+    super.key,
+    required this.onRetry,
+    this.pluginName,
+    this.errorDetails,
+    this.isEmulatedOnArm = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final cs = Theme.of(context).colorScheme;
+    final tt = Theme.of(context).textTheme;
+    final label = pluginName == null ? 'התוסף' : 'התוסף "$pluginName"';
+
+    return CenteredScrollableState(
+      padding: const EdgeInsets.all(32),
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(maxWidth: 540),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Icon(
+              FluentIcons.globe_prohibited_24_regular,
+              size: 56,
+              color: cs.error,
+            ),
+            const SizedBox(height: 16),
+            Text(
+              isEmulatedOnArm
+                  ? 'התוספים אינם נתמכים עדיין במחשב זה'
+                  : 'לא ניתן להפעיל את $label',
+              style: tt.titleLarge,
+            ),
+            const SizedBox(height: 12),
+            Text(
+              isEmulatedOnArm
+                  ? 'המחשב שלך מבוסס מעבד ARM, ואוצריא עדיין רצה עליו במצב '
+                        'תאימות. במצב זה רכיב הדפדפן שמציג את התוספים אינו '
+                        'נוצר, ולכן התוספים וחנות התוספים אינם זמינים. '
+                        'התמיכה בגרסה ייעודית למחשבי ARM נמצאת בעבודה.'
+                  : 'יצירת רכיב הדפדפן שמציג את התוספים נכשלה במחשב זה, ולכן '
+                        '$label לא נטען. שאר חלקי התוכנה — ספרים, חיפוש וכלים '
+                        'שאינם תוספים — ממשיכים לעבוד כרגיל.',
+              style: tt.bodyMedium,
+            ),
+            const SizedBox(height: 16),
+            Container(
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: cs.surfaceContainerHighest,
+                borderRadius: AppTokens.borderRadiusAll,
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text('מה אפשר לעשות:', style: tt.titleSmall),
+                  const SizedBox(height: 8),
+                  Text(
+                    isEmulatedOnArm
+                        ? '1. אפשר להמשיך להשתמש בכל שאר חלקי התוכנה כרגיל.\n'
+                              '2. כדאי לעקוב אחר עדכוני הגרסה — כשתצא גרסה '
+                              'למחשבי ARM התוספים יעבדו.\n'
+                              '3. אם ברצונך לסייע בבדיקת גרסה כזו — דווח לצוות '
+                              'הפיתוח שברשותך מחשב ARM.'
+                        : '1. לחץ "נסה שוב" — לעיתים מדובר בכשל חולף.\n'
+                              '2. אם הבעיה חוזרת, הפעל מחדש את התוכנה, ואם גם '
+                              'זה לא עזר — את המחשב.\n'
+                              '3. אם הבעיה נמשכת, דווח לצוות הפיתוח וצרף את '
+                              'פרטי השגיאה שלהלן.',
+                    style: tt.bodySmall,
+                  ),
+                ],
+              ),
+            ),
+            if (errorDetails != null) ...[
+              const SizedBox(height: 12),
+              ExpansionTile(
+                tilePadding: EdgeInsets.zero,
+                title: Text('פרטי השגיאה', style: tt.titleSmall),
+                children: [
+                  Align(
+                    alignment: AlignmentDirectional.centerStart,
+                    child: SelectableText(
+                      errorDetails!,
+                      style: tt.bodySmall,
+                      textDirection: TextDirection.ltr,
+                    ),
+                  ),
+                ],
+              ),
+            ],
+            const SizedBox(height: 16),
+            Row(
+              children: [
+                ActionButton.recommended(
+                  text: 'נסה שוב',
+                  icon: FluentIcons.arrow_clockwise_24_regular,
+                  onPressed: onRetry,
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/test/plugins/view/plugin_creation_failure_routing_test.dart
+++ b/test/plugins/view/plugin_creation_failure_routing_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:otzaria/plugins/view/plugin_tab_page.dart';
 
@@ -6,13 +7,17 @@ import 'package:otzaria/plugins/view/plugin_tab_page.dart';
 void main() {
   const tabUrl = 'file:///plugins/a/index.html';
   const otherUrl = 'file:///plugins/b/index.html';
+  const tabKey = ValueKey<String>('tab-a');
+  const otherKey = ValueKey<String>('tab-b');
 
   group('shouldHandleCreationFailure', () {
-    test('שתי יצירות מקבילות — רק בעל ה-URL התואם מגיב', () {
+    test('שתי יצירות מקבילות עם אותו URL — רק בעל המפתח התואם מגיב', () {
       // הטאב של תוסף A ממתין; הכשל שייך למופע של תוסף B.
       expect(
         shouldHandleCreationFailure(
-          failureUrl: otherUrl,
+          failureKey: otherKey,
+          expectedKey: tabKey,
+          failureUrl: tabUrl,
           expectedUrl: tabUrl,
           isCreated: false,
           alreadyFailed: false,
@@ -22,6 +27,8 @@ void main() {
 
       expect(
         shouldHandleCreationFailure(
+          failureKey: tabKey,
+          expectedKey: tabKey,
           failureUrl: tabUrl,
           expectedUrl: tabUrl,
           isCreated: false,
@@ -34,6 +41,8 @@ void main() {
     test('טאב שה-WebView שלו כבר נוצר אינו מוחלף במסך שגיאה', () {
       expect(
         shouldHandleCreationFailure(
+          failureKey: tabKey,
+          expectedKey: tabKey,
           failureUrl: tabUrl,
           expectedUrl: tabUrl,
           isCreated: true,
@@ -46,6 +55,8 @@ void main() {
     test('כשל שכבר הוצג אינו מטופל שוב', () {
       expect(
         shouldHandleCreationFailure(
+          failureKey: tabKey,
+          expectedKey: tabKey,
           failureUrl: tabUrl,
           expectedUrl: tabUrl,
           isCreated: false,
@@ -55,10 +66,12 @@ void main() {
       );
     });
 
-    test('אירוע בלי URL עדיין מטופל — אחרת החיווי היה נעלם', () {
+    test('אירוע ישן בלי מפתח נופל חזרה להתאמת URL', () {
       for (final unknown in <String?>[null, '']) {
         expect(
           shouldHandleCreationFailure(
+            failureKey: null,
+            expectedKey: tabKey,
             failureUrl: unknown,
             expectedUrl: tabUrl,
             isCreated: false,
@@ -68,6 +81,20 @@ void main() {
           reason: 'URL לא ידוע ($unknown) חייב להמשיך להציג את השגיאה',
         );
       }
+    });
+
+    test('אירוע ישן עם URL של טאב אחר אינו מטופל', () {
+      expect(
+        shouldHandleCreationFailure(
+          failureKey: null,
+          expectedKey: tabKey,
+          failureUrl: otherUrl,
+          expectedUrl: tabUrl,
+          isCreated: false,
+          alreadyFailed: false,
+        ),
+        isFalse,
+      );
     });
   });
 }

--- a/test/plugins/view/plugin_creation_failure_routing_test.dart
+++ b/test/plugins/view/plugin_creation_failure_routing_test.dart
@@ -1,0 +1,73 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/plugins/view/plugin_tab_page.dart';
+
+/// כשל היצירה מגיע ב-stream גלובלי, וכמה WebViewים נוצרים במקביל (מארח הרקע
+/// וטאבים). הבדיקות מוודאות שכשל מנותב רק לטאב שביקש אותו URL.
+void main() {
+  const tabUrl = 'file:///plugins/a/index.html';
+  const otherUrl = 'file:///plugins/b/index.html';
+
+  group('shouldHandleCreationFailure', () {
+    test('שתי יצירות מקבילות — רק בעל ה-URL התואם מגיב', () {
+      // הטאב של תוסף A ממתין; הכשל שייך למופע של תוסף B.
+      expect(
+        shouldHandleCreationFailure(
+          failureUrl: otherUrl,
+          expectedUrl: tabUrl,
+          isCreated: false,
+          alreadyFailed: false,
+        ),
+        isFalse,
+      );
+
+      expect(
+        shouldHandleCreationFailure(
+          failureUrl: tabUrl,
+          expectedUrl: tabUrl,
+          isCreated: false,
+          alreadyFailed: false,
+        ),
+        isTrue,
+      );
+    });
+
+    test('טאב שה-WebView שלו כבר נוצר אינו מוחלף במסך שגיאה', () {
+      expect(
+        shouldHandleCreationFailure(
+          failureUrl: tabUrl,
+          expectedUrl: tabUrl,
+          isCreated: true,
+          alreadyFailed: false,
+        ),
+        isFalse,
+      );
+    });
+
+    test('כשל שכבר הוצג אינו מטופל שוב', () {
+      expect(
+        shouldHandleCreationFailure(
+          failureUrl: tabUrl,
+          expectedUrl: tabUrl,
+          isCreated: false,
+          alreadyFailed: true,
+        ),
+        isFalse,
+      );
+    });
+
+    test('אירוע בלי URL עדיין מטופל — אחרת החיווי היה נעלם', () {
+      for (final unknown in <String?>[null, '']) {
+        expect(
+          shouldHandleCreationFailure(
+            failureUrl: unknown,
+            expectedUrl: tabUrl,
+            isCreated: false,
+            alreadyFailed: false,
+          ),
+          isTrue,
+          reason: 'URL לא ידוע ($unknown) חייב להמשיך להציג את השגיאה',
+        );
+      }
+    });
+  });
+}

--- a/test/plugins/view/plugin_webview_failed_view_test.dart
+++ b/test/plugins/view/plugin_webview_failed_view_test.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/plugins/view/plugin_webview_failed_view.dart';
+
+Widget _wrap(Widget child) => MaterialApp(
+  locale: const Locale('he', 'IL'),
+  home: Directionality(
+    textDirection: TextDirection.rtl,
+    child: Scaffold(body: child),
+  ),
+);
+
+void main() {
+  testWidgets('ההסבר הכללי מוצג כשאין אמולציית ARM', (tester) async {
+    await tester.pumpWidget(
+      _wrap(
+        PluginWebViewFailedView(
+          pluginName: 'מחשבון',
+          onRetry: () {},
+        ),
+      ),
+    );
+
+    expect(find.textContaining('לא ניתן להפעיל את התוסף "מחשבון"'), findsOne);
+    expect(find.textContaining('מבוסס מעבד ARM'), findsNothing);
+  });
+
+  testWidgets('ההסבר הייעודי מוצג במחשב ARM', (tester) async {
+    await tester.pumpWidget(
+      _wrap(
+        PluginWebViewFailedView(
+          isEmulatedOnArm: true,
+          onRetry: () {},
+        ),
+      ),
+    );
+
+    expect(find.text('התוספים אינם נתמכים עדיין במחשב זה'), findsOne);
+    expect(find.textContaining('מבוסס מעבד ARM'), findsOne);
+  });
+
+  testWidgets('פרטי השגיאה נגללים לפתיחה ומוצגים כטקסט נבחר', (tester) async {
+    await tester.pumpWidget(
+      _wrap(
+        PluginWebViewFailedView(
+          errorDetails: 'HRESULT 0x80070005 Access is denied.',
+          onRetry: () {},
+        ),
+      ),
+    );
+
+    expect(find.text('פרטי השגיאה'), findsOne);
+    await tester.tap(find.text('פרטי השגיאה'));
+    await tester.pumpAndSettle();
+    expect(find.text('HRESULT 0x80070005 Access is denied.'), findsOne);
+  });
+
+  testWidgets('כפתור "נסה שוב" מפעיל את ה-callback', (tester) async {
+    var retried = 0;
+    await tester.pumpWidget(
+      _wrap(PluginWebViewFailedView(onRetry: () => retried++)),
+    );
+
+    await tester.tap(find.text('נסה שוב'));
+    await tester.pump();
+    expect(retried, 1);
+  });
+}


### PR DESCRIPTION
> [!IMPORTANT]
> **טיוטה — חסום עד מיזוג [Otzaria/flutter_inappwebview#15](https://github.com/Otzaria/flutter_inappwebview/pull/15).**
>
> הקוד כאן קורא את `failure.requestedUrl`, שנוסף ב-PR #15 ואינו קיים ב-`master` של הפורק. `pubspec.yaml` מושך את התלות מ-`ref: master`, ולכן ה-CI כאן **אדום עד למיזוג שם** — ה-Analyze נופל על `undefined_getter` וכל משבצות הבדיקות נופלות אחריו על אותה שגיאת קומפילציה.
>
> [PR #14](https://github.com/Otzaria/flutter_inappwebview/pull/14) (שהוסיף את `WindowsWebViewCreationFailures` ואת ה-HRESULT) **כבר מוזג**; #15 הוא ההמשך שלו.
>
> **סדר הפעולות:** מיזוג #15 → הרצה מחדש של ה-CI כאן → הוצאה מטיוטה. אין צורך בשינוי קוד בצד אוצריא.

## הבעיה

כשל ביצירת רכיב הדפדפן של תוסף הסתיים במסך ריק בלי שום הסבר — השגיאה נרשמה רק ל-`errors.txt`. בחקירת issue #1014 המדווח ניסה לפתוח תוספים עשרות פעמים לאורך שעות בלי שום חיווי.

מסך ההכוונה הקיים (`PluginWebView2MissingView`) מכסה רק מצב שבו WebView2 Runtime חסר, ולא את המצב שבו ה-Runtime קיים ורק יצירת ה-controller נכשלת.

## מה נוסף

- **`PluginWebViewFailedView`** — מוצג במקום הריק, עם כפתור "נסה שוב" ומקטע מתקפל של פרטי השגיאה (כולל ה-HRESULT שמגיע מהפורק) לבחירה והעתקה לדיווח.
- **`WindowsArchInfo`** — מזהה ריצת x64 תחת אמולציה במחשבי ARM לפי `PROCESSOR_ARCHITEW6432`. במצב זה מוצג הסבר ייעודי (issue #1014) במקום להציע למשתמש לתקן משהו שאינו בשליטתו.
- **ניתוב הכשל לטאב הנכון** (בעקבות סקירת Codex) — ה-stream של הפלאגין גלובלי, ובעלייה נוצרים כמה WebViewים במקביל (מארח הרקע וטאבי תוספים). סינון לפי "מי שממתין ליצירה" בלבד לא הספיק: כשל של מופע אחד החליף במסך שגיאה טאב אחר, והסיר מהעץ WebView שיצירתו עדיין עשויה הייתה להצליח. האירוע נושא מעתה את ה-URL המבוקש (זהו PR #15), והטאב מגיב רק כשהוא תואם לשלו.
- הכשל נרשם ל-`errors.txt` עם מזהה התוסף ודגל האמולציה.

## אימות

- `flutter analyze` נקי (מול הפורק, עם override מקומי זמני — ראה הערת התלות למעלה).
- 137 בדיקות ב-`test/plugins/view/` עוברות, כולל בדיקת רגרסיה חדשה לשתי יצירות מקבילות (`plugin_creation_failure_routing_test.dart`) ומטריצת הארכיטקטורות של `WindowsArchInfo`.
- `flutter build windows` עובר מול הפורק המקומי.
- כשל קדם-קיים שאינו קשור: `test/plugins/plugin_spec_freshness_test.dart` נכשל גם על עץ נקי ללא השינויים כאן.

סוגר את #1015.
