### PR TITLE
חיפוש בתוך ספר: מציאת חצאי מילים (issue #1046)

### DIFF
--- a/lib/pdf_book/view/pdf_search_screen.dart
+++ b/lib/pdf_book/view/pdf_search_screen.dart
@@ -479,7 +479,7 @@ class PdfBookSearchViewState extends State<PdfBookSearchView> {
     }
     return InBookSearchRouting.isSearchableQuery(
           query,
-          wholeWord: _wholeWord,
+          wholeWord: _isSimpleSearch ? _wholeWord : true,
         )
         ? query
         : null;

--- a/lib/pdf_book/view/pdf_search_screen.dart
+++ b/lib/pdf_book/view/pdf_search_screen.dart
@@ -11,6 +11,8 @@ import 'package:otzaria/pdf_book/bloc/pdf_book_bloc.dart';
 import 'package:otzaria/pdf_book/bloc/pdf_book_event.dart';
 import 'package:otzaria/pdf_book/bloc/pdf_book_state.dart';
 import 'package:otzaria/search/book_facet.dart';
+import 'package:otzaria/search/in_book_search_preferences.dart';
+import 'package:otzaria/search/view/whole_word_search_action.dart';
 import 'package:otzaria/search/models/search_configuration.dart';
 import 'package:otzaria/search/search_query_builder.dart';
 import 'package:otzaria/search/search_repository.dart';
@@ -200,8 +202,17 @@ class PdfBookSearchViewState extends State<PdfBookSearchView> {
   /// תוצאות מיושנות (race) של חיפוש קודם.
   String? _pendingSimpleSearchScrollFor;
 
+  bool _wholeWord = InBookSearchPreferences.loadWholeWord();
+
   bool get _isSimpleSearch =>
       !_forceSearchEngine && _searchMode == SearchMode.exact;
+
+  /// החלפת מצב ההתאמה: הסריקה של pdfrx רצה מחדש עם התבנית המתאימה.
+  void _toggleWholeWord() {
+    setState(() => _wholeWord = !_wholeWord);
+    unawaited(InBookSearchPreferences.saveWholeWord(_wholeWord));
+    _searchTextUpdated();
+  }
 
   void _updateForceSearchEngine() {
     _forceSearchEngine = !InBookSearchRouting.canRunAsSimpleSearch(
@@ -264,7 +275,6 @@ class PdfBookSearchViewState extends State<PdfBookSearchView> {
       _onIncomingSearchConfiguration,
     );
     widget.textSearcher.addListener(_onTextSearcherMatchesChanged);
-    widget.searchController.addListener(_searchTextUpdated);
     _initializeBookPath();
   }
 
@@ -394,7 +404,6 @@ class PdfBookSearchViewState extends State<PdfBookSearchView> {
       _onIncomingSearchConfiguration,
     );
     widget.textSearcher.removeListener(_onTextSearcherMatchesChanged);
-    widget.searchController.removeListener(_searchTextUpdated);
     _pdfHighlightDebounce?.cancel();
     super.dispose();
   }
@@ -436,8 +445,6 @@ class PdfBookSearchViewState extends State<PdfBookSearchView> {
     required SearchMatchPolicy matchPolicy,
     required PdfBookBloc pdfBookBloc,
   }) {
-    final queryChanged = widget.searchController.text != query;
-
     setState(() {
       _searchOptions = searchOptions;
       _alternativeWords = alternativeWords;
@@ -458,10 +465,10 @@ class PdfBookSearchViewState extends State<PdfBookSearchView> {
       ),
     );
 
+    // שינוי תוכניתי של ה-controller אינו מפעיל את onChanged של השדה, ולכן
+    // החיפוש מורץ כאן ישירות.
     syncSearchControllerQuery(widget.searchController, query);
-    if (!queryChanged) {
-      _searchTextUpdated();
-    }
+    _searchTextUpdated();
   }
 
   Future<void> _searchTextUpdated() async {
@@ -507,7 +514,7 @@ class PdfBookSearchViewState extends State<PdfBookSearchView> {
       _pdfHighlightDebounce?.cancel();
       _pendingSimpleSearchScrollFor = query;
       // תבנית סובלנית-ניקוד מהמנוע, כדי שגם PDF ששכבת הטקסט שלו מנוקדת יודגש.
-      final literal = buildLiteralPattern(query);
+      final literal = buildLiteralPattern(query, wholeWord: _wholeWord);
       _lastPdfHighlightSource = literal?.source ?? query;
       widget.textSearcher.startTextSearch(
         literal?.regExp ?? query,
@@ -679,6 +686,7 @@ class PdfBookSearchViewState extends State<PdfBookSearchView> {
                     _isSimpleSearch
                         ? buildLiteralPattern(
                             widget.searchController.text,
+                            wholeWord: _wholeWord,
                           )?.regExp
                         : _lastAdvancedHighlightPattern,
                   );
@@ -687,6 +695,7 @@ class PdfBookSearchViewState extends State<PdfBookSearchView> {
                 height: 50,
                 query: widget.searchController.text,
                 isSimpleSearch: _isSimpleSearch,
+                wholeWord: _wholeWord,
               ),
             );
           },
@@ -724,7 +733,15 @@ class PdfBookSearchViewState extends State<PdfBookSearchView> {
         );
         _schedulePdfHighlight(null);
       },
-      additionalActions: const [],
+      searchFieldActions: [
+        if (_isSimpleSearch)
+          wholeWordSearchAction(
+            context: context,
+            wholeWord: _wholeWord,
+            onToggle: _toggleWholeWord,
+          ),
+      ],
+      searchFieldActionsKey: (_isSimpleSearch, _wholeWord),
       hintText: 'חפש כאן..',
       onAdvancedSearch: () async {
         final pdfBookBloc = context.read<PdfBookBloc>();
@@ -776,6 +793,7 @@ class SearchResultTile extends StatelessWidget {
     required this.height,
     required this.query,
     required this.isSimpleSearch,
+    required this.wholeWord,
     super.key,
   });
 
@@ -784,6 +802,7 @@ class SearchResultTile extends StatelessWidget {
   final double height;
   final String query;
   final bool isSimpleSearch;
+  final bool wholeWord;
 
   @override
   Widget build(BuildContext context) {
@@ -840,6 +859,7 @@ class SearchResultTile extends StatelessWidget {
         query: query,
         defaultStyle: defaultStyle,
         highlightStyle: highlightStyle,
+        wholeWord: wholeWord,
       );
 
       return Text.rich(

--- a/lib/pdf_book/view/pdf_search_screen.dart
+++ b/lib/pdf_book/view/pdf_search_screen.dart
@@ -471,13 +471,27 @@ class PdfBookSearchViewState extends State<PdfBookSearchView> {
     _searchTextUpdated();
   }
 
+  /// השאילתה שתרוץ בפועל, מנורמלת, או `null` כשאין מה לחפש עליה.
+  String? _searchableQuery(String raw) {
+    var query = raw.trim();
+    if (utils.hasNikud(query)) {
+      query = utils.removeVolwels(query);
+    }
+    return InBookSearchRouting.isSearchableQuery(
+          query,
+          wholeWord: _wholeWord,
+        )
+        ? query
+        : null;
+  }
+
   Future<void> _searchTextUpdated() async {
     // כל שינוי בשאילתה/במצב החיפוש מבטל תוצאות אסינכרוניות ישנות. בלי מזהה
     // דור, חיפוש איטי קודם יכול להסתיים אחרי החדש ולדרוס תוצאות והדגשות.
     final generation = ++_searchGeneration;
-    String query = widget.searchController.text.trim();
+    final searchable = _searchableQuery(widget.searchController.text);
 
-    if (query.isEmpty || (!_isSimpleSearch && _bookPath == null)) {
+    if (searchable == null || (!_isSimpleSearch && _bookPath == null)) {
       // איפוס גלילה ממתינה כדי שתוצאות מיושנות לא יגרמו לקפיצה אחרי
       // ניקוי השדה.
       _pendingSimpleSearchScrollFor = null;
@@ -497,9 +511,7 @@ class PdfBookSearchViewState extends State<PdfBookSearchView> {
       return;
     }
 
-    if (utils.hasNikud(query)) {
-      query = utils.removeVolwels(query);
-    }
+    final query = searchable;
 
     // איפוס השגיאה לפני פיצול המסלול — במסלול הפשוט התוצאות מגיעות
     // אסינכרונית, ובלי האיפוס כאן שגיאת מנוע קודמת נשארת מוצגת.
@@ -702,7 +714,7 @@ class PdfBookSearchViewState extends State<PdfBookSearchView> {
         ),
       ),
       isNoResults:
-          widget.searchController.text.isNotEmpty &&
+          _searchableQuery(widget.searchController.text) != null &&
           _searchResults.isEmpty &&
           !_isSearching,
       errorMessage: _searchErrorMessage,

--- a/lib/search/in_book_search_preferences.dart
+++ b/lib/search/in_book_search_preferences.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/foundation.dart' show debugPrint;
+import 'package:flutter_settings_screens/flutter_settings_screens.dart';
+
+/// העדפת "מילים שלמות בלבד" של החיפוש בתוך ספר (טקסט ו-PDF).
+///
+/// כבוי כברירת מחדל: הקלדת "שמים" מוצאת גם "השמים", כמו Ctrl+F בכל תוכנה.
+class InBookSearchPreferences {
+  static const String _wholeWordKey = 'key-in-book-search-whole-word';
+
+  InBookSearchPreferences._();
+
+  static bool loadWholeWord() {
+    try {
+      return Settings.getValue<bool>(_wholeWordKey) ?? false;
+    } catch (e) {
+      // Settings שלא אותחל (בדיקות, עלייה מוקדמת) — ברירת המחדל.
+      debugPrint('טעינת העדפת מילים שלמות נכשלה: $e');
+      return false;
+    }
+  }
+
+  /// האם ההתאמה בספר תהיה של מילים שלמות, בהינתן המסלול שירוץ בפועל.
+  /// מסלול המנוע תמיד מילים שלמות — ההדגשה שם נגזרת מהתבנית שהמנוע בנה
+  /// ואינה מושפעת מהמתג.
+  static bool resolveWholeWord({required bool isSimpleSearch}) =>
+      isSimpleSearch ? loadWholeWord() : true;
+
+  static Future<void> saveWholeWord(bool value) async {
+    try {
+      await Settings.setValue<bool>(_wholeWordKey, value);
+    } catch (e) {
+      debugPrint('שמירת העדפת מילים שלמות נכשלה: $e');
+    }
+  }
+}

--- a/lib/search/utils/in_book_search_routing.dart
+++ b/lib/search/utils/in_book_search_routing.dart
@@ -34,6 +34,18 @@ class InBookSearchParameters {
 class InBookSearchRouting {
   const InBookSearchRouting._();
 
+  /// המינימום להתאמה חלקית. תו בודד מתאים בתוך כמעט כל מילה, ולכן סריקה
+  /// עליו יקרה וחסרת ערך. במילים שלמות אין מינימום — "פ"/"ס" בתנ"ך.
+  static const int minPartialMatchChars = 2;
+
+  /// האם כדאי להריץ חיפוש על [normalizedQuery] (אחרי trim והסרת ניקוד).
+  static bool isSearchableQuery(
+    String normalizedQuery, {
+    required bool wholeWord,
+  }) =>
+      normalizedQuery.isNotEmpty &&
+      (wholeWord || normalizedQuery.length >= minPartialMatchChars);
+
   /// האם השאילתה ניתנת להרצה כחיפוש ליטרלי מקומי בספר.
   ///
   /// כל תוספת על שאילתה ליטרלית — מרווח בין מילים, אפשרות פר-מילה, מילה

--- a/lib/search/utils/literal_search_pattern.dart
+++ b/lib/search/utils/literal_search_pattern.dart
@@ -28,30 +28,82 @@ class LiteralSearchPattern {
 String normalizeLiteralQuery(String query) =>
     utils.removeVolwels(query).replaceAll(_whitespaceRun, ' ').trim();
 
-String? _cachedQuery;
-LiteralSearchPattern? _cachedPattern;
+/// עטיפת גבול-המילה שהמנוע מוסיף סביב הביטוי:
+/// `(?<!גבול לפני)(?:ביטוי)(?!גבול אחרי)`. מחזירה את הביטוי בלבד, או `null`
+/// אם המבנה אינו מזוהה — ואז החיפוש נשאר בהתאמת מילה שלמה במקום לסרוק
+/// בתבנית חתוכה שגויה.
+String? stripWordBoundaryWrapper(String source) {
+  if (!source.startsWith('(?<!')) return null;
+
+  // מחלקות התווים שבעטיפה אינן מכילות סוגריים, ולכן הסוגר המאזן את הפותח
+  // נמצא בספירת עומק פשוטה.
+  var depth = 0;
+  var lookbehindEnd = -1;
+  for (var i = 0; i < source.length; i++) {
+    final ch = source[i];
+    if (ch == '(') {
+      depth++;
+    } else if (ch == ')') {
+      depth--;
+      if (depth == 0) {
+        lookbehindEnd = i;
+        break;
+      }
+    }
+  }
+  if (lookbehindEnd < 0) return null;
+
+  // הגבול הסוגר הוא ה-`(?!` האחרון: `(?!` נוסף מופיע בתוך תבנית תג ה-HTML
+  // שבמפריד בין מילות השאילתה, והוא תמיד לפניו.
+  final lookaheadStart = source.lastIndexOf('(?!');
+  if (lookaheadStart <= lookbehindEnd) return null;
+
+  final phrase = source.substring(lookbehindEnd + 1, lookaheadStart);
+  return phrase.isEmpty ? null : phrase;
+}
+
+final Map<String, LiteralSearchPattern?> _cache = {};
 
 /// בונה (עם קאש) תבנית ליטרלית לשאילתה, לאחר נרמול.
 /// מחזיר `null` לשאילתה ריקה/רק-רווחים.
 ///
+/// [wholeWord] `false` מסיר את גבולות המילה שהמנוע מוסיף, כך ש"שמים" מתאים
+/// גם בתוך "השמים" — התנהגות Ctrl+F הרגילה. כל השאר (ניקוד, גרש/גרשיים,
+/// המפריד בין מילים) זהה בשני המצבים.
+///
 /// חובה להיקרא ב-isolate הראשי בלבד — קורא למנוע (flutter_rust_bridge)
 /// שקשור אליו. ב-isolate worker יש לקמפל דרך [compileLiteralPattern].
-LiteralSearchPattern? buildLiteralPattern(String query) {
+LiteralSearchPattern? buildLiteralPattern(
+  String query, {
+  bool wholeWord = true,
+}) {
   final q = normalizeLiteralQuery(query);
-  if (q == _cachedQuery) return _cachedPattern;
+  final cacheKey = '${wholeWord ? 'w' : 'p'}|$q';
+  if (_cache.containsKey(cacheKey)) return _cache[cacheKey];
 
-  // בונים לפני עדכון ה-cache: אם המנוע זורק, ה-cache נשאר עקבי (שאילתה
-  // קודמת + התבנית שלה) ולא מחזיר תבנית ישנה עבור השאילתה החדשה.
+  // בונים לפני עדכון ה-cache: אם המנוע זורק, ה-cache נשאר עקבי ולא מקבל
+  // רשומה חלקית לשאילתה החדשה.
   LiteralSearchPattern? result;
   if (q.isNotEmpty) {
     final source = engine.generateLiteralHighlightPattern(query: q);
     if (source != null) {
-      result = LiteralSearchPattern(source, compileLiteralPattern(source));
+      final effective = wholeWord
+          ? source
+          : (stripWordBoundaryWrapper(source) ?? source);
+      try {
+        result = LiteralSearchPattern(
+          effective,
+          compileLiteralPattern(effective),
+        );
+      } on FormatException {
+        // תבנית חתוכה שאינה מתקמפלת — נסיגה לתבנית המלאה של המנוע.
+        result = LiteralSearchPattern(source, compileLiteralPattern(source));
+      }
     }
   }
 
-  _cachedQuery = q;
-  _cachedPattern = result;
+  if (_cache.length >= 16) _cache.clear();
+  _cache[cacheKey] = result;
   return result;
 }
 

--- a/lib/search/utils/snippet_builder.dart
+++ b/lib/search/utils/snippet_builder.dart
@@ -168,15 +168,17 @@ class SnippetBuilder {
 
   /// מדגיש הופעות ליטרליות של [query] בטקסט מקומי [plainText].
   ///
-  /// ההתאמה סובלנית לניקוד/טעמים ולחילופי גרשיים עבריים/לועזיים, ומכבדת
-  /// גבולות מילה — בהתאם לסמנטיקת החיפוש המקומי (`_containsWholeWord`).
+  /// ההתאמה סובלנית לניקוד/טעמים ולחילופי גרשיים עבריים/לועזיים.
+  /// [wholeWord] חייב להיות זהה לזה שאיתו נמצאו התוצאות, אחרת תוצאה תוצג
+  /// בלי הדגשה.
   static List<InlineSpan> highlightLiteral({
     required String plainText,
     required String query,
     required TextStyle defaultStyle,
     required TextStyle highlightStyle,
+    bool wholeWord = true,
   }) {
-    final pattern = buildLiteralPattern(query)?.regExp;
+    final pattern = buildLiteralPattern(query, wholeWord: wholeWord)?.regExp;
     if (plainText.isEmpty || pattern == null) {
       return [TextSpan(text: plainText, style: defaultStyle)];
     }
@@ -225,6 +227,7 @@ class SnippetBuilder {
     required String fullText,
     required String query,
     required int maxChars,
+    bool wholeWord = true,
   }) {
     final text = fullText.replaceAll(_whitespace, ' ').trim();
     if (text.length <= maxChars) return text;
@@ -241,7 +244,7 @@ class SnippetBuilder {
       return lastSpace != -1 ? lastSpace + 1 : 0;
     }
 
-    final pattern = buildLiteralPattern(query)?.regExp;
+    final pattern = buildLiteralPattern(query, wholeWord: wholeWord)?.regExp;
     final anchor = pattern?.firstMatch(text);
     if (anchor == null) {
       final end = findWordEnd(maxChars);

--- a/lib/search/view/whole_word_search_action.dart
+++ b/lib/search/view/whole_word_search_action.dart
@@ -1,0 +1,22 @@
+import 'package:fluentui_system_icons/fluentui_system_icons.dart';
+import 'package:flutter/material.dart';
+import 'package:otzaria/widgets/text/otzaria_search_field.dart';
+
+/// מתג "מילים שלמות בלבד" של החיפוש בתוך ספר, בשדה החיפוש עצמו.
+/// משותף לחיפוש בספר טקסט ובספר PDF כדי שהאייקון והתווית לא יסטו.
+Widget wholeWordSearchAction({
+  required BuildContext context,
+  required bool wholeWord,
+  required VoidCallback onToggle,
+}) {
+  return OtzariaSearchAction.icon(
+    iconData: wholeWord
+        ? FluentIcons.text_whole_word_20_filled
+        : FluentIcons.text_whole_word_20_regular,
+    onPressed: onToggle,
+    tooltip: wholeWord
+        ? 'מחפש מילים שלמות בלבד'
+        : 'מחפש גם חלק ממילה — לחץ למילים שלמות',
+    color: wholeWord ? Theme.of(context).colorScheme.primary : null,
+  );
+}

--- a/lib/text_book/bloc/text_book_bloc.dart
+++ b/lib/text_book/bloc/text_book_bloc.dart
@@ -16,8 +16,10 @@ import 'package:otzaria/utils/text/text_manipulation.dart' as utils;
 import 'package:flutter_settings_screens/flutter_settings_screens.dart';
 import 'package:otzaria/data/data_providers/sqlite_data_provider.dart';
 import 'package:otzaria/data/data_providers/tantivy_data_provider.dart';
+import 'package:otzaria/search/in_book_search_preferences.dart';
 import 'package:otzaria/search/models/search_configuration.dart';
 import 'package:otzaria/search/search_engine_gateway.dart';
+import 'package:otzaria/search/utils/in_book_search_routing.dart';
 import 'package:otzaria/settings/engine/settings_repository.dart';
 import 'package:otzaria/settings/services/nikud_display_service.dart';
 import 'package:otzaria/settings/services/per_book_settings_service.dart';
@@ -1026,6 +1028,18 @@ class TextBookBloc extends Bloc<TextBookEvent, TextBookState> {
         searchMode: searchMode,
         searchDistance: searchDistance,
         matchPolicy: matchPolicy,
+        // נזרע כאן ולא בחלונית: החלונית נבנית רק כשנפתחת, וההדגשה בספר
+        // חייבת להיות זהה לפניה ואחריה.
+        searchWholeWord: InBookSearchPreferences.resolveWholeWord(
+          isSimpleSearch: InBookSearchRouting.canRunAsSimpleSearch(
+            searchMode: searchMode,
+            distance: searchDistance,
+            searchOptions: searchOptions,
+            alternativeWords: alternativeWords,
+            spacingValues: spacingValues,
+            matchPolicy: matchPolicy,
+          ),
+        ),
         searchResultLines: searchResultLines,
         scrollController: scrollController,
         positionsListener: positionsListener,
@@ -1991,6 +2005,7 @@ class TextBookBloc extends Bloc<TextBookEvent, TextBookState> {
           searchMode: event.searchMode,
           searchDistance: event.searchDistance,
           matchPolicy: event.matchPolicy,
+          searchWholeWord: event.searchWholeWord,
           selectedIndex: currentState.selectedIndex,
           clearPinpointHighlight: true,
           // שאילתה חדשה — תוצאות החיפוש הקודם אינן תקפות יותר.

--- a/lib/text_book/bloc/text_book_event.dart
+++ b/lib/text_book/bloc/text_book_event.dart
@@ -261,6 +261,9 @@ class UpdateSearchText extends TextBookEvent {
   final int? searchDistance;
   final SearchMatchPolicy? matchPolicy;
 
+  /// האם החיפוש הפשוט דורש מילים שלמות. ראו [TextBookLoaded.searchWholeWord].
+  final bool? searchWholeWord;
+
   const UpdateSearchText(
     this.text, {
     this.searchOptions,
@@ -269,6 +272,7 @@ class UpdateSearchText extends TextBookEvent {
     this.searchMode,
     this.searchDistance,
     this.matchPolicy,
+    this.searchWholeWord,
   });
 
   @override
@@ -280,6 +284,7 @@ class UpdateSearchText extends TextBookEvent {
     searchMode,
     searchDistance,
     matchPolicy,
+    searchWholeWord,
   ];
 }
 

--- a/lib/text_book/bloc/text_book_state.dart
+++ b/lib/text_book/bloc/text_book_state.dart
@@ -230,6 +230,11 @@ class TextBookLoaded extends TextBookState {
   final int searchDistance;
   final SearchMatchPolicy matchPolicy;
 
+  /// האם ההתאמה הפעילה בספר דורשת מילים שלמות. `false` מדגיש גם בתוך מילה
+  /// ("שמים" בתוך "השמים") — חלונית החיפוש שולחת אותו רק במסלול הפשוט, כך
+  /// שהדגשת תוצאות המנוע נשארת כשהייתה.
+  final bool searchWholeWord;
+
   /// שורות הספר שחיפוש המנוע החזיר בפועל (0-based), או null כשלא רץ חיפוש
   /// מנוע. ההדגשה במדיניות התאמה שאינה ברירת המחדל מוגבלת לשורות האלה, כדי
   /// שהאפליקציה לא תשחזר בעצמה את החלטת המנוע (טווח פסקה/כותרת, סף מילים).
@@ -310,6 +315,7 @@ class TextBookLoaded extends TextBookState {
     this.searchMode = SearchMode.exact,
     this.searchDistance = 0,
     this.matchPolicy = SearchMatchPolicy.standard,
+    this.searchWholeWord = true,
     this.searchResultLines,
     required this.scrollController,
     required this.positionsListener,
@@ -437,6 +443,7 @@ class TextBookLoaded extends TextBookState {
     SearchMode? searchMode,
     int? searchDistance,
     SearchMatchPolicy? matchPolicy,
+    bool? searchWholeWord,
     Set<int>? searchResultLines,
     ItemScrollController? scrollController,
     ItemPositionsListener? positionsListener,
@@ -519,6 +526,7 @@ class TextBookLoaded extends TextBookState {
       searchMode: searchMode ?? this.searchMode,
       searchDistance: searchDistance ?? this.searchDistance,
       matchPolicy: matchPolicy ?? this.matchPolicy,
+      searchWholeWord: searchWholeWord ?? this.searchWholeWord,
       searchResultLines: clearSearchResultLines
           ? null
           : (searchResultLines ?? this.searchResultLines),
@@ -626,6 +634,7 @@ class TextBookLoaded extends TextBookState {
     searchMode,
     searchDistance,
     matchPolicy,
+    searchWholeWord,
     searchResultLines,
     currentTitle,
     selectedTextForNote,

--- a/lib/text_book/utils/section_search_utils.dart
+++ b/lib/text_book/utils/section_search_utils.dart
@@ -79,6 +79,7 @@ double matchFractionInLine(
   String rawLine,
   String query, {
   int? matchOffset,
+  bool wholeWord = true,
   @visibleForTesting RegExp? pattern,
 }) {
   final clean = cleanLineForSearch(rawLine);
@@ -87,7 +88,8 @@ double matchFractionInLine(
   if (matchOffset != null) {
     offset = matchOffset;
   } else {
-    final regExp = pattern ?? buildLiteralPattern(query)?.regExp;
+    final regExp =
+        pattern ?? buildLiteralPattern(query, wholeWord: wholeWord)?.regExp;
     if (regExp == null) return 0;
     offset = regExp.firstMatch(clean)?.start ?? -1;
   }
@@ -110,10 +112,12 @@ double matchFractionFromLineLength({int? matchOffset, int? lineLength}) {
 bool queryMatchesInlineNoteOnly(
   String rawLine,
   String query, {
+  bool wholeWord = true,
   @visibleForTesting RegExp? pattern,
 }) {
   if (!rawLine.contains('footnote')) return false;
-  final regExp = pattern ?? buildLiteralPattern(query)?.regExp;
+  final regExp =
+      pattern ?? buildLiteralPattern(query, wholeWord: wholeWord)?.regExp;
   if (regExp == null) return false;
 
   final noteBody = notes.notesForLines([rawLine], const [0]).join(' ');
@@ -492,11 +496,13 @@ class SectionSearchWorkerRuntime {
 Future<List<TextSearchResult>> searchInContent({
   required List<String> content,
   required String query,
+  bool wholeWord = true,
   @visibleForTesting String? patternSource,
 }) async {
   if (content.isEmpty) return [];
 
-  final source = patternSource ?? buildLiteralPattern(query)?.source;
+  final source =
+      patternSource ?? buildLiteralPattern(query, wholeWord: wholeWord)?.source;
   if (source == null) return [];
 
   return _SearchWorkerHost.instance.search(

--- a/lib/text_book/view/combined_view/combined_book_screen.dart
+++ b/lib/text_book/view/combined_view/combined_book_screen.dart
@@ -770,7 +770,11 @@ class _CombinedViewState extends State<CombinedView> {
         final isFromSearch =
             state.searchText.isNotEmpty && initialIndex < state.content.length;
         final intraLineFraction = isFromSearch
-            ? matchFractionInLine(state.content[initialIndex], state.searchText)
+            ? matchFractionInLine(
+                state.content[initialIndex],
+                state.searchText,
+                wholeWord: state.searchWholeWord,
+              )
             : 0.0;
         WidgetsBinding.instance.addPostFrameCallback((_) {
           if (mounted && widget.tab.scrollController.isAttached) {
@@ -1764,6 +1768,7 @@ class _CombinedViewState extends State<CombinedView> {
       searchMode: state.searchMode,
       searchDistance: state.searchDistance,
       matchPolicy: state.matchPolicy,
+      partialWordHighlight: !state.searchWholeWord,
       fontSize: widget.textSize,
       fontFamily: settingsState.fontFamily,
       fontWeight: settingsState.fontBold ? FontWeight.bold : null,
@@ -2547,6 +2552,7 @@ class _CombinedViewState extends State<CombinedView> {
                               searchMode: state.searchMode,
                               searchDistance: state.searchDistance,
                               matchPolicy: state.matchPolicy,
+                              partialWordHighlight: !state.searchWholeWord,
                               // לפי שורת התוכן המוצגת — index הוא אינדקס
                               // מקטע במצב קריאה רציפה, לא אינדקס שורה.
                               isSearchResultLine: state
@@ -2857,6 +2863,7 @@ class _CombinedViewState extends State<CombinedView> {
       searchMode: effectiveSearchMode,
       searchDistance: effectiveSearchDistance,
       matchPolicy: effectiveMatchPolicy,
+      partialWordHighlight: !hasPinpoint && !state.searchWholeWord,
       isSearchResultLine: state.lineParticipatesInSearchHighlight(lineIndex),
       fontSize: widget.textSize,
       fontFamily: settingsState.fontFamily,

--- a/lib/text_book/view/page_shape/simple_text_viewer.dart
+++ b/lib/text_book/view/page_shape/simple_text_viewer.dart
@@ -1235,6 +1235,7 @@ class _SimpleTextViewerState extends State<SimpleTextViewer> {
       matchPolicy: widget.isMainText
           ? state.matchPolicy
           : SearchMatchPolicy.standard,
+      partialWordHighlight: widget.isMainText && !state.searchWholeWord,
       fontSize: widget.fontSize,
       fontFamily: widget.fontFamily ?? settingsState.fontFamily,
       fontWeight:
@@ -2955,6 +2956,8 @@ class _SimpleTextViewerState extends State<SimpleTextViewer> {
                     matchPolicy: widget.isMainText
                         ? state.matchPolicy
                         : SearchMatchPolicy.standard,
+                    partialWordHighlight:
+                        widget.isMainText && !state.searchWholeWord,
                     isSearchResultLine:
                         widget.isMainText &&
                         state.lineParticipatesInSearchHighlight(
@@ -3224,6 +3227,7 @@ class _SimpleTextViewerState extends State<SimpleTextViewer> {
       matchPolicy: useStateSearchSettings
           ? state.matchPolicy
           : SearchMatchPolicy.standard,
+      partialWordHighlight: useStateSearchSettings && !state.searchWholeWord,
       isSearchResultLine:
           useStateSearchSettings &&
           state.lineParticipatesInSearchHighlight(lineIndex),

--- a/lib/text_book/view/splited_view/splited_view_screen.dart
+++ b/lib/text_book/view/splited_view/splited_view_screen.dart
@@ -307,7 +307,13 @@ class _SplitedViewScreenState extends State<SplitedViewScreen> {
     if (query.isEmpty) return;
     final idx = state.selectedIndex ?? widget.tab.index;
     if (idx < 0 || idx >= state.content.length) return;
-    if (!queryMatchesInlineNoteOnly(state.content[idx], query)) return;
+    if (!queryMatchesInlineNoteOnly(
+      state.content[idx],
+      query,
+      wholeWord: state.searchWholeWord,
+    )) {
+      return;
+    }
 
     _didOpenNotesForSearch = true;
     if (!state.activeCommentators.contains(kNotesCommentatorTitle)) {

--- a/lib/text_book/view/text_book_search_screen.dart
+++ b/lib/text_book/view/text_book_search_screen.dart
@@ -17,6 +17,8 @@ import 'package:otzaria/text_book/bloc/text_book_state.dart';
 import 'package:otzaria/text_book/models/search_results.dart';
 import 'package:otzaria/utils/text/text_manipulation.dart' as utils;
 import 'package:otzaria/widgets/navigation/search_pane_base.dart';
+import 'package:otzaria/search/in_book_search_preferences.dart';
+import 'package:otzaria/search/view/whole_word_search_action.dart';
 import 'package:otzaria/search/search_repository.dart';
 import 'package:otzaria/search/search_query_builder.dart';
 import 'package:otzaria/search/utils/in_book_search_routing.dart';
@@ -109,6 +111,7 @@ class TextBookSearchViewState extends State<TextBookSearchView>
   SearchMode _searchMode = SearchMode.exact;
   int _searchDistance = 0;
   SearchMatchPolicy _matchPolicy = SearchMatchPolicy.standard;
+  bool _wholeWord = InBookSearchPreferences.loadWholeWord();
   int? _selectedSearchResultIndex;
   // מספר השורה בספר של התוצאה הנבחרת — משמש לשמירת הבחירה לפי זהות בין
   // חיפושים. אינדקס סידורי לבדו אינו אמין כי תוכן הרשימה משתנה כשהשאילתה
@@ -122,6 +125,10 @@ class TextBookSearchViewState extends State<TextBookSearchView>
 
   bool get _isSimpleSearch =>
       !_forceSearchEngine && _searchMode == SearchMode.exact;
+
+  /// המתג חל רק על הסריקה הליטרלית. במסלול המנוע ההדגשה נגזרת מהתבנית
+  /// שהמנוע בנה, ולכן הוא מדווח "מילים שלמות" ללא תלות במתג.
+  bool get _effectiveWholeWord => _isSimpleSearch ? _wholeWord : true;
 
   static const int _maxResultSnippetChars = 220;
 
@@ -180,6 +187,9 @@ class TextBookSearchViewState extends State<TextBookSearchView>
   }
 
   void _syncSearchConfigurationFromWidget() {
+    // ההעדפה גלובלית ונקראת מחדש: החלפת המתג בטאב אחר משאירה כאן ערך ישן,
+    // וההדגשה בגוף הספר הייתה סותרת את רשימת התוצאות.
+    _wholeWord = InBookSearchPreferences.loadWholeWord();
     _searchOptions = widget.initialSearchOptions;
     _alternativeWords = widget.initialAlternativeWords;
     _spacingValues = widget.initialSpacingValues;
@@ -200,8 +210,18 @@ class TextBookSearchViewState extends State<TextBookSearchView>
         searchMode: _searchMode,
         searchDistance: _searchDistance,
         matchPolicy: _matchPolicy,
+        searchWholeWord: _effectiveWholeWord,
       ),
     );
+  }
+
+  /// החלפת מצב ההתאמה: מעדכן את ההדגשה בגוף הספר ומריץ את החיפוש מחדש,
+  /// אחרת הרשימה נשארת עם תוצאות המצב הקודם.
+  void _toggleWholeWord() {
+    setState(() => _wholeWord = !_wholeWord);
+    unawaited(InBookSearchPreferences.saveWholeWord(_wholeWord));
+    _syncBlocSearchTextState();
+    _searchTextUpdated();
   }
 
   @override
@@ -400,7 +420,11 @@ class TextBookSearchViewState extends State<TextBookSearchView>
 
       final effectiveResults = widget.simpleSearchRunner != null
           ? await widget.simpleSearchRunner!(content, query)
-          : await searchInContent(content: content, query: query);
+          : await searchInContent(
+              content: content,
+              query: query,
+              wholeWord: _wholeWord,
+            );
 
       if (mounted && requestId == _activeSearchRequestId) {
         _applySearchResults(effectiveResults);
@@ -668,6 +692,7 @@ class TextBookSearchViewState extends State<TextBookSearchView>
             lineText,
             result.query,
             matchOffset: result.matchOffset,
+            wholeWord: _effectiveWholeWord,
           );
     final navigation = scrollToSourceLine(
       scrollController: widget.scrollControler,
@@ -866,12 +891,14 @@ class TextBookSearchViewState extends State<TextBookSearchView>
                       fullText: snippet,
                       query: result.query,
                       maxChars: _maxResultSnippetChars,
+                      wholeWord: _wholeWord,
                     );
                     highlightedSnippet = SnippetBuilder.highlightLiteral(
                       plainText: excerpt,
                       query: result.query,
                       defaultStyle: defaultStyle,
                       highlightStyle: highlightStyle,
+                      wholeWord: _wholeWord,
                     );
                   } else {
                     // המנוע מדגיש את הטוקן השלם; מדגישים מחדש בצד האפליקציה את
@@ -948,6 +975,7 @@ class TextBookSearchViewState extends State<TextBookSearchView>
             searchMode: _searchMode,
             searchDistance: _searchDistance,
             matchPolicy: _matchPolicy,
+            searchWholeWord: _effectiveWholeWord,
           ),
         );
         _searchTextUpdated();
@@ -968,18 +996,27 @@ class TextBookSearchViewState extends State<TextBookSearchView>
           _matchPolicy = SearchMatchPolicy.standard;
         });
         context.read<TextBookBloc>().add(
-          const UpdateSearchText(
+          UpdateSearchText(
             '',
-            searchOptions: {},
-            alternativeWords: {},
-            spacingValues: {},
+            searchOptions: const {},
+            alternativeWords: const {},
+            spacingValues: const {},
             searchMode: SearchMode.exact,
             searchDistance: 0,
             matchPolicy: SearchMatchPolicy.standard,
+            searchWholeWord: _wholeWord,
           ),
         );
       },
-      additionalActions: const [],
+      searchFieldActions: [
+        if (_isSimpleSearch)
+          wholeWordSearchAction(
+            context: context,
+            wholeWord: _wholeWord,
+            onToggle: _toggleWholeWord,
+          ),
+      ],
+      searchFieldActionsKey: (_isSimpleSearch, _wholeWord),
       hintText: 'חפש כאן...',
       onSubmitted: () => _moveBetweenResults(1),
       onArrowDown: () => _moveBetweenResults(1),
@@ -1034,6 +1071,16 @@ class TextBookSearchViewState extends State<TextBookSearchView>
               alternativeWords: result.alternativeWords,
               searchOptions: result.searchOptions,
             );
+        // הניתוב החדש נקבע לפני ה-setState, כדי שההדגשה שנשלחת ל-bloc תתאים
+        // למסלול שירוץ בפועל ולא למסלול הקודם.
+        final willRunSimpleSearch = InBookSearchRouting.canRunAsSimpleSearch(
+          searchMode: result.searchMode,
+          distance: result.distance,
+          searchOptions: normalizedParameters.searchOptions,
+          alternativeWords: normalizedParameters.alternativeWords,
+          spacingValues: normalizedParameters.customSpacing,
+          matchPolicy: result.matchPolicy,
+        );
         applyInBookSearchQuery(
           controller: searchTextController,
           query: result.query,
@@ -1047,6 +1094,7 @@ class TextBookSearchViewState extends State<TextBookSearchView>
                 searchMode: result.searchMode,
                 searchDistance: result.distance,
                 matchPolicy: result.matchPolicy,
+                searchWholeWord: willRunSimpleSearch ? _wholeWord : true,
               ),
             );
           },

--- a/lib/text_book/view/text_book_search_screen.dart
+++ b/lib/text_book/view/text_book_search_screen.dart
@@ -377,10 +377,24 @@ class TextBookSearchViewState extends State<TextBookSearchView>
     _contentFuture = null;
   }
 
+  /// השאילתה שתרוץ בפועל, מנורמלת, או `null` כשאין מה לחפש עליה.
+  String? _searchableQuery(String raw) {
+    var query = raw.trim();
+    if (utils.hasNikud(query)) {
+      query = utils.removeVolwels(query);
+    }
+    return InBookSearchRouting.isSearchableQuery(
+          query,
+          wholeWord: _wholeWord,
+        )
+        ? query
+        : null;
+  }
+
   Future<void> _searchTextUpdated() async {
     final requestId = ++_activeSearchRequestId;
-    String query = searchTextController.text.trim();
-    if (query.isEmpty) {
+    final searchable = _searchableQuery(searchTextController.text);
+    if (searchable == null) {
       setState(() {
         searchResults = [];
         _isSearching = false;
@@ -389,9 +403,7 @@ class TextBookSearchViewState extends State<TextBookSearchView>
       return;
     }
 
-    if (utils.hasNikud(query)) {
-      query = utils.removeVolwels(query);
-    }
+    final query = searchable;
 
     setState(() {
       _isSearching = true;
@@ -961,14 +973,14 @@ class TextBookSearchViewState extends State<TextBookSearchView>
       ),
       isNoResults:
           searchResults.isEmpty &&
-          searchTextController.text.isNotEmpty &&
+          _searchableQuery(searchTextController.text) != null &&
           !_isSearching,
       errorMessage: _searchErrorMessage,
       onSearchTextChanged: (value) {
         final activeParameters = _activeSearchParameters;
         context.read<TextBookBloc>().add(
           UpdateSearchText(
-            value,
+            _searchableQuery(value) ?? '',
             searchOptions: activeParameters.searchOptions,
             alternativeWords: activeParameters.alternativeWords,
             spacingValues: activeParameters.customSpacing,

--- a/lib/text_book/view/text_book_search_screen.dart
+++ b/lib/text_book/view/text_book_search_screen.dart
@@ -385,7 +385,7 @@ class TextBookSearchViewState extends State<TextBookSearchView>
     }
     return InBookSearchRouting.isSearchableQuery(
           query,
-          wholeWord: _wholeWord,
+          wholeWord: _effectiveWholeWord,
         )
         ? query
         : null;

--- a/lib/utils/text/text_manipulation.dart
+++ b/lib/utils/text/text_manipulation.dart
@@ -809,64 +809,50 @@ String highLight(
 
   if (matches.isEmpty) return data;
 
-  // אם לא צוין אינדקס נוכחי, נדגיש את כל התוצאות
-  if (currentIndex == -1) {
-    String result = data;
-    int offset = 0;
+  // מעבר אחד עם buffer: שרשור substring לכל התאמה מעתיק את כל השורה בכל פעם,
+  // ושורה ארוכה עם התאמות רבות חורגת מתקציב הפריים.
+  final buffer = StringBuffer();
+  var position = 0;
 
-    final style = yellowBackground
-        ? 'background-color: yellow; color: black'
-        : 'color: red';
+  for (int i = 0; i < matches.length; i++) {
+    final highlightMatch = matches[i];
+    final match = highlightMatch.match;
+    final matchedText = data.substring(match.start, match.end);
 
-    for (final highlightMatch in matches) {
-      final match = highlightMatch.match;
-      final matchedText = data.substring(match.start, match.end);
+    final String replacement;
+    if (currentIndex == -1) {
+      final style = yellowBackground
+          ? 'background-color: yellow; color: black'
+          : 'color: red';
       // הדגשת קטע מקושר (רקע צהוב) צריכה להיות רציפה כמו מרקר,
       // בניגוד להדגשת חיפוש שמסמנת רק את מילות החיפוש עצמן.
-      final replacement = yellowBackground
+      replacement = yellowBackground
           ? _highlightContinuousMatch(matchedText, highlightMatch.ranges, style)
           : _highlightMatchedSearchWords(
               matchedText,
               highlightMatch.ranges,
               style,
             );
-
-      final start = match.start + offset;
-      final end = match.end + offset;
-
-      result = result.substring(0, start) + replacement + result.substring(end);
-      offset += replacement.length - matchedText.length;
+    } else {
+      // התוצאה הנוכחית בכחול, השאר באדום.
+      final color = i == currentIndex ? 'blue' : 'red';
+      final backgroundColor = i == currentIndex
+          ? 'background-color: yellow;'
+          : '';
+      replacement = _highlightMatchedSearchWords(
+        matchedText,
+        highlightMatch.ranges,
+        'color: $color; $backgroundColor',
+      );
     }
 
-    return result;
+    buffer.write(data.substring(position, match.start));
+    buffer.write(replacement);
+    position = match.end;
   }
 
-  // נדגיש את התוצאה הנוכחית בכחול ואת השאר באדום
-  String result = data;
-  int offset = 0;
-
-  for (int i = 0; i < matches.length; i++) {
-    final highlightMatch = matches[i];
-    final match = highlightMatch.match;
-    final matchedText = data.substring(match.start, match.end);
-    final color = i == currentIndex ? 'blue' : 'red';
-    final backgroundColor = i == currentIndex
-        ? 'background-color: yellow;'
-        : '';
-    final replacement = _highlightMatchedSearchWords(
-      matchedText,
-      highlightMatch.ranges,
-      'color: $color; $backgroundColor',
-    );
-
-    final start = match.start + offset;
-    final end = match.end + offset;
-
-    result = result.substring(0, start) + replacement + result.substring(end);
-    offset += replacement.length - matchedText.length;
-  }
-
-  return result;
+  buffer.write(data.substring(position));
+  return buffer.toString();
 }
 
 /// מחזיר את טווחי ההדגשה (offsets גולמיים) של מילות החיפוש ב-[data], באותה

--- a/lib/widgets/navigation/nav_panel_search.dart
+++ b/lib/widgets/navigation/nav_panel_search.dart
@@ -35,9 +35,14 @@ class NavPanelSearchDelegate {
     this.onSubmitted,
     this.onClear,
     this.trailingActions = const [],
+    this.actionsKey,
     this.onArrowDown,
     this.onArrowUp,
   });
+
+  /// מזהה המצב החזותי של [trailingActions]. פעולה שמחליפה אייקון או צבע
+  /// שומרת על אורך הרשימה, ולכן בלעדיו הסרגל המורם נשאר על התצוגה הישנה.
+  final Object? actionsKey;
 
   /// מטפל בחיצי מעלה/מטה עבור שדה חיפוש שמחובר לפעולה זו. מוחזר
   /// [KeyEventResult.ignored] כשאין callback מתאים — ואז חל המנגנון הרגיל.
@@ -64,6 +69,7 @@ class NavPanelSearchDelegate {
       controller == other.controller &&
       focusNode == other.focusNode &&
       hintText == other.hintText &&
+      actionsKey == other.actionsKey &&
       trailingActions.length == other.trailingActions.length;
 }
 

--- a/lib/widgets/navigation/search_pane_base.dart
+++ b/lib/widgets/navigation/search_pane_base.dart
@@ -4,6 +4,10 @@ import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:otzaria/widgets/navigation/nav_panel_search.dart';
 import 'package:otzaria/widgets/text/otzaria_search_field.dart';
 
+/// השהיה לפני שהקלדה מפעילה חיפוש. סריקה על כל תו מקפיאה את ההקלדה
+/// בספרים גדולים; אותו ערך שבו משתמש [FindRefBloc].
+const Duration kSearchFieldDebounce = Duration(milliseconds: 250);
+
 class SearchPaneBase extends StatefulWidget {
   const SearchPaneBase({
     required this.searchController,
@@ -18,7 +22,8 @@ class SearchPaneBase extends StatefulWidget {
     required this.resetSearchCallback,
     this.hintText,
     this.onAdvancedSearch,
-    this.additionalActions,
+    this.searchFieldActions,
+    this.searchFieldActionsKey,
     this.collapsibleOnScroll = false,
     this.onSubmitted,
     this.onArrowDown,
@@ -42,7 +47,15 @@ class SearchPaneBase extends StatefulWidget {
   final VoidCallback resetSearchCallback;
   final String? hintText;
   final VoidCallback? onAdvancedSearch;
-  final List<Widget>? additionalActions;
+
+  /// פעולות שנוספות בתוך שדה החיפוש עצמו, לפני כפתור ההגדרות. נכנסות גם
+  /// לשדה המקומי וגם לשדה המורם שבסרגל חלונית הניווט — שם השדה המקומי אינו
+  /// מצויר כלל, ולכן פעולה שמוזרקת רק אליו לא תיראה.
+  final List<Widget>? searchFieldActions;
+
+  /// מזהה המצב החזותי של [searchFieldActions] — ראה
+  /// [NavPanelSearchDelegate.actionsKey]. חובה כשפעולה מחליפה אייקון או צבע.
+  final Object? searchFieldActionsKey;
   final bool collapsibleOnScroll;
   final VoidCallback? onSubmitted;
 
@@ -60,7 +73,7 @@ class _SearchPaneBaseState extends State<SearchPaneBase> {
 
   void _debounce(VoidCallback action) {
     _debounceTimer?.cancel();
-    _debounceTimer = Timer(const Duration(milliseconds: 200), () {
+    _debounceTimer = Timer(kSearchFieldDebounce, () {
       action();
       _debounceTimer = null;
     });
@@ -116,9 +129,11 @@ class _SearchPaneBaseState extends State<SearchPaneBase> {
       widget.focusNode.requestFocus();
     },
     trailingActions: [
+      ...?widget.searchFieldActions,
       if (widget.onAdvancedSearch != null)
         OtzariaSearchAction.settings(onPressed: widget.onAdvancedSearch!),
     ],
+    actionsKey: widget.searchFieldActionsKey,
     onArrowDown: widget.onArrowDown,
     onArrowUp: widget.onArrowUp,
   );
@@ -131,54 +146,36 @@ class _SearchPaneBaseState extends State<SearchPaneBase> {
     final searchField = Padding(
       key: const ValueKey('searchField'),
       padding: const EdgeInsets.all(8.0),
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Focus(
-            canRequestFocus: false,
-            onKeyEvent: (node, event) => delegate.handleArrowKey(event),
-            child: OtzariaSearchField(
-              controller: widget.searchController,
-              focusNode: widget.focusNode,
-              autofocus: true,
-              hintText: widget.hintText ?? '',
-              onChanged: (value) =>
-                  _debounce(() => widget.onSearchTextChanged?.call(value)),
-              onSubmitted: (_) {
-                widget.onSubmitted?.call();
-                widget.focusNode.requestFocus();
-              },
-              onClear: () {
-                widget.onSearchTextChanged?.call('');
-                widget.resetSearchCallback();
-                widget.focusNode.requestFocus();
-              },
-              isCompact: _isCompact,
-              onExpand: () => setState(() => _isCompact = false),
-              leading: const Icon(OtzariaIcons.search_24_regular),
-              trailingActions: [
-                if (widget.onAdvancedSearch != null)
-                  OtzariaSearchAction.settings(
-                    onPressed: widget.onAdvancedSearch!,
-                  ),
-              ],
-            ),
-          ),
-          if (!_isCompact &&
-              widget.additionalActions != null &&
-              widget.additionalActions!.isNotEmpty)
-            Padding(
-              padding: const EdgeInsets.only(
-                right: 8.0,
-                left: 8.0,
-                bottom: 4.0,
+      child: Focus(
+        canRequestFocus: false,
+        onKeyEvent: (node, event) => delegate.handleArrowKey(event),
+        child: OtzariaSearchField(
+          controller: widget.searchController,
+          focusNode: widget.focusNode,
+          autofocus: true,
+          hintText: widget.hintText ?? '',
+          onChanged: (value) =>
+              _debounce(() => widget.onSearchTextChanged?.call(value)),
+          onSubmitted: (_) {
+            widget.onSubmitted?.call();
+            widget.focusNode.requestFocus();
+          },
+          onClear: () {
+            widget.onSearchTextChanged?.call('');
+            widget.resetSearchCallback();
+            widget.focusNode.requestFocus();
+          },
+          isCompact: _isCompact,
+          onExpand: () => setState(() => _isCompact = false),
+          leading: const Icon(OtzariaIcons.search_24_regular),
+          trailingActions: [
+            ...?widget.searchFieldActions,
+            if (widget.onAdvancedSearch != null)
+              OtzariaSearchAction.settings(
+                onPressed: widget.onAdvancedSearch!,
               ),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.end,
-                children: widget.additionalActions!,
-              ),
-            ),
-        ],
+          ],
+        ),
       ),
     );
 

--- a/test/pdf_book/pdf_search_screen_visual_index_test.dart
+++ b/test/pdf_book/pdf_search_screen_visual_index_test.dart
@@ -160,6 +160,7 @@ Widget _buildTile({
   required String text,
   required String query,
   required bool isSimpleSearch,
+  bool wholeWord = true,
 }) {
   return MaterialApp(
     home: BlocProvider<SettingsBloc>.value(
@@ -181,6 +182,7 @@ Widget _buildTile({
           height: 50,
           query: query,
           isSimpleSearch: isSimpleSearch,
+          wholeWord: wholeWord,
         ),
       ),
     ),

--- a/test/search/in_book_search_preferences_test.dart
+++ b/test/search/in_book_search_preferences_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter_settings_screens/flutter_settings_screens.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/search/in_book_search_preferences.dart';
+
+/// חלונית החיפוש בספר נבנית גם לפני שההעדפות אותחלו (טסטי ווידג'ט, אתחול
+/// מוקדם). הקובץ הזה מריץ בכוונה בלי `Settings.init`.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test('הקובץ אכן רץ בלי אתחול ההעדפות', () {
+    expect(Settings.isInitialized, isFalse);
+  });
+
+  test('ברירת המחדל היא התאמה חלקית (issue #1046)', () {
+    expect(InBookSearchPreferences.loadWholeWord(), isFalse);
+  });
+
+  test('שמירה בלי אתחול אינה זורקת — גם לא אסינכרונית', () async {
+    await expectLater(
+      InBookSearchPreferences.saveWholeWord(true),
+      completes,
+    );
+    // הכשל נבלע ולכן ההעדפה נשארת בברירת המחדל, בלי לקרוס.
+    expect(InBookSearchPreferences.loadWholeWord(), isFalse);
+  });
+
+  test('מסלול המנוע תמיד מילים שלמות, ללא תלות בהעדפה', () {
+    expect(
+      InBookSearchPreferences.resolveWholeWord(isSimpleSearch: false),
+      isTrue,
+    );
+    expect(
+      InBookSearchPreferences.resolveWholeWord(isSimpleSearch: true),
+      isFalse,
+    );
+  });
+}

--- a/test/search/literal_search_pattern_test.dart
+++ b/test/search/literal_search_pattern_test.dart
@@ -1,6 +1,8 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:otzaria/search/utils/literal_search_pattern.dart';
 
+import '../text_book/utils/literal_pattern_test_helper.dart';
+
 void main() {
   group('normalizeLiteralQuery', () {
     test('מסיר ניקוד', () {
@@ -17,6 +19,57 @@ void main() {
 
     test('מכווץ רצפי רווח ומקצץ', () {
       expect(normalizeLiteralQuery('  שמע   ישראל  '), 'שמע ישראל');
+    });
+  });
+
+  group('stripWordBoundaryWrapper', () {
+    test('התאמה חלקית מוצאת מילה בתוך מילה, מלאה לא', () {
+      const line = 'את השמים ואת הארץ';
+      expect(literalPattern('שמים').hasMatch(line), isFalse);
+      expect(
+        literalPattern('שמים', wholeWord: false).hasMatch(line),
+        isTrue,
+      );
+    });
+
+    test('התאמה חלקית עדיין מוצאת מילה שלמה', () {
+      expect(
+        literalPattern('שמים', wholeWord: false).hasMatch('את שמים וארץ'),
+        isTrue,
+      );
+    });
+
+    test('שומרת על סובלנות לניקוד ולגרשיים', () {
+      expect(
+        literalPattern('הרעתי', wholeWord: false).hasMatch('וְהַרֵעֹתִי'),
+        isTrue,
+      );
+      expect(
+        literalPattern('רשי', wholeWord: false).hasMatch('שיטת רש״י'),
+        isFalse,
+      );
+      expect(
+        literalPattern('רשי', wholeWord: false).hasMatch('שיטת רשי'),
+        isTrue,
+      );
+    });
+
+    test('גבול פנימי בין מילים נשמר בהתאמה חלקית', () {
+      final pattern = literalPattern('שמע ישראל', wholeWord: false);
+      expect(pattern.hasMatch('ושמע ישראלים'), isTrue);
+      expect(pattern.hasMatch('שמעישראל'), isFalse);
+    });
+
+    test('חותכת את ה-(?! האחרון, לא כזה שבתוך הביטוי', () {
+      // תג HTML במפריד בין מילים מכיל (?! משלו — חיתוך לפי המופע הראשון
+      // היה קוטע את הביטוי באמצע.
+      const source = r'(?<![א-ת])(?:אב<(?!br)[^>]*>גד)(?![א-ת])';
+      expect(stripWordBoundaryWrapper(source), r'(?:אב<(?!br)[^>]*>גד)');
+    });
+
+    test('מחזירה null כשהמבנה אינו מזוהה', () {
+      expect(stripWordBoundaryWrapper('אבג'), isNull);
+      expect(stripWordBoundaryWrapper('(?<![א-ת])(?:אבג)'), isNull);
     });
   });
 }

--- a/test/search/utils/in_book_search_routing_test.dart
+++ b/test/search/utils/in_book_search_routing_test.dart
@@ -5,6 +5,44 @@ import 'package:otzaria_search_engine/otzaria_search_engine.dart'
     show SearchScope, WordMatchMode;
 
 void main() {
+  group('isSearchableQuery', () {
+    test('שאילתה ריקה — לא נחפשת בשני המצבים', () {
+      expect(
+        InBookSearchRouting.isSearchableQuery('', wholeWord: false),
+        isFalse,
+      );
+      expect(
+        InBookSearchRouting.isSearchableQuery('', wholeWord: true),
+        isFalse,
+      );
+    });
+
+    test('תו בודד אינו נחפש בהתאמה חלקית', () {
+      expect(
+        InBookSearchRouting.isSearchableQuery('ש', wholeWord: false),
+        isFalse,
+      );
+    });
+
+    test('תו בודד כן נחפש במילים שלמות — "פ"/"ס" בתנ"ך', () {
+      expect(
+        InBookSearchRouting.isSearchableQuery('פ', wholeWord: true),
+        isTrue,
+      );
+    });
+
+    test('שני תווים נחפשים בשני המצבים', () {
+      expect(
+        InBookSearchRouting.isSearchableQuery('של', wholeWord: false),
+        isTrue,
+      );
+      expect(
+        InBookSearchRouting.isSearchableQuery('של', wholeWord: true),
+        isTrue,
+      );
+    });
+  });
+
   group('canRunAsSimpleSearch', () {
     test('שאילתה ליטרלית בלי תוספות — מסלול פשוט', () {
       expect(

--- a/test/text_book/bloc/text_book_bloc_test.dart
+++ b/test/text_book/bloc/text_book_bloc_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_settings_screens/flutter_settings_screens.dart';
 import 'package:otzaria/data/data_providers/file_system_data_provider.dart';
 import 'package:otzaria/models/books.dart';
 import 'package:otzaria/models/links.dart';
+import 'package:otzaria/search/in_book_search_preferences.dart';
 import 'package:otzaria/search/models/search_configuration.dart';
 import 'package:otzaria_search_engine/otzaria_search_engine.dart'
     show SearchScope, WordMatchMode;
@@ -26,6 +27,61 @@ void main() {
   group('TextBookBloc', () {
     setUp(() async {
       await Settings.init(cacheProvider: _MemoryCacheProvider());
+    });
+
+    group('searchWholeWord נזרע מההעדפה', () {
+      tearDown(() => InBookSearchPreferences.saveWholeWord(false));
+
+      Future<TextBookLoaded> loadState({
+        required SearchMatchPolicy matchPolicy,
+      }) async {
+        final bloc = _createBloc(
+          repository: _FakeTextBookRepository(),
+          showPageShapeView: false,
+          matchPolicy: matchPolicy,
+        );
+        bloc.add(
+          const LoadContent(
+            fontSize: 20,
+            showSplitView: false,
+            removeNikud: false,
+            loadCommentators: false,
+          ),
+        );
+        await _waitFor(
+          () => bloc.state is TextBookLoaded,
+          description: 'TextBookLoaded',
+        );
+        final state = bloc.state as TextBookLoaded;
+        await bloc.close();
+        return state;
+      }
+
+      test('העדפה כבויה — הדגשה חלקית כבר בטעינה', () async {
+        await InBookSearchPreferences.saveWholeWord(false);
+        final state = await loadState(
+          matchPolicy: SearchMatchPolicy.standard,
+        );
+        expect(state.searchWholeWord, isFalse);
+      });
+
+      test('העדפה דלוקה — מילים שלמות', () async {
+        await InBookSearchPreferences.saveWholeWord(true);
+        final state = await loadState(
+          matchPolicy: SearchMatchPolicy.standard,
+        );
+        expect(state.searchWholeWord, isTrue);
+      });
+
+      test('מסלול המנוע מתעלם מההעדפה', () async {
+        await InBookSearchPreferences.saveWholeWord(false);
+        final state = await loadState(
+          matchPolicy: const SearchMatchPolicy(
+            wordMatchMode: WordMatchMode.anyWord,
+          ),
+        );
+        expect(state.searchWholeWord, isTrue);
+      });
     });
 
     test('במפרשים למטה טוען קישורים מיד עבור הטווח הגלוי', () async {

--- a/test/text_book/utils/literal_pattern_test_helper.dart
+++ b/test/text_book/utils/literal_pattern_test_helper.dart
@@ -104,7 +104,10 @@ String _charwisePattern(String word, bool isLast) {
 }
 
 /// מקור מחרוזת התבנית הליטרלית לשאילתה [query] (מנורמלת קודם).
-String literalPatternSource(String query) {
+///
+/// [wholeWord] `false` מסיר את עטיפת הגבול דרך [stripWordBoundaryWrapper]
+/// עצמה — כך שהבדיקות מריצות את הפונקציה שבייצור ולא העתק שלה.
+String literalPatternSource(String query, {bool wholeWord = true}) {
   final normalized = normalizeLiteralQuery(query);
   final words = normalized.split(' ').where((w) => w.isNotEmpty).toList();
   final last = words.length - 1;
@@ -114,13 +117,16 @@ String literalPatternSource(String query) {
   ].join(_wordSeparator);
   // גבול תלוי-הקשר כמו במנוע: גרש/גרשיים בין אותיות (רש״י) אינו גבול,
   // וה-lookahead מדלג בעצמו על ניקוד שנותר מ-backtracking של [ניקוד]*.
-  return '(?<![$_hebrewLetterClass]$_attachedMarks'
+  final wrapped =
+      '(?<![$_hebrewLetterClass]$_attachedMarks'
       '$_quoteBoundaryFragment?$_attachedMarks)'
       '(?:$phrase)'
       '(?!$_attachedMarks$_quoteBoundaryFragment?$_attachedMarks'
       '[$_hebrewLetterClass])';
+  if (wholeWord) return wrapped;
+  return stripWordBoundaryWrapper(wrapped) ?? wrapped;
 }
 
 /// תבנית ליטרלית מקומפלת לשאילתה [query].
-RegExp literalPattern(String query) =>
-    compileLiteralPattern(literalPatternSource(query));
+RegExp literalPattern(String query, {bool wholeWord = true}) =>
+    compileLiteralPattern(literalPatternSource(query, wholeWord: wholeWord));

--- a/test/text_book/utils/section_search_utils_test.dart
+++ b/test/text_book/utils/section_search_utils_test.dart
@@ -8,6 +8,48 @@ void main() {
     await resetSectionSearchWorkerForTesting();
   });
 
+  group('searchInContent - התאמה חלקית (issue #1046)', () {
+    test('"שמים" נמצא בתוך "השמים"', () async {
+      final results = await searchInContent(
+        content: ['בראשית ברא אלהים את השמים ואת הארץ'],
+        query: 'שמים',
+        wholeWord: false,
+        patternSource: literalPatternSource('שמים', wholeWord: false),
+      );
+      expect(results.length, 1);
+      expect(results.first.snippet, contains('השמים'));
+    });
+
+    test('אותו חיפוש במצב מילים שלמות אינו מוצא', () async {
+      final results = await searchInContent(
+        content: ['בראשית ברא אלהים את השמים ואת הארץ'],
+        query: 'שמים',
+        patternSource: literalPatternSource('שמים'),
+      );
+      expect(results, isEmpty);
+    });
+
+    test('תוצאה לכל הופעה — שלמה וחלקית באותה שורה', () async {
+      final results = await searchInContent(
+        content: ['שמים ושמים והשמים'],
+        query: 'שמים',
+        wholeWord: false,
+        patternSource: literalPatternSource('שמים', wholeWord: false),
+      );
+      expect(results.length, 3);
+    });
+
+    test('היסט ההתאמה מצביע על הופעה בתוך המילה', () async {
+      final results = await searchInContent(
+        content: ['את השמים'],
+        query: 'שמים',
+        wholeWord: false,
+        patternSource: literalPatternSource('שמים', wholeWord: false),
+      );
+      expect(results.single.matchOffset, 4);
+    });
+  });
+
   group('searchInContent - whole word matching', () {
     test('finds exact whole-word match', () async {
       final results = await searchInContent(
@@ -538,6 +580,18 @@ void main() {
           pattern: literalPattern('די'),
         ),
         isFalse,
+      );
+    });
+
+    test('במצב התאמה חלקית ההערה כן נספרת', () {
+      expect(
+        queryMatchesInlineNoteOnly(
+          noteLine,
+          'די',
+          wholeWord: false,
+          pattern: literalPattern('די', wholeWord: false),
+        ),
+        isTrue,
       );
     });
 

--- a/test/text_book/view/text_book_search_content_cache_test.dart
+++ b/test/text_book/view/text_book_search_content_cache_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_settings_screens/flutter_settings_screens.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/widgets/navigation/search_pane_base.dart';
 import 'package:otzaria/data/repository/data_repository.dart';
 import 'package:otzaria/library/models/library.dart';
 import 'package:otzaria/models/books.dart';
@@ -298,7 +299,7 @@ class _Harness {
   Future<void> type(String query) async {
     await tester.enterText(find.byType(TextField).first, query);
     await tester.pump();
-    await tester.pump(const Duration(milliseconds: 250));
+    await tester.pump(kSearchFieldDebounce + const Duration(milliseconds: 50));
   }
 
   Future<void> search(String query) async {

--- a/test/text_book/view/text_book_search_engine_route_test.dart
+++ b/test/text_book/view/text_book_search_engine_route_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_settings_screens/flutter_settings_screens.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/widgets/navigation/search_pane_base.dart';
 import 'package:otzaria/core/messages/library_messages.dart';
 import 'package:otzaria/data/repository/data_repository.dart';
 import 'package:otzaria/library/models/library.dart';
@@ -384,7 +385,9 @@ class _Harness {
       await tester.runAsync(
         () => Future<void>.delayed(const Duration(milliseconds: 20)),
       );
-      await tester.pump(const Duration(milliseconds: 250));
+      await tester.pump(
+        kSearchFieldDebounce + const Duration(milliseconds: 50),
+      );
     }
   }
 }

--- a/test/text_book/view/text_book_search_screen_test.dart
+++ b/test/text_book/view/text_book_search_screen_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_settings_screens/flutter_settings_screens.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/widgets/navigation/search_pane_base.dart';
 import 'package:otzaria/settings/engine/settings_bloc.dart';
 import 'package:otzaria/settings/engine/settings_event.dart';
 import 'package:otzaria/settings/engine/settings_state.dart';
@@ -29,6 +30,70 @@ Future<void> main() async {
 
   setUpAll(() async {
     await Settings.init(cacheProvider: MemoryCacheProvider());
+  });
+
+  testWidgets('תו בודד אינו מריץ חיפוש בהתאמה חלקית', (tester) async {
+    await InBookSearchPreferences.saveWholeWord(false);
+    addTearDown(() => InBookSearchPreferences.saveWholeWord(false));
+
+    final textBookBloc = _TestTextBookBloc(_loadedState());
+    final settingsBloc = _TestSettingsBloc(SettingsState.initial());
+    final focusNode = FocusNode();
+
+    addTearDown(textBookBloc.close);
+    addTearDown(settingsBloc.close);
+    addTearDown(focusNode.dispose);
+    addTearDown(resetSectionSearchWorkerForTesting);
+
+    final queries = <String>[];
+    Future<List<TextSearchResult>> simpleSearchRunner(
+      List<String> content,
+      String query,
+    ) async {
+      queries.add(query);
+      return const [];
+    }
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: MultiBlocProvider(
+          providers: [
+            BlocProvider<TextBookBloc>.value(value: textBookBloc),
+            BlocProvider<SettingsBloc>.value(value: settingsBloc),
+          ],
+          child: Scaffold(
+            body: TextBookSearchView(
+              contentLoader: () async => ['את השמים ואת הארץ'],
+              scrollControler: ItemScrollController(),
+              focusNode: focusNode,
+              closeLeftPaneCallback: () {},
+              initialQuery: '',
+              simpleSearchRunner: simpleSearchRunner,
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byType(TextField).first, 'ש');
+    await tester.pump(kSearchFieldDebounce + const Duration(milliseconds: 50));
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(queries, isEmpty);
+    // אין "אין תוצאות" על שאילתה שלא רצה בכלל.
+    expect(find.text('אין תוצאות'), findsNothing);
+    // הספר אינו מודגש על תו בודד.
+    expect(
+      textBookBloc.events.whereType<UpdateSearchText>().last.text,
+      isEmpty,
+    );
+
+    await tester.enterText(find.byType(TextField).first, 'שמ');
+    await tester.pump(kSearchFieldDebounce + const Duration(milliseconds: 50));
+    await tester.pump(const Duration(milliseconds: 100));
+
+    expect(queries, ['שמ']);
   });
 
   testWidgets('מתג "מילים שלמות" מריץ את החיפוש מחדש ומעדכן את ההדגשה', (
@@ -207,7 +272,7 @@ Future<void> main() async {
 
     await tester.pump();
     await tester.enterText(find.byType(TextField), 'אב');
-    await tester.pump(const Duration(milliseconds: 250));
+    await tester.pump(kSearchFieldDebounce + const Duration(milliseconds: 50));
     await tester.pump(const Duration(milliseconds: 100));
 
     expect(find.text(TextBookMessages.searchContentLoadFailed), findsWidgets);
@@ -279,7 +344,9 @@ Future<void> main() async {
       // הקלדה אמיתית → onSearchTextChanged מריץ חיפוש פעם אחת.
       // ההמתנה ארוכה מ-debounce שדה החיפוש (200ms).
       await tester.enterText(find.byType(TextField), 'אב');
-      await tester.pump(const Duration(milliseconds: 250));
+      await tester.pump(
+        kSearchFieldDebounce + const Duration(milliseconds: 50),
+      );
       final callsAfterTyping = runnerCalls;
       expect(callsAfterTyping, greaterThan(0));
 
@@ -287,7 +354,9 @@ Future<void> main() async {
       // ההקלדה דרך ה-bloc. שינוי שכבר משוקף ב-controller אסור שיריץ חיפוש נוסף.
       outerSetState(() => queryProp = 'אב');
       await tester.pump();
-      await tester.pump(const Duration(milliseconds: 250));
+      await tester.pump(
+        kSearchFieldDebounce + const Duration(milliseconds: 50),
+      );
       expect(
         runnerCalls,
         callsAfterTyping,
@@ -297,7 +366,9 @@ Future<void> main() async {
       // שינוי חיצוני אמיתי: ה-query שונה מתוכן ה-controller → חיפוש כן רץ.
       outerSetState(() => queryProp = 'אברהם');
       await tester.pump();
-      await tester.pump(const Duration(milliseconds: 250));
+      await tester.pump(
+        kSearchFieldDebounce + const Duration(milliseconds: 50),
+      );
       expect(
         runnerCalls,
         callsAfterTyping + 1,
@@ -364,10 +435,10 @@ Future<void> main() async {
     final textField = find.byType(TextField);
 
     await tester.enterText(textField, 'אב');
-    await tester.pump(const Duration(milliseconds: 250));
+    await tester.pump(kSearchFieldDebounce + const Duration(milliseconds: 50));
 
     await tester.enterText(textField, 'אברהם');
-    await tester.pump(const Duration(milliseconds: 250));
+    await tester.pump(kSearchFieldDebounce + const Duration(milliseconds: 50));
     await tester.pump(const Duration(milliseconds: 100));
 
     expect(find.text('חדש'), findsOneWidget);
@@ -425,8 +496,8 @@ Future<void> main() async {
     );
 
     await tester.pump();
-    await tester.enterText(find.byType(TextField), 'x');
-    await tester.pump(const Duration(milliseconds: 250));
+    await tester.enterText(find.byType(TextField), 'xa');
+    await tester.pump(kSearchFieldDebounce + const Duration(milliseconds: 50));
     await tester.pump(const Duration(milliseconds: 100));
   }
 
@@ -443,14 +514,19 @@ Future<void> main() async {
           TextSearchResult(
             snippet: 'מוקדם',
             index: 0,
-            query: 'x',
+            query: 'xa',
             address: 'א',
           ),
-          TextSearchResult(snippet: 'אמצע', index: 5, query: 'x', address: 'ב'),
+          TextSearchResult(
+            snippet: 'אמצע',
+            index: 5,
+            query: 'xa',
+            address: 'ב',
+          ),
           TextSearchResult(
             snippet: 'מאוחר',
             index: 10,
-            query: 'x',
+            query: 'xa',
             address: 'ג',
           ),
         ],
@@ -494,9 +570,9 @@ Future<void> main() async {
         tester: tester,
         visibleIndices: const [6],
         results: [
-          TextSearchResult(snippet: 'a', index: 0, query: 'x', address: 'א'),
-          TextSearchResult(snippet: 'b', index: 5, query: 'x', address: 'ב'),
-          TextSearchResult(snippet: 'c', index: 10, query: 'x', address: 'ג'),
+          TextSearchResult(snippet: 'a', index: 0, query: 'xa', address: 'א'),
+          TextSearchResult(snippet: 'b', index: 5, query: 'xa', address: 'ב'),
+          TextSearchResult(snippet: 'c', index: 10, query: 'xa', address: 'ג'),
         ],
       );
 
@@ -536,15 +612,25 @@ Future<void> main() async {
         List<String> content,
         String query,
       ) async {
-        if (query == 'x') {
+        if (query == 'xa') {
           // 3 תוצאות, line=50 באינדקס 1.
           return [
-            TextSearchResult(snippet: 'a', index: 10, query: 'x', address: 'א'),
-            TextSearchResult(snippet: 'b', index: 50, query: 'x', address: 'ב'),
+            TextSearchResult(
+              snippet: 'a',
+              index: 10,
+              query: 'xa',
+              address: 'א',
+            ),
+            TextSearchResult(
+              snippet: 'b',
+              index: 50,
+              query: 'xa',
+              address: 'ב',
+            ),
             TextSearchResult(
               snippet: 'c',
               index: 100,
-              query: 'x',
+              query: 'xa',
               address: 'ג',
             ),
           ];
@@ -591,8 +677,10 @@ Future<void> main() async {
       );
 
       await tester.pump();
-      await tester.enterText(find.byType(TextField), 'x');
-      await tester.pump(const Duration(milliseconds: 250));
+      await tester.enterText(find.byType(TextField), 'xa');
+      await tester.pump(
+        kSearchFieldDebounce + const Duration(milliseconds: 50),
+      );
       await tester.pump(const Duration(milliseconds: 100));
 
       // ניווט לתוצאה האמצעית (index 1, line=50) דרך כפתור החץ למטה.
@@ -604,7 +692,9 @@ Future<void> main() async {
 
       // עידכון השאילתה ל-'xy' — תוצאות חדשות שבהן line=50 נמצא ב-index 0.
       await tester.enterText(find.byType(TextField), 'xy');
-      await tester.pump(const Duration(milliseconds: 250));
+      await tester.pump(
+        kSearchFieldDebounce + const Duration(milliseconds: 50),
+      );
       await tester.pump(const Duration(milliseconds: 100));
 
       // התוצאה הנבחרת היא הראשונה (line=50 שנשמרה). כפתור "הקודם" מנוטרל,
@@ -636,7 +726,7 @@ Future<void> main() async {
         (i) => TextSearchResult(
           snippet: 'snippet $i',
           index: i,
-          query: 'x',
+          query: 'xa',
           address: 'קטע_$i',
         ),
       );
@@ -683,7 +773,7 @@ Future<void> main() async {
         (i) => TextSearchResult(
           snippet: 'snippet $i',
           index: i,
-          query: 'x',
+          query: 'xa',
           address: 'כתובת_$i',
         ),
       );
@@ -725,9 +815,9 @@ Future<void> main() async {
         tester: tester,
         visibleIndices: const [0],
         results: [
-          TextSearchResult(snippet: 'a', index: 0, query: 'x', address: 'א'),
-          TextSearchResult(snippet: 'b', index: 5, query: 'x', address: 'ב'),
-          TextSearchResult(snippet: 'c', index: 10, query: 'x', address: 'ג'),
+          TextSearchResult(snippet: 'a', index: 0, query: 'xa', address: 'א'),
+          TextSearchResult(snippet: 'b', index: 5, query: 'xa', address: 'ב'),
+          TextSearchResult(snippet: 'c', index: 10, query: 'xa', address: 'ג'),
         ],
       );
 
@@ -784,21 +874,26 @@ Future<void> main() async {
         List<String> content,
         String query,
       ) async {
-        if (query == 'x') {
+        if (query == 'xa') {
           // שתי הופעות באותה שורה (50) והופעה נוספת לפניהן.
           return [
-            TextSearchResult(snippet: 'a', index: 10, query: 'x', address: 'א'),
+            TextSearchResult(
+              snippet: 'a',
+              index: 10,
+              query: 'xa',
+              address: 'א',
+            ),
             TextSearchResult(
               snippet: 'b1',
               index: 50,
-              query: 'x',
+              query: 'xa',
               address: 'ב',
               matchOffset: 0,
             ),
             TextSearchResult(
               snippet: 'b2',
               index: 50,
-              query: 'x',
+              query: 'xa',
               address: 'ב',
               matchOffset: 30,
             ),
@@ -848,8 +943,10 @@ Future<void> main() async {
       );
 
       await tester.pump();
-      await tester.enterText(find.byType(TextField), 'x');
-      await tester.pump(const Duration(milliseconds: 250));
+      await tester.enterText(find.byType(TextField), 'xa');
+      await tester.pump(
+        kSearchFieldDebounce + const Duration(milliseconds: 50),
+      );
       await tester.pump(const Duration(milliseconds: 100));
 
       // ניווט להופעה השנייה בשורה 50 (אינדקס 2).
@@ -862,7 +959,9 @@ Future<void> main() async {
       tester.takeException();
 
       await tester.enterText(find.byType(TextField), 'xy');
-      await tester.pump(const Duration(milliseconds: 250));
+      await tester.pump(
+        kSearchFieldDebounce + const Duration(milliseconds: 50),
+      );
       await tester.pump(const Duration(milliseconds: 100));
 
       // הבחירה נשמרה על ההופעה עם offset 30 — האחרונה — ולכן "הבא" מנוטרל.
@@ -901,10 +1000,20 @@ Future<void> main() async {
         List<String> content,
         String query,
       ) async {
-        if (query == 'x') {
+        if (query == 'xa') {
           return [
-            TextSearchResult(snippet: 'a', index: 10, query: 'x', address: 'א'),
-            TextSearchResult(snippet: 'b', index: 50, query: 'x', address: 'ב'),
+            TextSearchResult(
+              snippet: 'a',
+              index: 10,
+              query: 'xa',
+              address: 'א',
+            ),
+            TextSearchResult(
+              snippet: 'b',
+              index: 50,
+              query: 'xa',
+              address: 'ב',
+            ),
           ];
         }
         if (query == 'xy') {
@@ -949,8 +1058,10 @@ Future<void> main() async {
       );
 
       await tester.pump();
-      await tester.enterText(find.byType(TextField), 'x');
-      await tester.pump(const Duration(milliseconds: 250));
+      await tester.enterText(find.byType(TextField), 'xa');
+      await tester.pump(
+        kSearchFieldDebounce + const Duration(milliseconds: 50),
+      );
       await tester.pump(const Duration(milliseconds: 100));
 
       // ניווט ל-line=50 (אינדקס 1).
@@ -959,7 +1070,9 @@ Future<void> main() async {
       tester.takeException();
 
       await tester.enterText(find.byType(TextField), 'xy');
-      await tester.pump(const Duration(milliseconds: 250));
+      await tester.pump(
+        kSearchFieldDebounce + const Duration(milliseconds: 50),
+      );
       await tester.pump(const Duration(milliseconds: 100));
 
       // line=50 לא קיים בתוצאות xy. visibleIndices=[1000] → fallback

--- a/test/text_book/view/text_book_search_screen_test.dart
+++ b/test/text_book/view/text_book_search_screen_test.dart
@@ -7,7 +7,9 @@ import 'package:otzaria/settings/engine/settings_bloc.dart';
 import 'package:otzaria/settings/engine/settings_event.dart';
 import 'package:otzaria/settings/engine/settings_state.dart';
 import 'package:otzaria/core/messages/text_book_messages.dart';
+import 'package:fluentui_system_icons/fluentui_system_icons.dart';
 import 'package:otzaria/models/books.dart';
+import 'package:otzaria/search/in_book_search_preferences.dart';
 import 'package:otzaria/text_book/bloc/text_book_bloc.dart';
 import 'package:otzaria/text_book/bloc/text_book_event.dart';
 import 'package:otzaria/text_book/bloc/text_book_state.dart';
@@ -27,6 +29,70 @@ Future<void> main() async {
 
   setUpAll(() async {
     await Settings.init(cacheProvider: MemoryCacheProvider());
+  });
+
+  testWidgets('מתג "מילים שלמות" מריץ את החיפוש מחדש ומעדכן את ההדגשה', (
+    tester,
+  ) async {
+    await InBookSearchPreferences.saveWholeWord(false);
+    addTearDown(() => InBookSearchPreferences.saveWholeWord(false));
+
+    final textBookBloc = _TestTextBookBloc(_loadedState());
+    final settingsBloc = _TestSettingsBloc(SettingsState.initial());
+    final focusNode = FocusNode();
+
+    addTearDown(textBookBloc.close);
+    addTearDown(settingsBloc.close);
+    addTearDown(focusNode.dispose);
+    addTearDown(resetSectionSearchWorkerForTesting);
+
+    var searchRuns = 0;
+    Future<List<TextSearchResult>> simpleSearchRunner(
+      List<String> content,
+      String query,
+    ) async {
+      searchRuns++;
+      return const [];
+    }
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: MultiBlocProvider(
+          providers: [
+            BlocProvider<TextBookBloc>.value(value: textBookBloc),
+            BlocProvider<SettingsBloc>.value(value: settingsBloc),
+          ],
+          child: Scaffold(
+            body: TextBookSearchView(
+              contentLoader: () async => ['את השמים ואת הארץ'],
+              scrollControler: ItemScrollController(),
+              focusNode: focusNode,
+              closeLeftPaneCallback: () {},
+              initialQuery: 'שמים',
+              simpleSearchRunner: simpleSearchRunner,
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    // ההעדפה כבויה — המתג מתחיל במצב "חצאי מילים".
+    expect(
+      find.byIcon(FluentIcons.text_whole_word_20_regular),
+      findsOneWidget,
+    );
+    final runsBeforeToggle = searchRuns;
+
+    await tester.tap(find.byIcon(FluentIcons.text_whole_word_20_regular));
+    await tester.pumpAndSettle();
+
+    expect(find.byIcon(FluentIcons.text_whole_word_20_filled), findsOneWidget);
+    expect(searchRuns, greaterThan(runsBeforeToggle));
+    expect(InBookSearchPreferences.loadWholeWord(), isTrue);
+
+    final lastUpdate = textBookBloc.events.whereType<UpdateSearchText>().last;
+    expect(lastUpdate.searchWholeWord, isTrue);
   });
 
   testWidgets('איפוס initialQuery חיצוני מנקה תוצאות חיפוש קיימות', (
@@ -940,8 +1006,10 @@ TextBookLoaded _loadedState({List<int> visibleIndices = const [0]}) {
 
 class _TestTextBookBloc extends Bloc<TextBookEvent, TextBookState>
     implements TextBookBloc {
+  final List<TextBookEvent> events = [];
+
   _TestTextBookBloc(super.initialState) {
-    on<TextBookEvent>((event, emit) {});
+    on<TextBookEvent>((event, emit) => events.add(event));
   }
 
   @override

--- a/test/widgets/nav_panel_search_test.dart
+++ b/test/widgets/nav_panel_search_test.dart
@@ -160,6 +160,75 @@ Widget wrap(Widget child) => MaterialApp(
   ),
 );
 
+/// חלונית מדומה מינימלית עם פעולה שמחליפה אייקון — בלי לשנות את אורך
+/// רשימת הפעולות. משמשת לרגרסיה של רענון הסרגל המורם.
+class _TogglingActionHost extends StatefulWidget {
+  const _TogglingActionHost();
+
+  @override
+  State<_TogglingActionHost> createState() => _TogglingActionHostState();
+}
+
+class _TogglingActionHostState extends State<_TogglingActionHost> {
+  final host = NavPanelSearchHost();
+  final controller = TextEditingController();
+  final focus = FocusNode();
+  bool on = false;
+
+  @override
+  void dispose() {
+    host.dispose();
+    controller.dispose();
+    focus.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        SizedBox(
+          height: 56,
+          child: NavPanelSearchBar(
+            host: host,
+            isOpen: true,
+            paneWidth: 300,
+            isPinned: false,
+          ),
+        ),
+        TextButton(
+          onPressed: () => setState(() => on = !on),
+          child: const Text('החלף'),
+        ),
+        Expanded(
+          child: NavPanelSearchScope(
+            host: host,
+            child: NavPanelSearchSlot(
+              index: 0,
+              child: NavPanelSearchPublisher(
+                delegate: NavPanelSearchDelegate(
+                  controller: controller,
+                  focusNode: focus,
+                  hintText: 'חיפוש בספר...',
+                  actionsKey: on,
+                  trailingActions: [
+                    Icon(
+                      on
+                          ? FluentIcons.text_whole_word_20_filled
+                          : FluentIcons.text_whole_word_20_regular,
+                    ),
+                  ],
+                ),
+                child: const SizedBox.shrink(),
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -185,6 +254,25 @@ void main() {
     expect(find.byType(OtzariaSearchField), findsOneWidget);
     expect(find.text('חיפוש בספר...'), findsOneWidget);
     expect(find.text('איתור כותרת...'), findsNothing);
+  });
+
+  // רגרסיה: פעולה שהחליפה אייקון בלי לשנות את אורך הרשימה נבלעה בהשוואת
+  // המטרה, והסרגל המורם נשאר מצויר עם האייקון הישן. actionsKey הוא מה
+  // שמבחין ביניהן.
+  testWidgets('פעולה שהחליפה אייקון מתעדכנת בסרגל המורם', (tester) async {
+    await tester.pumpWidget(wrap(const _TogglingActionHost()));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.byIcon(FluentIcons.text_whole_word_20_regular),
+      findsOneWidget,
+    );
+
+    await tester.tap(find.text('החלף'));
+    await tester.pumpAndSettle();
+
+    expect(find.byIcon(FluentIcons.text_whole_word_20_filled), findsOneWidget);
+    expect(find.byIcon(FluentIcons.text_whole_word_20_regular), findsNothing);
   });
 
   testWidgets('חלונית סגורה — הסרגל מכווץ לרוחב 0', (tester) async {

--- a/test/widgets/search_pane_base_test.dart
+++ b/test/widgets/search_pane_base_test.dart
@@ -1,8 +1,97 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/widgets/navigation/nav_panel_search.dart';
 import 'package:otzaria/widgets/navigation/search_pane_base.dart';
 
 void main() {
+  // הפעולות בשדה חייבות להופיע גם בחלונית ניווט: שם השדה המקומי אינו
+  // מצויר כלל, והשדה שבסרגל שמעליה הוא היחיד שנראה.
+  testWidgets('searchFieldActions מוצגות גם כשהשדה מורם לסרגל החלונית', (
+    tester,
+  ) async {
+    final controller = TextEditingController();
+    final focusNode = FocusNode();
+    final host = NavPanelSearchHost();
+
+    addTearDown(() {
+      controller.dispose();
+      focusNode.dispose();
+      host.dispose();
+    });
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Column(
+            children: [
+              SizedBox(
+                height: 56,
+                child: NavPanelSearchBar(
+                  host: host,
+                  isOpen: true,
+                  paneWidth: 300,
+                  isPinned: false,
+                ),
+              ),
+              Expanded(
+                child: NavPanelSearchScope(
+                  host: host,
+                  child: NavPanelSearchSlot(
+                    index: 0,
+                    child: SearchPaneBase(
+                      searchController: controller,
+                      focusNode: focusNode,
+                      resultsWidget: const SizedBox.shrink(),
+                      isNoResults: false,
+                      resetSearchCallback: () {},
+                      searchFieldActions: const [
+                        Icon(Icons.abc, key: ValueKey('wholeWordToggle')),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(find.byKey(const ValueKey('wholeWordToggle')), findsOneWidget);
+  });
+
+  testWidgets('searchFieldActions מוצגות גם בשדה המקומי (מחוץ לחלונית)', (
+    tester,
+  ) async {
+    final controller = TextEditingController();
+    final focusNode = FocusNode();
+
+    addTearDown(() {
+      controller.dispose();
+      focusNode.dispose();
+    });
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SearchPaneBase(
+            searchController: controller,
+            focusNode: focusNode,
+            resultsWidget: const SizedBox.shrink(),
+            isNoResults: false,
+            resetSearchCallback: () {},
+            searchFieldActions: const [
+              Icon(Icons.abc, key: ValueKey('wholeWordToggle')),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byKey(const ValueKey('wholeWordToggle')), findsOneWidget);
+  });
+
   testWidgets('מציג toolbar של תוצאות באותה שורה מול מונה התוצאות', (
     tester,
   ) async {


### PR DESCRIPTION
סוגר את #1046.

## הבעיה

בטקסט "את השמים וגו'", חיפוש `שמים` בחלונית החיפוש שבתוך הספר לא החזיר כלום.

## שורש הבאג

המסלול הפשוט (בלי אינדקס) סורק כל שורה עם תבנית שהמנוע מחזיר מ-`generateLiteralHighlightPattern`, והיא עטופה בגבולות מילה:

```
(?<![א-ת…])(?:שמים)(?!…[א-ת…])
```

התאמה נפסלת כשצמודה אליה אות עברית, ולכן `שמים` בתוך `השמים` נפסל.

זו רגרסיה, לא פיצ'ר חסר: עד קומיט `5635250f` ("תיקון קל לרשימת התוצאות בחיפוש בתוך ספר", 6/5/2026) החיפוש היה `cleanLine.contains(query)`, ו-`118293047` העביר את אותה סמנטיקה לתוך תבנית המנוע.

## הפתרון

`stripWordBoundaryWrapper` מסירה את העטיפה מהמחרוזת שהמנוע בנה. הביטוי עצמו — סובלנות לניקוד, גרש/גרשיים, והמפריד בין מילים — נשאר זהה בשני המצבים, וההבדל היחיד הוא הגבול. אם המבנה אינו מזוהה, נשארים בתבנית המלאה של המנוע (התנהגות היום).

התחלף גם שיקול חלופי: להשתמש ב-`generateHighlightPattern` שכבר נטול גבולות. הוא נדחה כי הוא מנרמל את השאילתה אחרת (`sanitize_query` מוחק נקודות וסוגריים), כלומר המתג היה משנה בשקט גם את הפיסוק בשאילתה.

**התיקון הנקי ביותר הוא במנוע** — פרמטר `partial_word` ל-`build_literal_pattern` שידלג על העטיפה. הוא דורש שחרור גרסה של `otzaria_search_engine`; כשזה יקרה אפשר להחליף את `stripWordBoundaryWrapper` בפרמטר ולמחוק אותה.

## התנהגות

ברירת המחדל היא התאמה חלקית — כמו Ctrl+F בוורד, בפנקס ובדפדפן, וכמו שאוצריא עצמה התנהגה עד מאי 2026. מתג **מילים שלמות** (`text_whole_word`) בשדה החיפוש מחזיר את ההתנהגות המחמירה, וההעדפה נשמרת גלובלית.

ההעדפה נזרעת ל-`TextBookLoaded` כבר בטעינת הספר, כדי שההדגשה בגוף הספר תהיה זהה לפני פתיחת חלונית החיפוש ואחריה. במסלול המנוע המתג אינו חל — ההדגשה שם נגזרת מהתבנית שהמנוע בנה.

## תיקונים נלווים שהתגלו בדרך

- **הקלדה ב-PDF הפעילה סריקה על כל תו.** `pdf_search_screen.dart` רשם מאזין ישיר על ה-`controller` בנוסף ל-`onSearchTextChanged` המושהה, כך שכל תו עלה בסריקה מלאה של שכבת הטקסט — פעמיים. המאזין הוסר, וההקלדה עוברת דרך `kSearchFieldDebounce` (250ms, כמו `FindRefBloc`).
- **`NavPanelSearchDelegate.actionsKey`.** `sameTargetAs` השווה את אורך `trailingActions` בלבד, ולכן פעולה שמחליפה אייקון (מתג) נבלעה והסרגל המורם נשאר על התצוגה הישנה.
- **`additionalActions` היה קוד מת** — `const []` בשני האתרים היחידים, ולא מרונדר כלל בחלונית ניווט. הוחלף ב-`searchFieldActions` שנכנס לשדה החיפוש עצמו, בשני מסלולי הציור.

## בדיקות

`flutter analyze lib test` — נקי.
`flutter test test/search test/text_book test/pdf_book test/widgets` — 3193 עברו, 1 נכשל.

הכישלון היחיד הוא `search_scope_menu_search_actions_test.dart` (issue #933), שאומת ב-`git stash` כנכשל גם בלי השינוי הזה.

בדיקות שנוספו:

| קובץ | מכסה |
|---|---|
| `literal_search_pattern_test.dart` | הסרת העטיפה, שימור ניקוד/גרשיים, `(?!` בתוך הביטוי, מבנה לא מזוהה |
| `section_search_utils_test.dart` | "שמים" מוצא "השמים" חלקי ולא מוצא במלא, תוצאה לכל הופעה, היסט ההתאמה |
| `text_book_bloc_test.dart` | זריעת `searchWholeWord` מההעדפה, ושמסלול המנוע מתעלם ממנה |
| `text_book_search_screen_test.dart` | לחיצה על המתג מריצה חיפוש מחדש ומעדכנת את ההדגשה |
| `nav_panel_search_test.dart` | פעולה שהחליפה אייקון מתעדכנת בסרגל המורם |
| `search_pane_base_test.dart` | הפעולות נראות גם כשהשדה מורם לחלונית |
| `in_book_search_preferences_test.dart` | ברירת המחדל והנסיגה כש-`Settings` לא אותחל |

## מה לא נכלל

- `countMatches` בחיפוש המפרשים סופר מילים שלמות תמיד — אי-עקביות שקדמה לשינוי, במסלול אחר.
- אין בדיקה מול פלט המנוע האמיתי (הבדיקות לא יכולות לקרוא ל-FFI ומשתמשות ברפליקה). אם המנוע ישנה את מבנה העטיפה, תהיה נסיגה שקטה למילים שלמות.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
