### PR TITLE
fix(library-update): fallback להורדה מלאה על כל כשל apply — הקשחה לקראת סכמה 4

### DIFF
--- a/lib/library_update/bloc/library_update_bloc.dart
+++ b/lib/library_update/bloc/library_update_bloc.dart
@@ -246,12 +246,19 @@ class LibraryUpdateBloc extends Bloc<LibraryUpdateEvent, LibraryUpdateState> {
     } catch (e, st) {
       if (_isStale(opId)) return;
       _logUpdateError('applyDeltaPlan', e, st);
-      // אי-התאמת hash הופכת את מסלול הדלתא ללא בטוח; הורדה מלאה עוקפת אותו.
-      if (e is PatchApplyException && e.isContentMismatch) {
-        final mismatchReason =
-            e.hashMismatchStage == PatchHashMismatchStage.toContentHash
-            ? 'תוצאת עדכון הדלתא אינה תואמת לגרסה הצפויה'
-            : 'תוכן הספרייה המקומית שונה מהצפוי';
+      // כל כשל apply (אי-התאמת hash, גרסה/סכמה לא תואמת, patch פגום) הופך
+      // את מסלול הדלתא ללא בטוח; הורדה מלאה עוקפת אותו. בלי זה, כשל שאינו
+      // אי-התאמת תוכן — למשל patch בסכמה חדשה מהנתמכת — משאיר את המשתמש
+      // בלולאת שגיאה ללא מוצא עד עדכון אפליקציה.
+      if (e is PatchApplyException) {
+        final String mismatchReason;
+        if (!e.isContentMismatch) {
+          mismatchReason = 'החלת עדכון הדלתא נכשלה';
+        } else if (e.hashMismatchStage == PatchHashMismatchStage.toContentHash) {
+          mismatchReason = 'תוצאת עדכון הדלתא אינה תואמת לגרסה הצפויה';
+        } else {
+          mismatchReason = 'תוכן הספרייה המקומית שונה מהצפוי';
+        }
         final fallback = plan.toFullDownloadFallback(
           reason: mismatchReason,
         );

--- a/test/library_update/library_update_bloc_test.dart
+++ b/test/library_update/library_update_bloc_test.dart
@@ -1092,6 +1092,42 @@ void main() {
     );
 
     blocTest<LibraryUpdateBloc, LibraryUpdateState>(
+      'כשל apply שאינו סטיית תוכן (למשל סכמה לא נתמכת) → fallback להורדה מלאה',
+      build: () => _bloc(
+        _FakeService(
+          deltaWithFallbackPlan,
+          applyError: const PatchApplyException(
+            'גרסת סכמת ה-patch (5) חדשה מהנתמך (4) — נדרש עדכון תוכנה',
+          ),
+        ),
+      ),
+      act: (b) => b.add(const StartLibraryUpdate()),
+      expect: () => [
+        isA<LibraryUpdateState>().having(
+          (s) => s.status,
+          'status',
+          LibraryUpdateStatus.checking,
+        ),
+        isA<LibraryUpdateState>()
+            .having(
+              (s) => s.status,
+              'status',
+              LibraryUpdateStatus.needsFullConfirmation,
+            )
+            .having(
+              (s) => s.plan?.kind,
+              'plan.kind',
+              LibraryUpdatePlanKind.fullDownload,
+            )
+            .having(
+              (s) => s.message,
+              'message',
+              contains('החלת עדכון הדלתא נכשלה'),
+            ),
+      ],
+    );
+
+    blocTest<LibraryUpdateBloc, LibraryUpdateState>(
       'סטיית תוכן בלי DB מלא בתוכנית → error',
       build: () => _bloc(
         _FakeService(


### PR DESCRIPTION
חלק האפליקציה במהלך סכמת patch 4 (`line_ref`, ‏Otzaria/SeforimLibrary#18): הקשחת מסלול ה-fallback כך שאף כשל apply לא ישאיר את המשתמש בלולאת שגיאה.

## מה השתנה

עד היום רק אי-התאמת hash (`isContentMismatch`) הפעילה fallback להורדה מלאה. כל `PatchApplyException` אחר — והחשוב שבהם: patch שסכמתו חדשה מהנתמך באפליקציה ("נדרש עדכון תוכנה") — הוצג כשגיאה חשופה, והמשתמש נשאר תקוע בנסיונות חוזרים עד שיעדכן אפליקציה.

מעכשיו כל `PatchApplyException` מוביל ל-`needsFullConfirmation` כשיש DB מלא בתוכנית: הודעות ה-hash הקיימות נשמרו כמו שהן, ולשאר הכשלים הודעה כללית. נוספה בדיקת bloc לתרחיש.

זה הצד ההגנתי; הצד המונע — planner שמדלג מראש על edges בסכמה לא נתמכת — מגיע עם שדרוג חבילת ה-updater (ראו תלויות).

## תלויות וסדר שחרור

1. Otzaria/SeforimLibrary#19 + Otzaria/otzaria_library_updater#8 — חוזה סכמה 4 בשני הצדדים (ה-jobs של ה-contract בשניהם הופכים ירוקים רק כשהשניים ממוזגים).
2. **אחרי מיזוג otzaria_library_updater#8:** לעדכן כאן את ה-`ref` של `seforim_library_updater` ב-`pubspec.yaml` ל-commit הממוזג (זה מביא את ה-planner החדש ואת תמיכת סכמה 4). אפשר כ-commit נוסף ל-PR הזה או כ-PR המשך.
3. לשחרר גרסת אפליקציה עם השדרוג, ורק אחרי שהיא בחוץ — לפרסם release ראשון של הספרייה בסכמה 4.

ה-PR הזה עצמו אינו תלוי בקוד חדש של החבילה (משתמש רק ב-API קיים), ולכן בטוח למזג גם לפני עדכון ה-ref.

## צ'קליסט

- [ ] otzaria_library_updater#8 מוזג
- [ ] ‏`pubspec.yaml`: ‏`ref` עודכן ל-commit הממוזג
- [ ] גרסת אפליקציה שוחררה לפני ה-release הראשון של סכמה 4
