### PR TITLE
allowlist: שש כתובות לתוסף "עינים למקרא"

### DIFF
--- a/lib/plugins/models/plugin_network_allowlist.g.dart
+++ b/lib/plugins/models/plugin_network_allowlist.g.dart
@@ -37,4 +37,10 @@ const List<String> pluginNetworkAllowlist = <String>[
   'https://api.github.com/repos/yair-yair/mdy-images-updated',
   'https://raw.githubusercontent.com/yair-yair/mdy-images-updated',
   'https://github.com/yair-yair/mdy-images-updated',
+  'https://raw.githubusercontent.com/e0548433917-gif/madaei-hatanach/main/manifest.json',
+  'https://api.github.com/repos/e0548433917-gif/madaei-hatanach/contents/manifest.json',
+  'https://script.google.com/macros/s/AKfycbxzlCAZzhaEM68jRqqekW8InrtbSiZrtiiIjgCKOInUvyBG43wLY29MYY6PrbHijpO6/exec',
+  'https://script.googleusercontent.com/macros/echo',
+  'https://docs.google.com/forms/d/e/1FAIpQLSd7NiGDUahnwpaestosEcDxPJoAkYXzVRUa2yB5EiXkLPSWvQ/formResponse',
+  'https://he.wikipedia.org/api/rest_v1/page/summary',
 ];

--- a/lib/plugins/models/plugin_network_allowlist.g.dart
+++ b/lib/plugins/models/plugin_network_allowlist.g.dart
@@ -42,5 +42,4 @@ const List<String> pluginNetworkAllowlist = <String>[
   'https://script.google.com/macros/s/AKfycbxzlCAZzhaEM68jRqqekW8InrtbSiZrtiiIjgCKOInUvyBG43wLY29MYY6PrbHijpO6/exec',
   'https://script.googleusercontent.com/macros/echo',
   'https://docs.google.com/forms/d/e/1FAIpQLSd7NiGDUahnwpaestosEcDxPJoAkYXzVRUa2yB5EiXkLPSWvQ/formResponse',
-  'https://he.wikipedia.org/api/rest_v1/page/summary',
 ];

--- a/plugin_network_allowlist.txt
+++ b/plugin_network_allowlist.txt
@@ -76,3 +76,11 @@ https://github.com/yair-yair/mdy-images-updated
 https://api.github.com/repos/yair-yair/mdy-images-updated
 https://raw.githubusercontent.com/yair-yair/mdy-images-updated
 https://github.com/yair-yair/mdy-images-updated
+
+# תוסף "עינים למקרא" (com.chadbedera.madaeihatanach)
+https://raw.githubusercontent.com/e0548433917-gif/madaei-hatanach/main/manifest.json
+https://api.github.com/repos/e0548433917-gif/madaei-hatanach/contents/manifest.json
+https://script.google.com/macros/s/AKfycbxzlCAZzhaEM68jRqqekW8InrtbSiZrtiiIjgCKOInUvyBG43wLY29MYY6PrbHijpO6/exec
+https://script.googleusercontent.com/macros/echo
+https://docs.google.com/forms/d/e/1FAIpQLSd7NiGDUahnwpaestosEcDxPJoAkYXzVRUa2yB5EiXkLPSWvQ/formResponse
+https://he.wikipedia.org/api/rest_v1/page/summary

--- a/plugin_network_allowlist.txt
+++ b/plugin_network_allowlist.txt
@@ -83,4 +83,3 @@ https://api.github.com/repos/e0548433917-gif/madaei-hatanach/contents/manifest.j
 https://script.google.com/macros/s/AKfycbxzlCAZzhaEM68jRqqekW8InrtbSiZrtiiIjgCKOInUvyBG43wLY29MYY6PrbHijpO6/exec
 https://script.googleusercontent.com/macros/echo
 https://docs.google.com/forms/d/e/1FAIpQLSd7NiGDUahnwpaestosEcDxPJoAkYXzVRUa2yB5EiXkLPSWvQ/formResponse
-https://he.wikipedia.org/api/rest_v1/page/summary


### PR DESCRIPTION
הוספת שש כתובות לרשימת ההיתר עבור התוסף **״עינים למקרא״** (`com.chadbedera.madaeihatanach`) — מדריך מאוחד לתנ״ך, משנה ותלמוד.

ריפו התוסף: https://github.com/e0548433917-gif/madaei-hatanach

## הכתובות ומה עובר בכל אחת

| כתובת | מי קורא | מה עובר |
|---|---|---|
| `https://raw.githubusercontent.com/e0548433917-gif/madaei-hatanach/main/manifest.json` | `shell/bridge.js` | GET של ה-manifest של התוסף בלבד, להשוואת מספר גרסה |
| `https://api.github.com/repos/e0548433917-gif/madaei-hatanach/contents/manifest.json` | `shell/bridge.js` | אותו דבר, כשה-raw חסום או נופל |
| `https://script.google.com/macros/s/AKfycbxz…/exec` | `shell/personal.js` | POST של דיווח באג שהמשתמש כתב; פותח GitHub Issue בריפו של התוסף |
| `https://script.googleusercontent.com/macros/echo` | (redirect) | יעד ההפניה של Apps Script — בלעדיו הבקשה נחסמת באמצע |
| `https://docs.google.com/forms/d/e/1FAIpQLSd7…/formResponse` | `shell/personal.js` | אותו דיווח, מסלול גיבוי |
| `https://he.wikipedia.org/api/rest_v1/page/summary` | `shell/guides.js` | GET תקציר לפי שם מדעי, לתמונת כרטיס במדריך הצומח |

כל השש מוצהרות גם ב-`network.allowlist` שבמניפסט של התוסף.

## למה זה חוסם היום

בלי האישור הזה, בדיקת העדכון ושליחת דיווחי המשתמשים מוחזרות 403 אצל **כל** המשתמשים — לא ״אין רשת״. בפועל: משתמש לוחץ ״שליחה״ בפאנל הדיווחים, ושום Issue לא נפתח.

## מה לא נכלל בכוונה

`https://github.com/e0548433917-gif/madaei-hatanach/releases` מוצהר במניפסט אך **אינו** מבוקש כאן: הוא נפתח דרך `app.openUrl` בדפדפן המערכת, ו-`app.openUrl` אינו נבדק מול ה-allowlist. לפי עקרון המינימום שבתיעוד אין סיבה לפתוח אותו לרשת ה-WebView.

## סנכרון

עודכנו שני הקבצים ששומרים על הסנכרון ש-`test/plugins/models/plugin_network_allowlist_branch_sync_test.dart` מחייב:

* `plugin_network_allowlist.txt` (מקור האמת)
* `lib/plugins/models/plugin_network_allowlist.g.dart` (העותק המקומפל, באותו סדר בדיוק)

הענף מבוסס על `dev` העדכני (`973e802`).
