### PR TITLE
ci: עדכון פעולות GitHub ל־Node 24

### DIFF
--- a/.github/workflows/Build Windows EXE Only no release.yaml
+++ b/.github/workflows/Build Windows EXE Only no release.yaml
@@ -26,7 +26,7 @@ jobs:
       VC_REDIST_MIN_VERSION: '14.51.36247.0'
     steps:
       - name: Clone repository
-        uses: actions/checkout@v4.4.0
+        uses: actions/checkout@v7.0.1
 
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
@@ -418,19 +418,19 @@ jobs:
           }
 
       - name: Upload Windows installer (regular)
-        uses: actions/upload-artifact@v4.6.2
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: otzaria-windows-installer
           path: installer/otzaria-*-windows.exe
 
       - name: Upload Windows installer (full)
-        uses: actions/upload-artifact@v4.6.2
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: otzaria-windows-installer-full
           path: installer/otzaria-*-windows-full.exe
 
       - name: Upload Windows ZIP
-        uses: actions/upload-artifact@v4.6.2
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: otzaria-windows-zip
           path: otzaria-windows.zip

--- a/.github/workflows/build-and-announce.yml
+++ b/.github/workflows/build-and-announce.yml
@@ -47,7 +47,7 @@ jobs:
     outputs:
       is_version: ${{ steps.check.outputs.is_version }}
     steps:
-      - uses: actions/checkout@v4.4.0
+      - uses: actions/checkout@v7.0.1
       - name: Check if commit message is a version tag
         id: check
         run: |
@@ -82,7 +82,7 @@ jobs:
     #   CARGO_HOME:  ${{ github.workspace }}\.cargo
     steps:
       - name: Clone repository
-        uses: actions/checkout@v4.4.0
+        uses: actions/checkout@v7.0.1
 
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
@@ -112,7 +112,7 @@ jobs:
       #   uses: dtolnay/rust-toolchain@stable
 
       # - name: Cache cargo registry and git
-      #   uses: actions/cache@v4.2.3
+      #   uses: actions/cache@v6.1.0
       #   with:
       #     path: |
       #       ${{ env.CARGO_HOME }}\registry
@@ -499,25 +499,25 @@ jobs:
           }
 
       - name: Upload Windows installer (regular)
-        uses: actions/upload-artifact@v4.6.2
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: otzaria-windows-installer
           path: installer/otzaria-*-windows.exe
 
       - name: Upload Windows installer (full)
-        uses: actions/upload-artifact@v4.6.2
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: otzaria-windows-installer-full
           path: installer/otzaria-*-windows-full.exe
 
       - name: Upload Windows indexed installer tools
-        uses: actions/upload-artifact@v4.6.2
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: otzaria-windows-indexed-installer-tools
           path: indexed-installer-tools/*
 
       - name: Upload Windows ZIP
-        uses: actions/upload-artifact@v4.6.2
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: otzaria-windows-zip
           path: otzaria-windows.zip
@@ -532,7 +532,7 @@ jobs:
     runs-on: windows-11-arm
     steps:
       - name: Clone repository
-        uses: actions/checkout@v4.4.0
+        uses: actions/checkout@v7.0.1
 
       # אין חבילת SDK רשמית של Flutter ל-Windows-ARM במניפסט של flutter-action —
       # מתקינים מ-git באותו תג, כמו בלינוקס-ARM. ה-bootstrap מוריד Dart SDK
@@ -662,13 +662,13 @@ jobs:
           }
 
       - name: Upload Windows ARM64 installer
-        uses: actions/upload-artifact@v4.6.2
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: otzaria-windows-arm64-installer
           path: installer/otzaria-*-windows-arm64.exe
 
       - name: Upload Windows ARM64 ZIP
-        uses: actions/upload-artifact@v4.6.2
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: otzaria-windows-arm64-zip
           path: otzaria-windows-arm64.zip
@@ -703,7 +703,7 @@ jobs:
       # הפלאגין jni דורש כותרות JDK בזמן CMake (ב-runner הרגיל JDK מותקן מראש)
       JAVA_HOME: /usr/lib/jvm/java-17-openjdk-${{ matrix.arch == 'aarch64' && 'arm64' || 'amd64' }}
     steps:
-      # חובה לפני actions/checkout: הקונטיינר מינימלי וחסרים בו git/curl/unzip/zstd.
+      # חובה לפני actions/checkout.0.1: הקונטיינר מינימלי וחסרים בו git/curl/unzip/zstd.
       # בלי git ה-checkout מוריד tarball בלי היסטוריה ושלב בדיקת הגרסה (git log) נשבר;
       # zstd נדרש ל-cache של actions וגם לחילוץ ה-SDK (tar.zst).
       - name: Prepare container base tools
@@ -717,7 +717,7 @@ jobs:
           # בלי wildcard כל פקודת git (כולל flutter עצמו) נופלת על dubious ownership.
           git config --global --add safe.directory '*'
       - name: Clone repository
-        uses: actions/checkout@v4.4.0
+        uses: actions/checkout@v7.0.1
 
       - name: Check if commit message is a version tag
         id: check_version
@@ -787,7 +787,7 @@ jobs:
           rustup show
 
       - name: Cache cargo registry and git
-        uses: actions/cache@v4.3.0
+        uses: actions/cache@v6.1.0
         with:
           path: |
             ${{ env.CARGO_HOME }}/registry
@@ -1273,21 +1273,21 @@ jobs:
       
       - name: Upload Linux DEB package
         if: matrix.target == 'deb' && steps.find_packages.outputs.deb_file != ''
-        uses: actions/upload-artifact@v4.6.2
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: otzaria-linux-deb${{ matrix.arch == 'aarch64' && '-arm64' || '' }}
           path: ${{ steps.find_packages.outputs.deb_file }}
           
       - name: Upload Linux RPM package
         if: github.event_name != 'pull_request' && matrix.target == 'rpm' && steps.find_packages.outputs.rpm_file != ''
-        uses: actions/upload-artifact@v4.6.2
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: otzaria-linux-rpm${{ matrix.arch == 'aarch64' && '-arm64' || '' }}
           path: ${{ steps.find_packages.outputs.rpm_file }}
        
       - name: Upload linux build (raw)
         if: matrix.target == 'raw'
-        uses: actions/upload-artifact@v4.6.2
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: otzaria-linux-raw${{ matrix.arch == 'aarch64' && '-arm64' || '' }}
           path: linux-build/*
@@ -1393,14 +1393,14 @@ jobs:
 
       - name: Upload Linux FULL bundle
         if: matrix.target == 'full'
-        uses: actions/upload-artifact@v4.6.2
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: otzaria-linux-full${{ matrix.arch == 'aarch64' && '-arm64' || '' }}
           path: otzaria-linux-full${{ matrix.arch == 'aarch64' && '-arm64' || '' }}.tar.gz
 
       - name: Upload indexed FULL library parts
         if: matrix.target == 'full' && matrix.arch == 'x86_64'
-        uses: actions/upload-artifact@v4.6.2
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: otzaria-library-full-indexed
           path: indexed-release-parts/*
@@ -1409,7 +1409,7 @@ jobs:
 
       - name: Upload indexed FULL manifest for installer build
         if: matrix.target == 'full' && matrix.arch == 'x86_64'
-        uses: actions/upload-artifact@v4.6.2
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: otzaria-library-full-indexed-manifest
           path: indexed-release-parts/*.manifest.json
@@ -1423,7 +1423,7 @@ jobs:
       CARGO_HOME: ${{ github.workspace }}/.cargo
     steps:
       - name: Clone repository
-        uses: actions/checkout@v4.4.0
+        uses: actions/checkout@v7.0.1
 
       - name: Check if commit message is a version tag
         id: check_version
@@ -1473,7 +1473,7 @@ jobs:
           rustup show
 
       - name: Cache Rust
-        uses: actions/cache@v4.3.0
+        uses: actions/cache@v6.1.0
         with:
           path: |
             ${{ env.CARGO_HOME }}/registry
@@ -1524,7 +1524,7 @@ jobs:
           echo "All Android Rust targets installed successfully"
 
       - name: Cache Gradle
-        uses: actions/cache@v4.3.0
+        uses: actions/cache@v6.1.0
         with:
           path: |
             ~/.gradle/caches
@@ -1534,7 +1534,7 @@ jobs:
             ${{ runner.os }}-gradle-
 
       - name: Cache Pub
-        uses: actions/cache@v4.3.0
+        uses: actions/cache@v6.1.0
         with:
           path: |
             ~/.pub-cache
@@ -1637,7 +1637,7 @@ jobs:
           df -h
       
       - name: Upload apk
-        uses: actions/upload-artifact@v4.6.2
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: otzaria-android.apk
           path: build/app/outputs/flutter-apk/app-release.apk
@@ -1664,7 +1664,7 @@ jobs:
 
       - name: Upload Android FULL bundle
         if: true
-        uses: actions/upload-artifact@v4.6.2
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: otzaria-android-full
           path: otzaria-android-full.zip
@@ -1686,7 +1686,7 @@ jobs:
       CARGO_HOME:  ${{ github.workspace }}/.cargo
     steps:
       - name: Clone repository
-        uses: actions/checkout@v4.4.0
+        uses: actions/checkout@v7.0.1
 
       - name: Check if commit message is a version tag
         id: check_version
@@ -1744,7 +1744,7 @@ jobs:
 
       # (רשות אבל מומלץ) קאשינג לספריות cargo כדי לזרז בניות
       - name: Cache cargo registry and git
-        uses: actions/cache@v4.3.0
+        uses: actions/cache@v6.1.0
         with:
           path: |
             ${{ env.CARGO_HOME }}/registry
@@ -1910,21 +1910,21 @@ jobs:
 
       - name: Upload macOS DMG
         if: always()
-        uses: actions/upload-artifact@v4.6.2
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: otzaria-macos.dmg
           path: otzaria-macos.dmg
 
       - name: Upload macOS update zip
         if: always()
-        uses: actions/upload-artifact@v4.6.2
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: otzaria-macos-update
           path: otzaria-macos.zip
 
       - name: Upload macOS FULL bundle
         if: true
-        uses: actions/upload-artifact@v4.6.2
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: otzaria-macos-full
           path: otzaria-macos-full.zip
@@ -1936,22 +1936,22 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v4.4.0
+        uses: actions/checkout@v7.0.1
 
       - name: Download Windows app bundle
-        uses: actions/download-artifact@v4.3.0
+        uses: actions/download-artifact@v8.0.1
         with:
           name: otzaria-windows-zip
           path: indexed-inputs/windows
 
       - name: Download indexed installer tools
-        uses: actions/download-artifact@v4.3.0
+        uses: actions/download-artifact@v8.0.1
         with:
           name: otzaria-windows-indexed-installer-tools
           path: indexed-inputs/tools
 
       - name: Download indexed library manifest
-        uses: actions/download-artifact@v4.3.0
+        uses: actions/download-artifact@v8.0.1
         with:
           name: otzaria-library-full-indexed-manifest
           path: indexed-inputs/library
@@ -2004,7 +2004,7 @@ jobs:
           }
 
       - name: Upload Windows indexed FULL bootstrap installer
-        uses: actions/upload-artifact@v4.6.2
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: otzaria-windows-installer-full-indexed
           path: installer/otzaria-*-windows-full-indexed.exe
@@ -2032,10 +2032,10 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v4.4.0
+        uses: actions/checkout@v7.0.1
       
       - name: Download all artifacts
-        uses: actions/download-artifact@v4.3.0
+        uses: actions/download-artifact@v8.0.1
         with:
           path: artifacts
       
@@ -2416,7 +2416,7 @@ jobs:
       
       - name: Create Release
         if: github.event_name == 'workflow_dispatch'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3.0.3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           tag_name: ${{ steps.version.outputs.tag }}
@@ -2444,10 +2444,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.4.0
+        uses: actions/checkout@v7.0.1
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7.0.0
         with:
           python-version: '3.13'
 

--- a/.github/workflows/deploy-google-play.yml
+++ b/.github/workflows/deploy-google-play.yml
@@ -21,7 +21,7 @@ jobs:
       CARGO_HOME: ${{ github.workspace }}/.cargo
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.1
         with:
           ref: ${{ github.ref }}
 
@@ -37,7 +37,7 @@ jobs:
           df -h
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5.7.0
         with:
           distribution: temurin
           java-version: '17'
@@ -60,7 +60,7 @@ jobs:
           rustup show
 
       - name: Cache Rust
-        uses: actions/cache@v4
+        uses: actions/cache@v6.1.0
         with:
           path: |
             ${{ env.CARGO_HOME }}/registry
@@ -106,7 +106,7 @@ jobs:
           install_target_with_retry "i686-linux-android"
 
       - name: Cache Gradle
-        uses: actions/cache@v4
+        uses: actions/cache@v6.1.0
         with:
           path: |
             ~/.gradle/caches
@@ -116,7 +116,7 @@ jobs:
             ${{ runner.os }}-gradle-
 
       - name: Cache Pub
-        uses: actions/cache@v4
+        uses: actions/cache@v6.1.0
         with:
           path: |
             ~/.pub-cache
@@ -206,7 +206,7 @@ jobs:
         run: flutter build appbundle --release
 
       - name: Upload to Google Play Production
-        uses: r0adkll/upload-google-play@v1.1.3
+        uses: r0adkll/upload-google-play@v1.1.5
         with:
           serviceAccountJsonPlainText: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
           packageName: org.otzaria.otzaria

--- a/.github/workflows/flutter_tests.yml
+++ b/.github/workflows/flutter_tests.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.1
 
       # שימוש ב-channel stable + flutter-version קבוע, אחיד עם build-and-announce.yml.
       # הגרסה ננעלת מפני שדרוגים אוטומטיים של pub/CI אחרי שחרור גרסת flutter יציבה חדשה.
@@ -82,7 +82,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.1
 
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
@@ -99,7 +99,7 @@ jobs:
       # ה-cache מיוצר ב-warm_search_engine_cache.yml על ענף הבסיס.
       - name: Cache search engine library
         id: engine-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6.1.0
         with:
           path: ~/.pub-cache/hosted/pub.dev/otzaria_search_engine-*/rust/target/release/libsearch_engine.so
           # בלי restore-keys: .so מגרסה קודמת נכשל בבדיקת ה-content hash של FRB,

--- a/.github/workflows/forum-labels.yml
+++ b/.github/workflows/forum-labels.yml
@@ -11,7 +11,7 @@ jobs:
   label:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@v9.0.0
         with:
           script: |
             const body = context.payload.issue.body || '';

--- a/.github/workflows/warm_search_engine_cache.yml
+++ b/.github/workflows/warm_search_engine_cache.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.1
 
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
@@ -35,7 +35,7 @@ jobs:
 
       - name: Cache search engine library
         id: engine-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6.1.0
         with:
           path: ~/.pub-cache/hosted/pub.dev/otzaria_search_engine-*/rust/target/release/libsearch_engine.so
           key: ${{ runner.os }}-search-engine-lib-${{ hashFiles('pubspec.lock') }}

--- a/.github/workflows/webview2_smoke.yml
+++ b/.github/workflows/webview2_smoke.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.1
 
       - name: Setup Flutter
         uses: subosito/flutter-action@v2

--- a/.github/workflows/wiki-edit-log.yml
+++ b/.github/workflows/wiki-edit-log.yml
@@ -21,7 +21,7 @@ jobs:
   log:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@v9.0.0
         with:
           script: |
             const { owner, repo } = context.repo;

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '2.2.20'
+    ext.kotlin_version = '2.4.10'
     repositories {
         google()
         mavenCentral()
@@ -7,7 +7,7 @@ buildscript {
 
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'com.android.tools.build:gradle:8.11.1'
+        classpath 'com.android.tools.build:gradle:8.13.2'
     }
 }
 

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -23,8 +23,8 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id("com.android.application") version "8.11.1" apply false
-    id("org.jetbrains.kotlin.android") version "2.2.20" apply false
+    id("com.android.application") version "8.13.2" apply false
+    id("org.jetbrains.kotlin.android") version "2.4.10" apply false
 }
 
 include ":app"


### PR DESCRIPTION
## מה עודכן
- פעולות GitHub מהדור החדש שפועלות על Node 24: checkout, cache, upload/download artifact, setup-java, setup-python ו־github-script.
- softprops/action-gh-release ל־3.0.3 ו־r0adkll/upload-google-play ל־1.1.5; שתיהן פועלות על Node 24.
- נשמרו כל הקלטים וההתנהגות הקיימת של ה־workflows. העלאת Google Play משתמשת כבר ב־releaseFiles, והגרסה החדשה מתקנת את טיפול התאימות של אותו קלט.

## היקף בטיחות
- השינויים מוגבלים ל־CI. אין שינוי בקוד Dart, בתלויות runtime, ב־minSdk, ב־targetSdk או בחבילה שמגיעה למשתמשים.
- כל הריצות הן על GitHub-hosted runners, ולכן עומדות בדרישת ה־runner של פעולות Node 24.
- לא עודכנו Python, Flutter, AGP, Gradle, file_picker או תלויות major של האפליקציה.

## אימות
- כל קובצי ה־YAML נותחו בהצלחה.
- flutter analyze עבר ללא ממצאים.
- ה־PR יריץ את זרימות ה־CI הרגילות של GitHub.