### PR TITLE
chore: עדכוני תלויות בטוחים ותואמי Android

### DIFF
--- a/.github/workflows/Build Windows EXE Only no release.yaml
+++ b/.github/workflows/Build Windows EXE Only no release.yaml
@@ -26,7 +26,7 @@ jobs:
       VC_REDIST_MIN_VERSION: '14.51.36247.0'
     steps:
       - name: Clone repository
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v4.4.0
 
       - name: Set up Flutter
         uses: subosito/flutter-action@v2

--- a/.github/workflows/build-and-announce.yml
+++ b/.github/workflows/build-and-announce.yml
@@ -47,7 +47,7 @@ jobs:
     outputs:
       is_version: ${{ steps.check.outputs.is_version }}
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@v4.4.0
       - name: Check if commit message is a version tag
         id: check
         run: |
@@ -82,7 +82,7 @@ jobs:
     #   CARGO_HOME:  ${{ github.workspace }}\.cargo
     steps:
       - name: Clone repository
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v4.4.0
 
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
@@ -532,7 +532,7 @@ jobs:
     runs-on: windows-11-arm
     steps:
       - name: Clone repository
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v4.4.0
 
       # אין חבילת SDK רשמית של Flutter ל-Windows-ARM במניפסט של flutter-action —
       # מתקינים מ-git באותו תג, כמו בלינוקס-ARM. ה-bootstrap מוריד Dart SDK
@@ -717,7 +717,7 @@ jobs:
           # בלי wildcard כל פקודת git (כולל flutter עצמו) נופלת על dubious ownership.
           git config --global --add safe.directory '*'
       - name: Clone repository
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v4.4.0
 
       - name: Check if commit message is a version tag
         id: check_version
@@ -787,7 +787,7 @@ jobs:
           rustup show
 
       - name: Cache cargo registry and git
-        uses: actions/cache@v4.2.3
+        uses: actions/cache@v4.3.0
         with:
           path: |
             ${{ env.CARGO_HOME }}/registry
@@ -1423,7 +1423,7 @@ jobs:
       CARGO_HOME: ${{ github.workspace }}/.cargo
     steps:
       - name: Clone repository
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v4.4.0
 
       - name: Check if commit message is a version tag
         id: check_version
@@ -1473,7 +1473,7 @@ jobs:
           rustup show
 
       - name: Cache Rust
-        uses: actions/cache@v4.2.3
+        uses: actions/cache@v4.3.0
         with:
           path: |
             ${{ env.CARGO_HOME }}/registry
@@ -1524,7 +1524,7 @@ jobs:
           echo "All Android Rust targets installed successfully"
 
       - name: Cache Gradle
-        uses: actions/cache@v4.2.3
+        uses: actions/cache@v4.3.0
         with:
           path: |
             ~/.gradle/caches
@@ -1534,7 +1534,7 @@ jobs:
             ${{ runner.os }}-gradle-
 
       - name: Cache Pub
-        uses: actions/cache@v4.2.3
+        uses: actions/cache@v4.3.0
         with:
           path: |
             ~/.pub-cache
@@ -1686,7 +1686,7 @@ jobs:
       CARGO_HOME:  ${{ github.workspace }}/.cargo
     steps:
       - name: Clone repository
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v4.4.0
 
       - name: Check if commit message is a version tag
         id: check_version
@@ -1744,7 +1744,7 @@ jobs:
 
       # (רשות אבל מומלץ) קאשינג לספריות cargo כדי לזרז בניות
       - name: Cache cargo registry and git
-        uses: actions/cache@v4.2.3
+        uses: actions/cache@v4.3.0
         with:
           path: |
             ${{ env.CARGO_HOME }}/registry
@@ -1936,7 +1936,7 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v4.4.0
 
       - name: Download Windows app bundle
         uses: actions/download-artifact@v4.3.0
@@ -2032,7 +2032,7 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v4.4.0
       
       - name: Download all artifacts
         uses: actions/download-artifact@v4.3.0
@@ -2444,7 +2444,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v4.4.0
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -105,5 +105,5 @@ flutter {
 }
 
 dependencies {
-    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.1.4'
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.1.5'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '2.1.0'
+    ext.kotlin_version = '2.2.20'
     repositories {
         google()
         mavenCentral()
@@ -7,7 +7,7 @@ buildscript {
 
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'com.android.tools.build:gradle:8.9.1'
+        classpath 'com.android.tools.build:gradle:8.11.1'
     }
 }
 

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -2,3 +2,7 @@ org.gradle.jvmargs=-Xmx4G
 android.useAndroidX=true
 android.enableJetifier=true
 
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=false
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=false

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-all.zip

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -23,8 +23,8 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id("com.android.application") version "8.9.1" apply false
-    id("org.jetbrains.kotlin.android") version "2.1.0" apply false
+    id("com.android.application") version "8.11.1" apply false
+    id("org.jetbrains.kotlin.android") version "2.2.20" apply false
 }
 
 include ":app"


### PR DESCRIPTION
## מה עודכן
- GitHub Actions בתוך סדרת v4: actions/checkout ל־v4.4.0 ו־actions/cache ל־v4.3.0.
- Android build toolchain למינימום הנתמך העדכני של Flutter: AGP 8.11.1, Gradle 8.14.5 ו־Kotlin 2.2.20.
- coreLibraryDesugaring ל־2.1.5.
- נשמר מצב ה־Flutter legacy Gradle/Kotlin במפורש, ללא מעבר ל־AGP 9 וללא שינוי בקוד האפליקציה, minSdk או targetSdk.

## מה נותר בכוונה
- עדכוני major ושדרוגים שדורשים מיגרציה (למשל AGP 9, file_picker, googleapis) לא נכללו.
- upload-google-play לא עודכן, משום שגרסת התיקון משנה את runtime הפעולה ל־Node 24 ודורשת בדיקת רילייס נפרדת.

## אימות
- flutter analyze
- flutter build apk --debug
- flutter test: 11,109 בדיקות עברו; שלושת הכשלים ב־test/tour/tour_cubit_test.dart קיימים גם ב־origin/dev נקי על macOS (המבחן מצפה CTRL והקוד מציג ⌘), ואינם קשורים ל־PR.