### PR TITLE
גלילה אוטומטית בלחיצה על גלגל העכבר

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -486,6 +486,25 @@ NavPanelTabHeader(                 // tabs only — the pin is NOT here
 - Adding a per-panel list `padding` for the tree — the inset lives in `NavTreeGroupCard` / `NavTreeHeader` (`kNavTreeSideInset`), and lists use `kNavTreeListPadding`
 - A per-panel search field built from `RtlTextField` + `InputDecoration` — every field inside a nav panel is `OtzariaSearchField`
 
+### 11. Middle-click autoscroll — already global, never re-implement
+
+`MiddleClickAutoScroll` wraps the whole app once in `lib/app.dart`, so **every** scrollable area already supports middle-click autoscroll: lists, reading screens, the library, settings, dialogs, and the PDF viewer. It works by dispatching synthetic wheel events down the hit-test path captured on click, so anything that reacts to the mouse wheel reacts to it too — no per-screen wiring.
+
+**Never:**
+- Add a per-screen middle-click scroll handler, an anchor overlay, or an autoscroll timer — the global widget already covers it
+- Wrap a screen in a second `MiddleClickAutoScroll`
+
+**Do** wrap a region in `AutoScrollBarrier` when middle-click there is reserved for something else (a tab that closes on middle-click):
+```dart
+import 'package:otzaria/widgets/misc/middle_click_autoscroll.dart';
+
+Listener(
+  onPointerDown: (e) { if (e.buttons == kMiddleMouseButton) closeTab(tab); },
+  child: AutoScrollBarrier(child: tabContent),
+)
+```
+A barrier anywhere in the hit-test path suppresses autoscroll for that click.
+
 ## Code Guidelines
 
 ### RTL Support (Critical!)
@@ -778,6 +797,7 @@ dart format lib/file.dart    # Format ONLY files you modified
 | רוחב עמודת הטקסט (בסיס אזור הקריאה, יציב בפתיחת חלונית) | `test/widgets/layout/reading_area_width_test.dart` |
 | Scrollable list scrollbar | `test/widgets/scrollable_positioned_list_scrollbar_test.dart` |
 | Smooth mouse-wheel scrolling | `test/widgets/smooth_wheel_scroll_test.dart` |
+| גלילה אוטומטית בלחיצת גלגל העכבר | `test/widgets/middle_click_autoscroll_test.dart` |
 | Smart text render settings | `test/widgets/smart_text/render_settings_test.dart` |
 | Smart text ↔ plugin section sync gate | `test/widgets/smart_text/smart_text_section_sync_gate_test.dart` |
 | קיבוע מדויק של גובה השורה (סימוני הערות, `<big>`) בשלושת מסלולי הרינדור | `test/widgets/smart_text/exact_line_height_test.dart` |

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -9,6 +9,7 @@ import 'package:otzaria/core/ui_snack.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:otzaria/navigation/view/main_window_screen.dart';
 import 'package:otzaria/settings/settings_exports.dart';
+import 'package:otzaria/widgets/misc/middle_click_autoscroll.dart';
 import 'package:window_manager/window_manager.dart';
 
 // AppColors הועבר ל-lib/theme/app_colors.dart
@@ -94,6 +95,10 @@ class App extends StatelessWidget {
                 child: content,
               );
             }
+
+            // גלילה אוטומטית בלחיצת גלגל העכבר — עטיפה אחת לכל האפליקציה,
+            // מתחת למסגרת החלון כדי שכפתורי המסגרת יישארו לחיצים.
+            content = MiddleClickAutoScroll(child: content);
 
             if (!useVirtualWindowFrame) {
               return content;

--- a/lib/navigation/view/custom_title_bar.dart
+++ b/lib/navigation/view/custom_title_bar.dart
@@ -18,6 +18,7 @@ import 'package:otzaria/navigation/view/reading_tab_strip.dart';
 import 'package:otzaria/navigation/view/tab_context_menu.dart';
 import 'package:otzaria/navigation/view/tab_search_menu.dart';
 import 'package:otzaria/navigation/view/tab_visuals.dart';
+import 'package:otzaria/widgets/misc/middle_click_autoscroll.dart';
 import 'package:otzaria/theme/app_surfaces.dart';
 import 'package:otzaria/tabs/bloc/tabs_bloc.dart';
 import 'package:otzaria/tabs/bloc/tabs_state.dart';
@@ -1269,7 +1270,7 @@ class _CustomTitleBarState extends State<CustomTitleBar> {
           _pendingTabSelection = tab;
         }
       },
-      child: child,
+      child: AutoScrollBarrier(child: child),
     );
   }
 

--- a/lib/navigation/view/vertical_reading_tab_strip.dart
+++ b/lib/navigation/view/vertical_reading_tab_strip.dart
@@ -13,6 +13,7 @@ import 'package:otzaria/tabs/bloc/tabs_state.dart';
 import 'package:otzaria/tabs/models/combined_tab.dart';
 import 'package:otzaria/tabs/models/tab.dart';
 import 'package:otzaria/widgets/misc/app_menu_exports.dart';
+import 'package:otzaria/widgets/misc/middle_click_autoscroll.dart';
 
 /// גובה שורת כרטיסיה בעמודה האנכית.
 const double kVerticalTabHeight = 38;
@@ -201,7 +202,7 @@ class _VerticalReadingTabStripState extends State<VerticalReadingTabStrip> {
             bloc.add(SetCurrentTab(target));
           }
         },
-        child: child,
+        child: AutoScrollBarrier(child: child),
       ),
     );
   }

--- a/lib/plugins/view/plugin_tab_page.dart
+++ b/lib/plugins/view/plugin_tab_page.dart
@@ -34,6 +34,7 @@ import 'package:otzaria/utils/navigation/book_open_coordinator.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:otzaria/settings/services/safer_mode_guard.dart';
 import 'package:otzaria/widgets/dialogs/dialogs_exports.dart';
+import 'package:otzaria/widgets/misc/middle_click_autoscroll.dart';
 import 'package:otzaria/plugins/view/plugin_dev_error_view.dart';
 import 'package:otzaria/plugins/view/webview_environment_holder.dart';
 import 'package:otzaria/plugins/bloc/plugin_system_bloc.dart';
@@ -1149,7 +1150,9 @@ class _PluginTabPageState extends State<PluginTabPage> {
       },
     );
 
-    return webView;
+    // ה-WebView מגיב ללחצן האמצעי בעצמו (Chromium מפעיל שם גלילה אוטומטית
+    // משלו), ובלי החסימה היו נפתחים שני עוגנים במקביל.
+    return AutoScrollBarrier(child: webView);
   }
 
   static bool get _needsWebViewPrerequisites {

--- a/lib/settings/view/settings_screen.dart
+++ b/lib/settings/view/settings_screen.dart
@@ -488,19 +488,18 @@ class _MySettingsScreenState extends State<MySettingsScreen> {
             child: Scaffold(
               backgroundColor: bgColor,
               body: Listener(
-                // [תיקון גלילה] גלגל עכבר מכל מקום (כולל sidebar) גולל את התוכן
+                // גלגלת מכל מקום במסך (כולל ה-sidebar) גוללת את התוכן.
+                // הרישום ב-resolver מוותר לגליל שמתחת לסמן, אם יש כזה —
+                // בלעדיו שניהם היו גוללים ובמהירות כפולה.
                 onPointerSignal: (event) {
-                  if (event is PointerScrollEvent &&
-                      _contentScrollController.hasClients) {
-                    final newOffset =
-                        _contentScrollController.offset + event.scrollDelta.dy;
-                    _contentScrollController.jumpTo(
-                      newOffset.clamp(
-                        0.0,
-                        _contentScrollController.position.maxScrollExtent,
-                      ),
-                    );
-                  }
+                  if (event is! PointerScrollEvent) return;
+                  if (!_contentScrollController.hasClients) return;
+                  GestureBinding.instance.pointerSignalResolver.register(
+                    event,
+                    (_) => _contentScrollController.position.pointerScroll(
+                      event.scrollDelta.dy,
+                    ),
+                  );
                 },
                 child: Row(
                   children: [

--- a/lib/widgets/misc/middle_click_autoscroll.dart
+++ b/lib/widgets/misc/middle_click_autoscroll.dart
@@ -1,0 +1,424 @@
+import 'dart:math' as math;
+
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/scheduler.dart';
+import 'package:flutter/services.dart';
+
+/// מזהה המצביע של אירועי הגלגלת הסינתטיים ש[MiddleClickAutoScroll] משגר.
+///
+/// [SmoothWheelScroll] מדלג עליהם: הם כבר מגיעים חלקים בכל פריים, והחלקה
+/// נוספת רק מוסיפה פיגור וזחילה אחרי שהמשתמש שחרר את הכפתור.
+const int kAutoScrollSyntheticDevice = -0xA5C;
+
+/// גלילה אוטומטית בלחיצה על גלגל העכבר.
+///
+/// לחיצה על הגלגל מעגנת סמן במקום הלחיצה, ומכאן המרחק של הסמן מהעוגן קובע
+/// את כיוון הגלילה ואת מהירותה. שחרור במקום נועל את המצב (הגלילה נמשכת עד
+/// לחיצה נוספת או Esc), וגרירה ושחרור מסיימים אותה.
+///
+/// עוטף את כל האפליקציה פעם אחת ב-[MaterialApp.builder], ולכן פועל בכל
+/// אזור גליל: רשימות, מסכי קריאה, ספרייה, הגדרות, דיאלוגים וצופה ה-PDF.
+/// המימוש משגר אירועי גלגלת לנתיב שנתפס בלחיצה, כך שכל מי שמגיב לגלגלת
+/// מגיב גם כאן — כולל מעבר לרשימה החיצונית כשהפנימית הגיעה לקצה.
+///
+/// כדי לשמור לחיצת גלגל לשימוש אחר באזור מסוים (למשל סגירת לשונית), יש
+/// לעטוף אותו ב-[AutoScrollBarrier].
+class MiddleClickAutoScroll extends StatefulWidget {
+  const MiddleClickAutoScroll({super.key, required this.child});
+
+  final Widget child;
+
+  @override
+  State<MiddleClickAutoScroll> createState() => _MiddleClickAutoScrollState();
+}
+
+class _MiddleClickAutoScrollState extends State<MiddleClickAutoScroll>
+    with SingleTickerProviderStateMixin, WidgetsBindingObserver {
+  /// רדיוס האזור סביב העוגן שבו אין גלילה, כדי שרעד יד לא יזיז.
+  static const double _deadZone = 16.0;
+
+  /// מרחק שמעליו שחרור הכפתור מסיים את הגלילה במקום לנעול אותה.
+  static const double _dragThreshold = 12.0;
+
+  /// המהירות (פיקסלים לשנייה) היא חזקה של המרחק מהעוגן: עדינה בקרבת
+  /// העוגן ומאיצה ככל שמתרחקים, כמו הגלילה האוטומטית במערכת ההפעלה.
+  static const double _speedExponent = 1.3;
+  static const double _speedFactor = 1.6;
+  static const double _maxSpeed = 6000.0;
+
+  static const double _anchorRadius = 17.0;
+
+  late final Ticker _ticker;
+  Duration? _lastTick;
+
+  /// נקודת הלחיצה, בקואורדינטות גלובליות. null = הגלילה אינה פעילה.
+  Offset? _anchor;
+  Offset _pointer = Offset.zero;
+
+  /// פינת השכבה בקואורדינטות גלובליות, לציור העוגן במקום הנכון.
+  Offset _origin = Offset.zero;
+
+  /// נתיב הפגיעה שנתפס בלחיצה. הגלילה נשארת נעולה עליו גם כשהתוכן מתחלף.
+  HitTestResult? _hitTest;
+
+  /// המאזין לגלגלת הרדוד ביותר בנתיב. משמש רק כמדד חיות: מאזין עמוק יותר
+  /// עשוי להיות פריט ממוחזר שיוסר תוך כדי גלילה, בעוד שהרדוד חי כל עוד
+  /// המסך על המסך.
+  RenderObject? _liveness;
+  int? _pointerId;
+  int _viewId = 0;
+
+  /// ציר הגלילה של האזור שנתפס, לציור החיצים ולנטרול הציר השני.
+  Axis? _axis;
+
+  /// כל ה-[Scrollable]־ים שנבנו מתחת לעטיפה, לפי ה-RenderObject שדרכו הם
+  /// מופיעים בנתיב הפגיעה. מאפשר לדעת אם ליעד שנלחץ יש בכלל לאן לגלול.
+  final Map<RenderObject, ScrollableState> _scrollables = {};
+
+  bool get _isActive => _anchor != null;
+
+  @override
+  void initState() {
+    super.initState();
+    _ticker = createTicker(_onTick);
+    WidgetsBinding.instance.addObserver(this);
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    HardwareKeyboard.instance.removeHandler(_onKey);
+    // Ticker.dispose זורק על טיקר שעדיין רץ, וגלילה נעולה משאירה אותו רץ.
+    _ticker.stop();
+    _ticker.dispose();
+    super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state != AppLifecycleState.resumed) _stop();
+  }
+
+  // --------------------------------------------------------------- מחזור חיים
+
+  void _onPointerDown(PointerDownEvent event) {
+    // כל לחיצה במצב פעיל מסיימת, כמו במערכת ההפעלה.
+    if (_isActive) {
+      _stop();
+      return;
+    }
+    if (event.kind != PointerDeviceKind.mouse) return;
+    if (event.buttons != kMiddleMouseButton) return;
+
+    _scrollables.removeWhere((_, state) => !state.mounted);
+    final result = HitTestResult();
+    GestureBinding.instance.hitTestInView(result, event.position, event.viewId);
+    final target = _resolveTarget(result);
+    if (target == null) return;
+
+    final box = context.findRenderObject();
+    _origin = box is RenderBox && box.hasSize
+        ? box.localToGlobal(Offset.zero)
+        : Offset.zero;
+    _hitTest = result;
+    _liveness = target.liveness;
+    _pointerId = event.pointer;
+    _viewId = event.viewId;
+    _pointer = event.position;
+    _lastTick = null;
+    HardwareKeyboard.instance.addHandler(_onKey);
+    _ticker.start();
+    setState(() {
+      _anchor = event.position;
+      _axis = target.axis;
+    });
+  }
+
+  void _onPointerMove(PointerMoveEvent event) {
+    if (!_isActive || event.pointer != _pointerId) return;
+    _pointer = event.position;
+  }
+
+  void _onPointerUp(PointerUpEvent event) {
+    if (!_isActive || event.pointer != _pointerId) return;
+    _pointerId = null;
+    // שחרור אחרי גרירה מסיים; שחרור במקום נועל את הגלילה על הסמן.
+    if ((_pointer - _anchor!).distance > _dragThreshold) _stop();
+  }
+
+  void _stop() {
+    if (!_isActive) return;
+    _ticker.stop();
+    HardwareKeyboard.instance.removeHandler(_onKey);
+    _hitTest = null;
+    _liveness = null;
+    _pointerId = null;
+    setState(() {
+      _anchor = null;
+      _axis = null;
+    });
+  }
+
+  bool _onKey(KeyEvent event) {
+    if (!_isActive) return false;
+    if (event is! KeyDownEvent) return false;
+    if (event.logicalKey != LogicalKeyboardKey.escape) return false;
+    _stop();
+    return true;
+  }
+
+  // ------------------------------------------------------------ זיהוי היעד
+
+  /// לוכד כל [Scrollable] שנבנה מתחת לעטיפה מתוך ההודעות שהוא שולח.
+  ///
+  /// המפתח הוא ה-[Listener] שמקבל את אותות הגלגלת — הוא מה שמופיע בנתיב
+  /// הפגיעה, ולא ה-RenderObject השורשי של ה-[Scrollable]. הוא נמצא בין
+  /// ה-context ששולח את ההודעות לבין השורש, ולכן מטפסים בטווח הזה בלבד.
+  bool _capture(BuildContext? notificationContext) {
+    if (notificationContext == null) return false;
+    final state = Scrollable.maybeOf(notificationContext);
+    if (state == null) return false;
+
+    final root = state.context.findRenderObject();
+    var node = notificationContext.findRenderObject();
+    while (node != null) {
+      if (node is RenderPointerListener && node.onPointerSignal != null) {
+        _scrollables[node] = state;
+        break;
+      }
+      if (identical(node, root)) break;
+      node = node.parent;
+    }
+    return false;
+  }
+
+  /// מוצא בנתיב את מה שיש לגלול: את הציר שלו ואת המאזין שישמש מדד חיות.
+  /// null = אין מה לגלול כאן, או שיש בנתיב [AutoScrollBarrier].
+  ///
+  /// כל [Scrollable] וגם צופה ה-PDF מאזינים לאותות הגלגלת דרך [Listener],
+  /// ולכן סימן אחד מכסה את שניהם. [Scrollable] שאין לו לאן לזוז מדולג לטובת
+  /// זה שמעליו — בדיוק כפי שגלגלת אמיתית עוברת אליו.
+  ({RenderObject liveness, Axis? axis})? _resolveTarget(HitTestResult result) {
+    RenderObject? liveness;
+    Axis? axis;
+    var found = false;
+
+    for (final entry in result.path) {
+      final object = entry.target;
+      if (object is _RenderAutoScrollBarrier) return null;
+      if (object is! RenderPointerListener || object.onPointerSignal == null) {
+        continue;
+      }
+      liveness = object;
+      if (found) continue;
+
+      final scrollable = _scrollables[object];
+      if (scrollable == null) {
+        // מאזין שאינו Scrollable (צופה PDF, WebView) — הציר אינו ידוע.
+        found = true;
+        continue;
+      }
+      if (!_canScroll(scrollable)) continue;
+      axis = scrollable.position.axis;
+      found = true;
+    }
+
+    return found ? (liveness: liveness!, axis: axis) : null;
+  }
+
+  bool _canScroll(ScrollableState scrollable) {
+    if (!scrollable.mounted) return false;
+    final position = scrollable.position;
+    if (!position.hasPixels || !position.hasContentDimensions) return false;
+    if (!position.physics.shouldAcceptUserOffset(position)) return false;
+    return position.maxScrollExtent > position.minScrollExtent;
+  }
+
+  // ---------------------------------------------------------------- הגלילה
+
+  double _speed(double distance) {
+    final magnitude = distance.abs() - _deadZone;
+    if (magnitude <= 0) return 0.0;
+    final speed = math.min(
+      math.pow(magnitude, _speedExponent).toDouble() * _speedFactor,
+      _maxSpeed,
+    );
+    return distance.isNegative ? -speed : speed;
+  }
+
+  void _onTick(Duration elapsed) {
+    final anchor = _anchor;
+    final hitTest = _hitTest;
+    if (anchor == null || hitTest == null) return;
+
+    // כשהאזור שנתפס יורד מהמסך אין למי לשגר, והמצב הפעיל רק לוכד את העכבר.
+    if (!(_liveness?.attached ?? false)) {
+      _stop();
+      return;
+    }
+
+    final previous = _lastTick;
+    _lastTick = elapsed;
+    if (previous == null) return;
+    final seconds = (elapsed - previous).inMicroseconds / 1000000.0;
+    // פריים חריג (חלון ממוזער, נעילת מסך) היה מקפיץ מרחק עצום בבת אחת.
+    if (seconds <= 0 || seconds > 0.1) return;
+
+    final distance = _pointer - anchor;
+    final horizontal = _speed(distance.dx) * seconds;
+    final vertical = _speed(distance.dy) * seconds;
+    // Shift מהפך את הציר ש-Scrollable קורא מהאירוע, ולכן כשהציר ידוע אותה
+    // מהירות נשלחת בשני הצירים — אחרת הגלילה קופאת כל עוד Shift לחוץ.
+    final delta = switch (_axis) {
+      Axis.vertical => Offset(vertical, vertical),
+      Axis.horizontal => Offset(horizontal, horizontal),
+      null => Offset(horizontal, vertical),
+    };
+    if (delta == Offset.zero) return;
+
+    GestureBinding.instance.dispatchEvent(
+      PointerScrollEvent(
+        viewId: _viewId,
+        timeStamp: elapsed,
+        device: kAutoScrollSyntheticDevice,
+        position: anchor,
+        scrollDelta: delta,
+      ),
+      hitTest,
+    );
+  }
+
+  // ----------------------------------------------------------------- תצוגה
+
+  @override
+  Widget build(BuildContext context) {
+    return NotificationListener<ScrollMetricsNotification>(
+      onNotification: (notification) => _capture(notification.context),
+      child: NotificationListener<ScrollNotification>(
+        onNotification: (notification) => _capture(notification.context),
+        child: _buildInteraction(context),
+      ),
+    );
+  }
+
+  Widget _buildInteraction(BuildContext context) {
+    return Listener(
+      behavior: HitTestBehavior.translucent,
+      onPointerDown: _onPointerDown,
+      onPointerMove: _onPointerMove,
+      onPointerUp: _onPointerUp,
+      onPointerCancel: (event) {
+        if (event.pointer == _pointerId) _stop();
+      },
+      // passthrough מעביר לילד את האילוצים המקוריים, כך שהעטיפה אינה משנה
+      // את הפריסה של האפליקציה שמתחתיה.
+      child: Stack(
+        fit: StackFit.passthrough,
+        children: [
+          widget.child,
+          if (_anchor != null)
+            Positioned.fill(
+              child: MouseRegion(
+                cursor: SystemMouseCursors.allScroll,
+                opaque: true,
+                onHover: (event) => _pointer = event.position,
+                onExit: (_) => _stop(),
+                child: CustomPaint(
+                  painter: _AutoScrollAnchorPainter(
+                    center: _anchor! - _origin,
+                    axis: _axis,
+                    colors: Theme.of(context).colorScheme,
+                  ),
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+/// מסמן אזור שבו לחיצת גלגל שמורה לפעולה אחרת, ולכן [MiddleClickAutoScroll]
+/// לא יופעל בו (למשל לשונית שנסגרת בלחיצת גלגל).
+class AutoScrollBarrier extends SingleChildRenderObjectWidget {
+  const AutoScrollBarrier({super.key, required Widget super.child});
+
+  @override
+  RenderObject createRenderObject(BuildContext context) =>
+      _RenderAutoScrollBarrier();
+}
+
+class _RenderAutoScrollBarrier extends RenderProxyBoxWithHitTestBehavior {
+  _RenderAutoScrollBarrier() : super(behavior: HitTestBehavior.translucent);
+}
+
+/// מצייר את עוגן הגלילה: עיגול ובתוכו חיצים משולשים לכיווני הגלילה.
+class _AutoScrollAnchorPainter extends CustomPainter {
+  const _AutoScrollAnchorPainter({
+    required this.center,
+    required this.axis,
+    required this.colors,
+  });
+
+  final Offset center;
+  final Axis? axis;
+  final ColorScheme colors;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final circle = Path()
+      ..addOval(
+        Rect.fromCircle(
+          center: center,
+          radius: _MiddleClickAutoScrollState._anchorRadius,
+        ),
+      );
+    canvas.drawShadow(circle, colors.shadow, 3.0, false);
+    canvas.drawPath(circle, Paint()..color = colors.surfaceContainerHighest);
+    canvas.drawPath(
+      circle,
+      Paint()
+        ..color = colors.outlineVariant
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = 1.5,
+    );
+
+    final ink = Paint()..color = colors.onSurfaceVariant;
+    canvas.drawCircle(center, 2.0, ink);
+
+    if (axis != Axis.horizontal) {
+      _arrow(canvas, ink, const Offset(0, -1));
+      _arrow(canvas, ink, const Offset(0, 1));
+    }
+    if (axis != Axis.vertical) {
+      _arrow(canvas, ink, const Offset(-1, 0));
+      _arrow(canvas, ink, const Offset(1, 0));
+    }
+  }
+
+  /// מצייר משולש שקודקודו פונה ל-[direction] (וקטור יחידה על אחד הצירים).
+  void _arrow(Canvas canvas, Paint paint, Offset direction) {
+    const base = 7.0;
+    const inner = 6.0;
+    const height = 5.0;
+    final normal = Offset(direction.dy, direction.dx);
+    final tip = center + direction * (inner + height);
+    final edge = center + direction * inner;
+    canvas.drawPath(
+      Path()
+        ..moveTo(tip.dx, tip.dy)
+        ..lineTo(edge.dx + normal.dx * base / 2, edge.dy + normal.dy * base / 2)
+        ..lineTo(edge.dx - normal.dx * base / 2, edge.dy - normal.dy * base / 2)
+        ..close(),
+      paint,
+    );
+  }
+
+  @override
+  bool shouldRepaint(_AutoScrollAnchorPainter oldDelegate) =>
+      center != oldDelegate.center ||
+      axis != oldDelegate.axis ||
+      colors != oldDelegate.colors;
+}

--- a/lib/widgets/misc/smooth_wheel_scroll.dart
+++ b/lib/widgets/misc/smooth_wheel_scroll.dart
@@ -5,6 +5,7 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
+import 'package:otzaria/widgets/misc/middle_click_autoscroll.dart';
 
 /// מחליק את גלילת גלגלת העכבר ברשימה שמתחתיו.
 ///
@@ -88,6 +89,9 @@ class _SmoothWheelScrollState extends State<SmoothWheelScroll>
   bool _shouldClaim(PointerScrollEvent event) {
     // משטח מגע מגיע כאירועי pan ומקבל אינרציה מהפיזיקה; רק לגלגלת אין.
     if (event.kind != PointerDeviceKind.mouse) return false;
+    // הגלילה האוטומטית כבר מייצרת תנועה חלקה בכל פריים, וההחלקה כאן הייתה
+    // מוסיפה לה פיגור וזחילה אחרי שהמשתמש שחרר את הכפתור.
+    if (event.device == kAutoScrollSyntheticDevice) return false;
     if (_isOverNestedScrollable(event.position)) {
       _finish();
       return false;

--- a/test/widgets/middle_click_autoscroll_test.dart
+++ b/test/widgets/middle_click_autoscroll_test.dart
@@ -1,0 +1,417 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/widgets/misc/middle_click_autoscroll.dart';
+import 'package:otzaria/widgets/misc/smooth_wheel_scroll.dart';
+
+const _itemHeight = 40.0;
+const _itemCount = 500;
+const _viewportHeight = 600.0;
+
+void main() {
+  late ScrollController controller;
+
+  Widget buildApp({
+    Widget? child,
+    Axis axis = Axis.vertical,
+    bool barrier = false,
+    int itemCount = _itemCount,
+    ScrollPhysics? physics,
+    TextDirection direction = TextDirection.ltr,
+  }) {
+    controller = ScrollController();
+    Widget list =
+        child ??
+        ListView.builder(
+          controller: controller,
+          scrollDirection: axis,
+          physics: physics,
+          itemCount: itemCount,
+          itemBuilder: (context, index) => SizedBox(
+            height: _itemHeight,
+            width: _itemHeight,
+            child: Text('שורה $index'),
+          ),
+        );
+    if (barrier) list = AutoScrollBarrier(child: list);
+
+    return MaterialApp(
+      home: Directionality(
+        textDirection: direction,
+        child: Scaffold(
+          body: MiddleClickAutoScroll(
+            child: SizedBox(
+              height: _viewportHeight,
+              width: 400,
+              child: list,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// לוחצת על גלגל העכבר ומחזירה את ה-gesture, כדי שאפשר יהיה להזיז ולשחרר.
+  Future<TestGesture> middleClick(
+    WidgetTester tester,
+    Offset position,
+  ) async {
+    final gesture = await tester.createGesture(
+      kind: PointerDeviceKind.mouse,
+      buttons: kMiddleMouseButton,
+    );
+    await gesture.addPointer(location: position);
+    await gesture.down(position);
+    await tester.pump();
+    return gesture;
+  }
+
+  Finder anchor() => find.byWidgetPredicate(
+    (widget) => widget is CustomPaint && widget.painter != null,
+    description: 'עוגן הגלילה',
+  );
+
+  testWidgets('לחיצת גלגל מציגה עוגן וגוררת גלילה בכיוון התנועה', (
+    tester,
+  ) async {
+    await tester.pumpWidget(buildApp());
+    final center = tester.getCenter(find.byType(ListView));
+
+    final gesture = await middleClick(tester, center);
+    expect(anchor(), findsOneWidget);
+    expect(controller.offset, 0.0);
+
+    // מתחת לאזור המת אין תנועה.
+    await gesture.moveTo(center + const Offset(0, 10));
+    await tester.pump(const Duration(milliseconds: 100));
+    expect(controller.offset, 0.0);
+
+    await gesture.moveTo(center + const Offset(0, 120));
+    await tester.pump(const Duration(milliseconds: 100));
+    final forward = controller.offset;
+    expect(forward, greaterThan(0.0));
+
+    // תנועה למעלה מחזירה אחורה.
+    await gesture.moveTo(center - const Offset(0, 120));
+    await tester.pump(const Duration(milliseconds: 100));
+    expect(controller.offset, lessThan(forward));
+
+    await gesture.up();
+    await tester.pump();
+  });
+
+  testWidgets('ככל שמתרחקים מהעוגן הגלילה מהירה יותר', (tester) async {
+    await tester.pumpWidget(buildApp());
+    final center = tester.getCenter(find.byType(ListView));
+
+    final gesture = await middleClick(tester, center);
+    await gesture.moveTo(center + const Offset(0, 60));
+    await tester.pump(const Duration(milliseconds: 100));
+    final slow = controller.offset;
+
+    await gesture.moveTo(center + const Offset(0, 240));
+    await tester.pump(const Duration(milliseconds: 100));
+    final fast = controller.offset - slow;
+
+    expect(slow, greaterThan(0.0));
+    expect(fast, greaterThan(slow));
+    await gesture.up();
+    await tester.pump();
+  });
+
+  testWidgets('שחרור במקום נועל את הגלילה, ולחיצה נוספת מסיימת', (
+    tester,
+  ) async {
+    await tester.pumpWidget(buildApp());
+    final center = tester.getCenter(find.byType(ListView));
+
+    final gesture = await middleClick(tester, center);
+    await gesture.up();
+    await tester.pump();
+    expect(anchor(), findsOneWidget);
+
+    // אחרי השחרור ריחוף העכבר ממשיך להזין את הגלילה.
+    await gesture.moveTo(center + const Offset(0, 120));
+    await tester.pump(const Duration(milliseconds: 100));
+    expect(controller.offset, greaterThan(0.0));
+
+    final locked = controller.offset;
+    await tester.tapAt(center, buttons: kPrimaryMouseButton);
+    await tester.pump(const Duration(milliseconds: 100));
+    expect(anchor(), findsNothing);
+    expect(controller.offset, locked);
+  });
+
+  testWidgets('שחרור אחרי גרירה מסיים את הגלילה', (tester) async {
+    await tester.pumpWidget(buildApp());
+    final center = tester.getCenter(find.byType(ListView));
+
+    final gesture = await middleClick(tester, center);
+    await gesture.moveTo(center + const Offset(0, 120));
+    await tester.pump(const Duration(milliseconds: 100));
+    await gesture.up();
+    await tester.pump();
+
+    expect(anchor(), findsNothing);
+    final stopped = controller.offset;
+    await tester.pump(const Duration(milliseconds: 100));
+    expect(controller.offset, stopped);
+  });
+
+  testWidgets('Esc מסיים את הגלילה', (tester) async {
+    await tester.pumpWidget(buildApp());
+    final center = tester.getCenter(find.byType(ListView));
+
+    final gesture = await middleClick(tester, center);
+    await gesture.up();
+    await tester.pump();
+    expect(anchor(), findsOneWidget);
+
+    await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+    await tester.pump();
+    expect(anchor(), findsNothing);
+  });
+
+  testWidgets('רשימה אופקית נגררת לצדדים בלבד', (tester) async {
+    await tester.pumpWidget(buildApp(axis: Axis.horizontal));
+    final center = tester.getCenter(find.byType(ListView));
+
+    final gesture = await middleClick(tester, center);
+    await gesture.moveTo(center + const Offset(0, 120));
+    await tester.pump(const Duration(milliseconds: 100));
+    expect(controller.offset, 0.0);
+
+    await gesture.moveTo(center + const Offset(120, 0));
+    await tester.pump(const Duration(milliseconds: 100));
+    expect(controller.offset, greaterThan(0.0));
+
+    await gesture.up();
+    await tester.pump();
+  });
+
+  testWidgets('אזור שאינו גליל אינו מפעיל את הגלילה', (tester) async {
+    await tester.pumpWidget(
+      buildApp(child: const Center(child: Text('אין כאן גלילה'))),
+    );
+
+    await middleClick(tester, tester.getCenter(find.text('אין כאן גלילה')));
+    expect(anchor(), findsNothing);
+  });
+
+  testWidgets('רשימה שתוכנה נכנס במלואו אינה מפעילה את הגלילה', (tester) async {
+    await tester.pumpWidget(buildApp(itemCount: 2));
+
+    await middleClick(tester, tester.getCenter(find.byType(ListView)));
+    expect(anchor(), findsNothing);
+  });
+
+  testWidgets('רשימה עם NeverScrollableScrollPhysics אינה מפעילה', (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      buildApp(physics: const NeverScrollableScrollPhysics()),
+    );
+
+    await middleClick(tester, tester.getCenter(find.byType(ListView)));
+    expect(anchor(), findsNothing);
+  });
+
+  testWidgets('רשימה פנימית שאין בה מה לגלול מוסרת לרשימה החיצונית', (
+    tester,
+  ) async {
+    final outer = ScrollController();
+    addTearDown(outer.dispose);
+
+    await tester.pumpWidget(
+      buildApp(
+        child: ListView(
+          controller: outer,
+          children: [
+            SizedBox(
+              height: 200,
+              child: ListView(
+                key: const Key('inner'),
+                children: const [SizedBox(height: 50, child: Text('פנימית'))],
+              ),
+            ),
+            const SizedBox(height: 2000),
+          ],
+        ),
+      ),
+    );
+
+    final center = tester.getCenter(find.text('פנימית'));
+    final gesture = await middleClick(tester, center);
+    expect(anchor(), findsOneWidget);
+
+    await gesture.moveTo(center + const Offset(0, 120));
+    await tester.pump(const Duration(milliseconds: 100));
+    expect(outer.offset, greaterThan(0.0));
+
+    await gesture.up();
+    await tester.pump();
+  });
+
+  testWidgets('Shift לחוץ אינו מקפיא את הגלילה', (tester) async {
+    await tester.pumpWidget(buildApp());
+    final center = tester.getCenter(find.byType(ListView));
+
+    await tester.sendKeyDownEvent(LogicalKeyboardKey.shiftLeft);
+    addTearDown(
+      () => tester.sendKeyUpEvent(LogicalKeyboardKey.shiftLeft),
+    );
+
+    final gesture = await middleClick(tester, center);
+    await gesture.moveTo(center + const Offset(0, 120));
+    await tester.pump(const Duration(milliseconds: 100));
+    expect(controller.offset, greaterThan(0.0));
+
+    await gesture.up();
+    await tester.pump();
+  });
+
+  testWidgets('רשימה אופקית ב-RTL נגררת לכיוון הנכון', (tester) async {
+    await tester.pumpWidget(
+      buildApp(axis: Axis.horizontal, direction: TextDirection.rtl),
+    );
+    final center = tester.getCenter(find.byType(ListView));
+
+    final gesture = await middleClick(tester, center);
+    // ב-RTL הרשימה מתחילה בימין, ולכן גרירה שמאלה מקדמת אותה.
+    await gesture.moveTo(center - const Offset(120, 0));
+    await tester.pump(const Duration(milliseconds: 100));
+    expect(controller.offset, greaterThan(0.0));
+
+    await gesture.up();
+    await tester.pump();
+  });
+
+  testWidgets('SmoothWheelScroll אינו מחליק את הגלילה האוטומטית', (
+    tester,
+  ) async {
+    final inner = ScrollController();
+    addTearDown(inner.dispose);
+    await tester.pumpWidget(
+      buildApp(
+        child: SmoothWheelScroll(
+          child: ListView.builder(
+            controller: inner,
+            itemCount: _itemCount,
+            itemBuilder: (context, index) =>
+                SizedBox(height: _itemHeight, child: Text('שורה $index')),
+          ),
+        ),
+      ),
+    );
+    final center = tester.getCenter(find.byType(ListView));
+
+    final gesture = await middleClick(tester, center);
+    await gesture.moveTo(center + const Offset(0, 120));
+    await tester.pump(const Duration(milliseconds: 100));
+    await gesture.up();
+    await tester.pump();
+
+    // שחרור אחרי גרירה מסיים מיד — בלי זנב שממשיך לזחול.
+    final stopped = inner.offset;
+    expect(stopped, greaterThan(0.0));
+    await tester.pump(const Duration(milliseconds: 300));
+    expect(inner.offset, stopped);
+  });
+
+  testWidgets('AutoScrollBarrier שומר את לחיצת הגלגל לשימוש אחר', (
+    tester,
+  ) async {
+    await tester.pumpWidget(buildApp(barrier: true));
+
+    await middleClick(tester, tester.getCenter(find.byType(ListView)));
+    expect(anchor(), findsNothing);
+    expect(controller.offset, 0.0);
+  });
+
+  testWidgets('AutoScrollBarrier על פריט בתוך רשימה גלילה חוסם', (
+    tester,
+  ) async {
+    final inner = ScrollController();
+    addTearDown(inner.dispose);
+    await tester.pumpWidget(
+      buildApp(
+        child: ListView.builder(
+          controller: inner,
+          itemCount: _itemCount,
+          itemBuilder: (context, index) => SizedBox(
+            height: _itemHeight,
+            child: AutoScrollBarrier(child: Text('שורה $index')),
+          ),
+        ),
+      ),
+    );
+
+    await middleClick(tester, tester.getCenter(find.text('שורה 3')));
+    expect(anchor(), findsNothing);
+    expect(inner.offset, 0.0);
+  });
+
+  testWidgets('מעבר לרקע מסיים את הגלילה', (tester) async {
+    await tester.pumpWidget(buildApp());
+
+    final gesture = await middleClick(
+      tester,
+      tester.getCenter(find.byType(ListView)),
+    );
+    await gesture.up();
+    await tester.pump();
+    expect(anchor(), findsOneWidget);
+
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.inactive);
+    await tester.pump();
+    expect(anchor(), findsNothing);
+  });
+
+  testWidgets('לחיצת גלגל במגע אינה מפעילה את הגלילה', (tester) async {
+    await tester.pumpWidget(buildApp());
+    final center = tester.getCenter(find.byType(ListView));
+
+    final gesture = await tester.createGesture(
+      kind: PointerDeviceKind.touch,
+      buttons: kMiddleMouseButton,
+    );
+    await gesture.down(center);
+    await tester.pump();
+
+    expect(anchor(), findsNothing);
+    await gesture.up();
+  });
+
+  testWidgets('פירוק הווידג׳ט בזמן גלילה נעולה אינו זורק', (tester) async {
+    await tester.pumpWidget(buildApp());
+
+    final gesture = await middleClick(
+      tester,
+      tester.getCenter(find.byType(ListView)),
+    );
+    await gesture.up();
+    await tester.pump();
+    expect(anchor(), findsOneWidget);
+
+    await tester.pumpWidget(const MaterialApp(home: SizedBox.shrink()));
+    await tester.pump();
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('כשהרשימה יורדת מהמסך הגלילה מסתיימת', (tester) async {
+    await tester.pumpWidget(buildApp());
+    final center = tester.getCenter(find.byType(ListView));
+
+    final gesture = await middleClick(tester, center);
+    await gesture.up();
+    await tester.pump();
+    expect(anchor(), findsOneWidget);
+
+    await tester.pumpWidget(
+      buildApp(child: const Center(child: Text('מסך אחר'))),
+    );
+    await tester.pump(const Duration(milliseconds: 100));
+    expect(anchor(), findsNothing);
+  });
+}


### PR DESCRIPTION
סוגר את #1002.

## מה זה עושה

לחיצה על גלגל העכבר מעגנת סמן במקום הלחיצה (עיגול עם חיצים משולשים), ומכאן מרחק הסמן מהעוגן קובע את כיוון הגלילה ואת מהירותה — ההתנהגות המוכרת מדפדפנים וממערכת ההפעלה.

- **שחרור במקום** נועל את המצב — הגלילה נמשכת לפי מיקום העכבר עד לחיצה נוספת, `Esc`, מעבר לרקע, או יציאת העכבר מהחלון.
- **גרירה ושחרור** מסיימים מיד.
- אזור מת של 16px סביב העוגן מונע תזוזה מרעד יד; המהירות עולה כחזקה של המרחק, כך שקרוב לעוגן השליטה עדינה ורחוק ממנו הגלילה מהירה.
- הסמן הופך ל-`allScroll` ואינטראקציה עם התוכן חסומה כל עוד המצב פעיל.

## איפה זה עובד

**בכל האפליקציה.** העטיפה היא אחת, ב-`MaterialApp.builder`, ולכן התכונה פועלת בכל אזור גליל: מסכי הקריאה, חלוניות המפרשים, הספרייה, תוצאות החיפוש, ההגדרות, הדיאלוגים וגם צופה ה-PDF.

## איך

`MiddleClickAutoScroll` תופס את הלחיצה, שומר את נתיב ה-hit-test, ומשגר בכל פריים `PointerScrollEvent` סינתטי אל אותו נתיב דרך `GestureBinding.dispatchEvent`. כלומר הוא **מדמה גלגלת עכבר** במקום לנהל גלילה בעצמו. מכאן:

- כל מי שכבר מגיב לגלגלת מגיב גם כאן — כולל pdfrx, שאינו `Scrollable` רגיל.
- מעבר לרשימה החיצונית כשהפנימית הגיעה לקצה עובד מעצמו, דרך `PointerSignalResolver`.

הלחיצה נתפסת רק כשבאמת יש מה לגלול: הווידג'ט לוכד את ה-`Scrollable`־ים שמתחתיו מתוך ה-`ScrollNotification`־ים שהם שולחים, ומצליב אותם עם נתיב הפגיעה כדי לבדוק `physics.shouldAcceptUserOffset` ואת טווח הגלילה. רשימה שתוכנה נכנס במלואו, או כזו עם `NeverScrollableScrollPhysics`, מדולגת לטובת מה שמעליה — בדיוק כפי שגלגלת אמיתית עוברת. הציר נלקח מה-`ScrollPosition` שנבחר, ולכן החיצים המצוירים תואמים למה שבאמת יזוז.

## התנגשויות שטופלו

- **לשוניות** — לחיצת גלגל על לשונית סוגרת אותה, ולכן תוכן הלשונית עטוף ב-`AutoScrollBarrier` (סמן שמבטל את הגלילה האוטומטית לאותה לחיצה). לחיצה על רקע רצועת הלשוניות עדיין גוללת אותה כשהיא גלילה.
- **WebView של תוסף** — Chromium מפעיל שם גלילה אוטומטית משלו; בלי חסימה היו נפתחים שני עוגנים במקביל. גם הוא עטוף ב-`AutoScrollBarrier`.
- **`SmoothWheelScroll`** — ההחלקה שבמסכי הקריאה הייתה מוסיפה פיגור לגלילה האוטומטית וזנב שממשיך לזחול אחרי שהמשתמש שחרר. האירועים הסינתטיים מסומנים ב-`device` ייעודי ומדולגים שם.
- **מסך ההגדרות** — ה-`Listener` שגולל את התוכן מכל מקום במסך עשה `jumpTo` ישירות, בלי `PointerSignalResolver`, ולכן גלגלת מעל תוכן ההגדרות גללה פעמיים. הוסב לרישום ב-resolver, שמוותר לגליל שמתחת לסמן.

## בדיקות

`test/widgets/middle_click_autoscroll_test.dart` — 19 טסטים: הצגת העוגן, כיוון הגלילה, האצה לפי מרחק, האזור המת, נעילה מול גרירה, `Esc`, מעבר לרקע, ציר אופקי (כולל RTL), `Shift` לחוץ, אזור שאינו גליל, רשימה שתוכנה נכנס במלואו, `NeverScrollableScrollPhysics`, מסירה לרשימה החיצונית, אי-החלקה ע"י `SmoothWheelScroll`, `AutoScrollBarrier` בשתי טופולוגיות, לחיצה במגע, פירוק הווידג'ט בזמן גלילה נעולה, וירידת הרשימה מהמסך.

`flutter analyze` נקי, ומערכי הטסטים של האזורים שנגעתי בהם עוברים.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
