### PR TITLE
כלים: החזרת רשת האייקונים לחלונית הכלים (ביטול e6186f52c)

### DIFF
--- a/lib/navigation/view/main_window_screen.dart
+++ b/lib/navigation/view/main_window_screen.dart
@@ -3130,8 +3130,8 @@ class MainWindowScreenState extends State<MainWindowScreen>
                                           onClose: _closeToolsLauncher,
                                           alignment:
                                               AlignmentDirectional.centerStart,
-                                          // רחב מספיק שתוויות הכלים הארוכות
-                                          // ייכנסו בשורה בלי קיצור.
+                                          // רחב מספיק שארבע הקוביות שבשורה יהיו
+                                          // מרווחות, ועדיין לא חמש.
                                           width: 440,
                                           deferChildBuildOnOpen: true,
                                           child: ToolsLauncherPanel(

--- a/lib/tools/view/tools_launcher_panel.dart
+++ b/lib/tools/view/tools_launcher_panel.dart
@@ -7,7 +7,6 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
-import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:otzaria/plugins/bloc/plugin_system_bloc.dart';
 import 'package:otzaria/plugins/bloc/plugin_system_event.dart';
@@ -31,7 +30,7 @@ import 'package:otzaria/tools/tool_order.dart';
 import 'package:otzaria/widgets/controls/action_buttons.dart';
 import 'package:otzaria/widgets/dialogs/dialogs_exports.dart';
 import 'package:otzaria/widgets/feedback/edge_scrollbar_behavior.dart';
-import 'package:otzaria/widgets/lists/nav_tree_tile.dart';
+import 'package:otzaria/widgets/layout/app_card.dart';
 import 'package:otzaria/widgets/misc/app_popup_menu.dart';
 import 'package:otzaria/widgets/text/otzaria_search_field.dart';
 
@@ -90,14 +89,28 @@ List<ToolGroup> groupToolEntries(List<ToolCatalogEntry> entries) {
   return groups;
 }
 
-/// סדר השורות כפי שהן מוצגות בפועל.
+/// סדר הקוביות כפי שהן מוצגות בפועל.
 @visibleForTesting
 List<ToolCatalogEntry> orderedToolEntries(List<ToolCatalogEntry> entries) => [
   for (final group in groupToolEntries(entries)) ...group.entries,
 ];
 
+/// רוחב היעד לקובייה — ברוחב הפאנל שבברירת מחדל נכנסות ארבע קוביות בשורה.
+@visibleForTesting
+const double kToolTileTargetWidth = 88;
+
+/// המרווח בקצה ימין שמפנה מקום לפס הגלילה, כדי שלא יעלה על הקוביות.
+@visibleForTesting
+const double kToolGridScrollbarGutter = 14;
+
+/// מספר העמודות ברשת לרוחב נתון. הרוחב שמועבר הוא זה שנשאר לקוביות — כלומר
+/// לאחר הפחתת [kToolGridScrollbarGutter].
+@visibleForTesting
+int toolGridColumns(double width) =>
+    (width / kToolTileTargetWidth).floor().clamp(2, 5);
+
 /// האינדקס המסומן הבא בניווט מקלדת. `-1` = אין סימון, והחץ הראשון מסמן את
-/// השורה הראשונה.
+/// הקובייה הראשונה.
 @visibleForTesting
 int nextHighlightIndex({
   required int current,
@@ -105,7 +118,7 @@ int nextHighlightIndex({
   required int total,
 }) {
   if (total <= 0) return 0;
-  // ממצב "אין סימון" כל חץ מסמן את השורה הראשונה, ולא מדלג delta שורות.
+  // ממצב "אין סימון" כל חץ מסמן את הקובייה הראשונה, ולא מדלג delta קוביות.
   if (current < 0) return 0;
   return (current + delta).clamp(0, total - 1);
 }
@@ -120,7 +133,7 @@ bool canReorderBetween(ToolCatalogEntry source, ToolCatalogEntry target) =>
     source.isPlugin == target.isPlugin &&
     source.sortGroupPriority == target.sortGroupPriority;
 
-/// פעולה בתפריט השורה. מקור אמת אחד — נצרך גם בכפתור ⋯ וגם בבדיקות.
+/// פעולה בתפריט הקובייה. מקור אמת אחד — נצרך גם בכפתור ⋯ וגם בבדיקות.
 /// [onTap] ריק (`null`) = הפעולה מוצגת מעומעמת (למשל הזזה בקצה הקבוצה).
 /// [children] הופך את הפעולה לתת-תפריט, ואז [onTap] אינו בשימוש.
 @visibleForTesting
@@ -145,7 +158,7 @@ class ToolTileAction {
   });
 }
 
-/// תוכן פאנל הכלים: חיפוש למעלה, ומתחתיו רשימת עץ ניווט מקובצת.
+/// תוכן פאנל הכלים: חיפוש למעלה, ומתחתיו רשת קוביות מקובצת.
 class ToolsLauncherPanel extends StatefulWidget {
   final ValueChanged<ToolCatalogEntry> onToolSelected;
   final VoidCallback onClose;
@@ -166,18 +179,19 @@ class ToolsLauncherPanel extends StatefulWidget {
 
 class _ToolsLauncherPanelState extends State<ToolsLauncherPanel> {
   final TextEditingController _searchController = TextEditingController();
-  final ScrollController _listScrollController = ScrollController();
+  final ScrollController _gridScrollController = ScrollController();
   late final FocusNode _searchFocusNode = FocusNode(
     onKeyEvent: _handleSearchFieldKey,
   );
   String _query = '';
 
-  /// השורה המסומנת בניווט מקלדת, כאינדקס ברשימה המסוננת השטוחה.
+  /// הקובייה המסומנת בניווט מקלדת, כאינדקס ברשימה המסוננת השטוחה.
   /// `-1` = אין סימון, כדי שלא ייראה כאילו הכלי הראשון נבחר.
   int _highlightedIndex = -1;
   List<ToolCatalogEntry> _keyboardEntries = const [];
+  int _keyboardColumns = 2;
 
-  /// הכלי שזז אחרון ומספר ההזזה — מריצים פעימת הדגשה על השורה שזזה.
+  /// הכלי שזז אחרון ומספר ההזזה — מריצים פעימת הדגשה על הקובייה שזזה.
   String? _movedToolId;
   int _moveNonce = 0;
 
@@ -186,17 +200,17 @@ class _ToolsLauncherPanelState extends State<ToolsLauncherPanel> {
   List<String>? _pendingBuiltInOrder;
   List<String>? _pendingPluginOrder;
 
-  /// אזור הרשימה כולו — קצוותיו הם אזורי גלילת הקצה בזמן גרירה.
-  final GlobalKey _listAreaKey = GlobalKey();
+  /// אזור הרשת כולו — קצוותיו הם אזורי גלילת הקצה בזמן גרירה.
+  final GlobalKey _gridAreaKey = GlobalKey();
 
-  /// מסמן אפס-גובה אחרי השורה האחרונה — הגבול שמתחתיו שחרור הוא "לסוף".
-  final GlobalKey _listEndKey = GlobalKey();
+  /// מסמן אפס-גובה אחרי הקובייה האחרונה — הגבול שמתחתיו שחרור הוא "לסוף".
+  final GlobalKey _gridEndKey = GlobalKey();
 
   /// גלילת הקצה בגרירה: הכיוון (1- למעלה, 1 למטה) והשעון שמניע אותה.
   double _autoScrollDirection = 0;
   Timer? _autoScrollTimer;
 
-  /// השורה שמציגה קו "אחרי" כשהגרירה מרחפת בשטח הריק שמתחת לרשימה.
+  /// הקובייה שמציגה קו "אחרי" כשהגרירה מרחפת בשטח הריק שמתחת לרשת.
   String? _endDropIndicatorId;
 
   @override
@@ -213,7 +227,7 @@ class _ToolsLauncherPanelState extends State<ToolsLauncherPanel> {
   void dispose() {
     _autoScrollTimer?.cancel();
     _searchController.dispose();
-    _listScrollController.dispose();
+    _gridScrollController.dispose();
     _searchFocusNode.dispose();
     super.dispose();
   }
@@ -276,8 +290,11 @@ class _ToolsLauncherPanelState extends State<ToolsLauncherPanel> {
     );
   }
 
-  /// חצי מעלה/מטה מזיזים את הסימון; חצי ימין/שמאל נשארים לטקסט שבשדה החיפוש.
-  KeyEventResult _handleKey(KeyEvent event, List<ToolCatalogEntry> entries) {
+  KeyEventResult _handleKey(
+    KeyEvent event,
+    List<ToolCatalogEntry> entries,
+    int columns,
+  ) {
     if (event is! KeyDownEvent && event is! KeyRepeatEvent) {
       return KeyEventResult.ignored;
     }
@@ -286,9 +303,16 @@ class _ToolsLauncherPanelState extends State<ToolsLauncherPanel> {
         widget.onClose();
         return KeyEventResult.handled;
       case LogicalKeyboardKey.arrowDown:
-        _moveHighlight(1, entries.length);
+        _moveHighlight(columns, entries.length);
         return KeyEventResult.handled;
       case LogicalKeyboardKey.arrowUp:
+        _moveHighlight(-columns, entries.length);
+        return KeyEventResult.handled;
+      // ב-RTL הקובייה הבאה נמצאת משמאל, ולכן החיצים מתהפכים ביחס ל-LTR.
+      case LogicalKeyboardKey.arrowLeft:
+        _moveHighlight(1, entries.length);
+        return KeyEventResult.handled;
+      case LogicalKeyboardKey.arrowRight:
         _moveHighlight(-1, entries.length);
         return KeyEventResult.handled;
       case LogicalKeyboardKey.enter:
@@ -300,11 +324,11 @@ class _ToolsLauncherPanelState extends State<ToolsLauncherPanel> {
   }
 
   KeyEventResult _handleSearchFieldKey(FocusNode _, KeyEvent event) =>
-      _handleKey(event, _keyboardEntries);
+      _handleKey(event, _keyboardEntries, _keyboardColumns);
 
   // ── סידור מחדש ──────────────────────────────────────────────────────────────
 
-  /// סידור אפשרי רק ברשימה המלאה: בחיפוש השורות מסוננות, ו"השכן" על המסך
+  /// סידור אפשרי רק ברשימה המלאה: בחיפוש הקוביות מסוננות, ו"השכן" על המסך
   /// אינו השכן האמיתי בסדר.
   bool get _isReorderEnabled => normalizeToolSearchText(_query).isEmpty;
 
@@ -317,8 +341,8 @@ class _ToolsLauncherPanelState extends State<ToolsLauncherPanel> {
     final pluginBloc = context.read<PluginSystemBloc>();
     final settingsBloc = context.read<SettingsBloc>();
 
-    // שיגור מושהה לפריים הבא: שיגור בזמן בניית הרשימה מפיל את Flutter על
-    // הפעלה-מחדש של רכיבי Overlay.
+    // שיגור מושהה לפריים הבא: הרשת נבנית בתוך LayoutBuilder, ושיגור בזמן
+    // הבנייה מפיל את Flutter על הפעלה-מחדש של רכיבי Overlay.
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
       if (source.isPlugin) {
@@ -354,6 +378,88 @@ class _ToolsLauncherPanelState extends State<ToolsLauncherPanel> {
     });
   }
 
+  // ── שחרור בשטח הריק וגלילת קצה בגרירה ───────────────────────────────────────
+
+  /// היעד לשחרור בשטח הריק: הקובייה האחרונה בקבוצה של [source], או `null`
+  /// כשהמקור כבר אחרון ואין מה להזיז.
+  ToolCatalogEntry? _endOfGroupTarget(ToolCatalogEntry source) {
+    final last = _keyboardEntries.lastWhereOrNull(
+      (entry) =>
+          entry.isPlugin == source.isPlugin &&
+          entry.sortGroupPriority == source.sortGroupPriority,
+    );
+    return (last == null || last.toolId == source.toolId) ? null : last;
+  }
+
+  /// האם הסמן מתחת לקובייה האחרונה — בשטח הריק של הרשת.
+  bool _isBelowGridTiles(Offset globalPointer) {
+    final box = _gridEndKey.currentContext?.findRenderObject() as RenderBox?;
+    if (box == null || !box.hasSize) return false;
+    return globalPointer.dy >= box.localToGlobal(Offset.zero).dy;
+  }
+
+  bool _acceptEndOfGridDrop(DragTargetDetails<ToolCatalogEntry> details) {
+    final target = _isReorderEnabled && _isBelowGridTiles(details.offset)
+        ? _endOfGroupTarget(details.data)
+        : null;
+    _setEndDropIndicator(target?.toolId);
+    return target != null;
+  }
+
+  void _dropAtEndOfGroup(ToolCatalogEntry source) {
+    _onDragEnded();
+    final target = _endOfGroupTarget(source);
+    if (target == null) return;
+    _reorder(source: source, target: target, placeAfter: true);
+  }
+
+  void _setEndDropIndicator(String? toolId) {
+    if (toolId == _endDropIndicatorId) return;
+    setState(() => _endDropIndicatorId = toolId);
+  }
+
+  void _onDragEnded() {
+    _setEndDropIndicator(null);
+    _stopDragAutoScroll();
+  }
+
+  /// מזניק או עוצר את גלילת הקצה לפי מיקום הסמן באזור הרשת.
+  void _updateDragAutoScroll(Offset globalPointer) {
+    final box = _gridAreaKey.currentContext?.findRenderObject() as RenderBox?;
+    if (box == null || !box.hasSize) return _stopDragAutoScroll();
+    final dy = box.globalToLocal(globalPointer).dy;
+    var direction = 0.0;
+    if (dy < _kGridAutoScrollEdge) {
+      direction = -1;
+    } else if (dy > box.size.height - _kGridAutoScrollEdge) {
+      direction = 1;
+    }
+    if (direction == 0) return _stopDragAutoScroll();
+    _autoScrollDirection = direction;
+    _autoScrollTimer ??= Timer.periodic(
+      _kGridAutoScrollTick,
+      _onAutoScrollTick,
+    );
+  }
+
+  void _onAutoScrollTick(Timer _) {
+    if (!_gridScrollController.hasClients) return _stopDragAutoScroll();
+    final position = _gridScrollController.position;
+    final target =
+        (position.pixels + _autoScrollDirection * _kGridAutoScrollStep).clamp(
+          position.minScrollExtent,
+          position.maxScrollExtent,
+        );
+    if (target == position.pixels) return _stopDragAutoScroll();
+    position.jumpTo(target);
+  }
+
+  void _stopDragAutoScroll() {
+    _autoScrollTimer?.cancel();
+    _autoScrollTimer = null;
+    _autoScrollDirection = 0;
+  }
+
   /// מנקה את הסדר הממתין ברגע שה-bloc התיישר עליו. חייב לקרות ב-build, כי שם
   /// מגיע ה-state המעודכן.
   void _clearSettledPendingOrders(
@@ -385,89 +491,7 @@ class _ToolsLauncherPanelState extends State<ToolsLauncherPanel> {
     }
   }
 
-  // ── שחרור בשטח הריק וגלילת קצה בגרירה ───────────────────────────────────────
-
-  /// היעד לשחרור בשטח הריק: השורה האחרונה בקבוצה של [source], או `null`
-  /// כשהמקור כבר אחרון ואין מה להזיז.
-  ToolCatalogEntry? _endOfGroupTarget(ToolCatalogEntry source) {
-    final last = _keyboardEntries.lastWhereOrNull(
-      (entry) =>
-          entry.isPlugin == source.isPlugin &&
-          entry.sortGroupPriority == source.sortGroupPriority,
-    );
-    return (last == null || last.toolId == source.toolId) ? null : last;
-  }
-
-  /// האם הסמן מתחת לשורה האחרונה — בשטח הריק של הרשימה.
-  bool _isBelowListRows(Offset globalPointer) {
-    final box = _listEndKey.currentContext?.findRenderObject() as RenderBox?;
-    if (box == null || !box.hasSize) return false;
-    return globalPointer.dy >= box.localToGlobal(Offset.zero).dy;
-  }
-
-  bool _acceptEndOfListDrop(DragTargetDetails<ToolCatalogEntry> details) {
-    final target = _isReorderEnabled && _isBelowListRows(details.offset)
-        ? _endOfGroupTarget(details.data)
-        : null;
-    _setEndDropIndicator(target?.toolId);
-    return target != null;
-  }
-
-  void _dropAtEndOfGroup(ToolCatalogEntry source) {
-    _onDragEnded();
-    final target = _endOfGroupTarget(source);
-    if (target == null) return;
-    _reorder(source: source, target: target, placeAfter: true);
-  }
-
-  void _setEndDropIndicator(String? toolId) {
-    if (toolId == _endDropIndicatorId) return;
-    setState(() => _endDropIndicatorId = toolId);
-  }
-
-  void _onDragEnded() {
-    _setEndDropIndicator(null);
-    _stopDragAutoScroll();
-  }
-
-  /// מזניק או עוצר את גלילת הקצה לפי מיקום הסמן באזור הרשימה.
-  void _updateDragAutoScroll(Offset globalPointer) {
-    final box = _listAreaKey.currentContext?.findRenderObject() as RenderBox?;
-    if (box == null || !box.hasSize) return _stopDragAutoScroll();
-    final dy = box.globalToLocal(globalPointer).dy;
-    var direction = 0.0;
-    if (dy < _kListAutoScrollEdge) {
-      direction = -1;
-    } else if (dy > box.size.height - _kListAutoScrollEdge) {
-      direction = 1;
-    }
-    if (direction == 0) return _stopDragAutoScroll();
-    _autoScrollDirection = direction;
-    _autoScrollTimer ??= Timer.periodic(
-      _kListAutoScrollTick,
-      _onAutoScrollTick,
-    );
-  }
-
-  void _onAutoScrollTick(Timer _) {
-    if (!_listScrollController.hasClients) return _stopDragAutoScroll();
-    final position = _listScrollController.position;
-    final target =
-        (position.pixels + _autoScrollDirection * _kListAutoScrollStep).clamp(
-          position.minScrollExtent,
-          position.maxScrollExtent,
-        );
-    if (target == position.pixels) return _stopDragAutoScroll();
-    position.jumpTo(target);
-  }
-
-  void _stopDragAutoScroll() {
-    _autoScrollTimer?.cancel();
-    _autoScrollTimer = null;
-    _autoScrollDirection = 0;
-  }
-
-  /// פעולות השורה, בסדר שבו הן מוצגות בתפריט ⋯.
+  /// פעולות הקובייה, בסדר שבו הן מוצגות בתפריט ⋯.
   List<ToolTileAction> _tileActions(
     ToolCatalogEntry entry, {
     required VoidCallback? onMoveEarlier,
@@ -482,23 +506,24 @@ class _ToolsLauncherPanelState extends State<ToolsLauncherPanel> {
         label: 'הזזה',
         onTap: null,
         children: [
+          // RtlIcon בשורת התפריט מהפך את החץ, כך שיצביע לכיוון ההזזה בפועל.
           ToolTileAction(
-            icon: FluentIcons.arrow_up_24_regular,
-            label: 'הזז למעלה',
+            icon: FluentIcons.arrow_left_24_regular,
+            label: 'הזז אחורה',
             onTap: onMoveEarlier,
           ),
           ToolTileAction(
-            icon: FluentIcons.arrow_down_24_regular,
-            label: 'הזז למטה',
+            icon: FluentIcons.arrow_right_24_regular,
+            label: 'הזז קדימה',
             onTap: onMoveLater,
           ),
           ToolTileAction(
-            icon: FluentIcons.arrow_upload_24_regular,
+            icon: FluentIcons.arrow_previous_24_regular,
             label: 'הזז לתחילה',
             onTap: onMoveToStart,
           ),
           ToolTileAction(
-            icon: FluentIcons.arrow_download_24_regular,
+            icon: FluentIcons.arrow_next_24_regular,
             label: 'הזז לסוף',
             onTap: onMoveToEnd,
           ),
@@ -612,7 +637,7 @@ class _ToolsLauncherPanelState extends State<ToolsLauncherPanel> {
                           settingsState.isOfflineMode,
                           allEntries,
                         )
-                      : _buildList(
+                      : _buildGrid(
                           entries,
                           openToolIds,
                           bottomInset:
@@ -624,7 +649,7 @@ class _ToolsLauncherPanelState extends State<ToolsLauncherPanel> {
                 ),
                 PositionedDirectional(
                   bottom: AppTokens.spaceSM,
-                  start: kNavTreeSideInset,
+                  start: kToolGridScrollbarGutter,
                   child: _PluginsToolbar(
                     showDevTools:
                         widget.showDevTools ?? PluginDevToolsMode.enabled,
@@ -718,56 +743,97 @@ class _ToolsLauncherPanelState extends State<ToolsLauncherPanel> {
     );
   }
 
-  Widget _buildList(
+  Widget _buildGrid(
     List<ToolCatalogEntry> entries,
     Set<String> openToolIds, {
     required double bottomInset,
   }) {
-    final groups = groupToolEntries(entries);
-    var runningIndex = 0;
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final columns = toolGridColumns(
+          constraints.maxWidth - kToolGridScrollbarGutter,
+        );
+        _keyboardColumns = columns;
+        final groups = groupToolEntries(entries);
+        var runningIndex = 0;
 
-    return Focus(
-      autofocus: false,
-      onKeyEvent: (_, event) => _handleKey(event, entries),
-      child: NavTreeFocusGroup(
-        // היעד מאחורי הרשימה כולה: קולט שחרור בשטח הריק שמתחת לשורות, ומזין
-        // את גלילת הקצה בכל מקום שאין בו שורה קולטת.
-        child: DragTarget<ToolCatalogEntry>(
-          key: _listAreaKey,
-          onWillAcceptWithDetails: _acceptEndOfListDrop,
-          onMove: (details) => _updateDragAutoScroll(details.offset),
-          onLeave: (_) => _onDragEnded(),
-          onAcceptWithDetails: (details) => _dropAtEndOfGroup(details.data),
-          builder: (context, _, _) => ScrollConfiguration(
-            behavior: const EdgeScrollbarBehavior.right(),
-            child: ListView(
-              controller: _listScrollController,
-              padding:
-                  kNavTreeListPadding + EdgeInsets.only(bottom: bottomInset),
-              children: [
-                for (var i = 0; i < groups.length; i++) ...[
-                  // קבוצות עוקבות באותה תווית (תוספים לפני/אחרי הכלים המובנים)
-                  // נראות כמקטע אחד — הכותרת מוצגת רק במעבר תווית.
-                  if (i == 0 || groups[i].label != groups[i - 1].label)
-                    NavTreeHeader(title: groups[i].label),
-                  for (var j = 0; j < groups[i].entries.length; j++)
-                    _buildRow(
-                      group: groups[i].entries,
-                      indexInGroup: j,
-                      flatIndex: runningIndex++,
-                      openToolIds: openToolIds,
+        final theme = Theme.of(context);
+        return Focus(
+          autofocus: false,
+          onKeyEvent: (_, event) => _handleKey(event, entries, columns),
+          // היעד מאחורי הרשת כולה: קולט שחרור בשטח הריק שמתחת לקוביות, ומזין
+          // את גלילת הקצה בכל מקום שאין בו קובייה קולטת.
+          child: DragTarget<ToolCatalogEntry>(
+            key: _gridAreaKey,
+            onWillAcceptWithDetails: _acceptEndOfGridDrop,
+            onMove: (details) => _updateDragAutoScroll(details.offset),
+            onLeave: (_) => _onDragEnded(),
+            onAcceptWithDetails: (details) => _dropAtEndOfGroup(details.data),
+            builder: (context, _, _) => ScrollConfiguration(
+              behavior: const EdgeScrollbarBehavior.right(),
+              child: ListView(
+                controller: _gridScrollController,
+                // הרווח בימין שמור לפס הגלילה, כדי שלא יעלה על הקוביות.
+                padding: EdgeInsets.only(
+                  right: kToolGridScrollbarGutter,
+                  bottom: bottomInset,
+                ),
+                children: [
+                  for (var i = 0; i < groups.length; i++) ...[
+                    // קבוצות עוקבות באותה תווית (תוספים לפני/אחרי הכלים המובנים)
+                    // נראות כמקטע אחד — הכותרת והמפריד מוצגים רק במעבר תווית.
+                    if (i > 0 && groups[i].label != groups[i - 1].label)
+                      const Padding(
+                        padding: EdgeInsets.only(
+                          top: AppTokens.spaceMD,
+                          bottom: AppTokens.spaceSM,
+                        ),
+                        child: Divider(height: 1),
+                      ),
+                    if (i == 0 || groups[i].label != groups[i - 1].label)
+                      Padding(
+                        padding: const EdgeInsets.only(
+                          top: AppTokens.spaceSM,
+                          bottom: AppTokens.spaceSM,
+                        ),
+                        child: Text(
+                          groups[i].label,
+                          style: theme.textTheme.titleSmall?.copyWith(
+                            color: theme.colorScheme.secondary,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                      ),
+                    GridView.count(
+                      crossAxisCount: columns,
+                      shrinkWrap: true,
+                      physics: const NeverScrollableScrollPhysics(),
+                      mainAxisSpacing: AppTokens.spaceSM,
+                      crossAxisSpacing: AppTokens.spaceSM,
+                      childAspectRatio: 1.0,
+                      children: [
+                        for (var j = 0; j < groups[i].entries.length; j++)
+                          _buildTile(
+                            group: groups[i].entries,
+                            indexInGroup: j,
+                            flatIndex: runningIndex++,
+                            openToolIds: openToolIds,
+                          ),
+                      ],
                     ),
+                  ],
+                  SizedBox(key: _gridEndKey, height: 0),
+                  const SizedBox(height: AppTokens.spaceMD),
                 ],
-                SizedBox(key: _listEndKey, height: 0),
-              ],
+              ),
             ),
           ),
-        ),
-      ),
+        );
+      },
     );
   }
 
-  Widget _buildRow({
+  Widget _buildTile({
     required List<ToolCatalogEntry> group,
     required int indexInGroup,
     required int flatIndex,
@@ -802,8 +868,6 @@ class _ToolsLauncherPanelState extends State<ToolsLauncherPanel> {
         entry: entry,
         isOpen: openToolIds.contains(entry.toolId),
         isHighlighted: flatIndex == _highlightedIndex,
-        isGroupStart: isFirst,
-        isGroupEnd: isLast,
         movePulse: entry.toolId == _movedToolId ? _moveNonce : 0,
         // בלי זה הפוקוס נשאר על מסלול התפריט שנסגר, ומקשי הפאנל (Escape,
         // חצים, Enter) מפסיקים לעבוד עד לחיצה על שדה החיפוש.
@@ -886,23 +950,23 @@ class _PluginsToolbar extends StatelessWidget {
   }
 }
 
-/// עוטף שורה ביכולת גרירה לסידור מחדש: גוררים שורה, וקו ההוספה מראה בין אילו
-/// שורות היא תיפול — לפי חצי השורה שהסמן נמצא בו, כמו סידור לשוניות בדפדפן.
-/// במגע הגרירה מתחילה בלחיצה ארוכה, כדי לא לחטוף את הגלילה.
+/// עוטף קובייה ביכולת גרירה לסידור מחדש: גוררים קובייה, וקו ההוספה מראה בין
+/// אילו קוביות היא תיפול — לפי חצי הקובייה שהסמן נמצא בו, כמו סידור לשוניות
+/// בדפדפן. במגע הגרירה מתחילה בלחיצה ארוכה, כדי לא לחטוף את הגלילה.
 class _ReorderableToolTile extends StatefulWidget {
   final ToolCatalogEntry entry;
   final ToolTile tile;
   final bool canDrag;
 
-  /// קו "אחרי" כפוי — כשגרירה מרחפת בשטח הריק והשורה היא סוף קבוצת היעד.
+  /// קו "אחרי" כפוי — כשגרירה מרחפת בשטח הריק והקובייה היא סוף קבוצת היעד.
   final bool showEndIndicator;
   final void Function(ToolCatalogEntry source, {required bool placeAfter})
   onAcceptSource;
 
-  /// תזוזת גרירה מעל השורה — מזינה את גלילת הקצה של הרשימה.
+  /// תזוזת גרירה מעל הקובייה — מזינה את גלילת הקצה של הרשת.
   final ValueChanged<Offset> onDragOver;
 
-  /// הגרירה עזבה את השורה או הסתיימה — עוצרת את גלילת הקצה.
+  /// הגרירה עזבה את הקובייה או הסתיימה — עוצרת את גלילת הקצה.
   final VoidCallback onDragEnded;
 
   const _ReorderableToolTile({
@@ -921,7 +985,7 @@ class _ReorderableToolTile extends StatefulWidget {
 }
 
 class _ReorderableToolTileState extends State<_ReorderableToolTile> {
-  /// `true` = השורה הנגררת תיפול *אחרי* השורה הזאת בסדר.
+  /// `true` = הקובייה הנגררת תיפול *אחרי* הקובייה הזאת בסדר.
   bool _placeAfter = false;
 
   bool get _isTouch => switch (defaultTargetPlatform) {
@@ -929,14 +993,17 @@ class _ReorderableToolTileState extends State<_ReorderableToolTile> {
     _ => false,
   };
 
-  /// ברשימה אנכית סמן בחצי העליון של השורה מציב לפניה, ובחצי התחתון אחריה.
+  /// בכיוון RTL "לפני" הוא הצד הימני של הקובייה, ולכן סמן בחצי הימני מציב
+  /// לפניה וסמן בחצי השמאלי מציב אחריה.
   void _updateSide(ToolCatalogEntry source, Offset globalPointer) {
-    // Flutter מדווח על תזוזה גם ליעדים שנדחו, כולל השורה הנגררת עצמה.
+    // Flutter מדווח על תזוזה גם ליעדים שנדחו, כולל הקובייה הנגררת עצמה.
     if (!canReorderBetween(source, widget.entry)) return;
     final box = context.findRenderObject() as RenderBox?;
     if (box == null || !box.hasSize) return;
     final local = box.globalToLocal(globalPointer);
-    final placeAfter = local.dy >= box.size.height / 2;
+    final isRtl = Directionality.of(context) == TextDirection.rtl;
+    final inLeadingHalf = local.dx < box.size.width / 2;
+    final placeAfter = isRtl ? inLeadingHalf : !inLeadingHalf;
     if (placeAfter != _placeAfter) setState(() => _placeAfter = placeAfter);
   }
 
@@ -988,16 +1055,16 @@ class _ReorderableToolTileState extends State<_ReorderableToolTile> {
 /// מרחק התזוזה שממנו לחיצה נחשבת גרירה.
 ///
 /// ה-`Draggable` הרגיל תופס את המחווה כבר בפיקסל אחד בעכבר, ואז לחיצה שבה
-/// היד רעדה קלות אינה מגיעה ללחצן שבשורה — הכלי לא נפתח והתפריט לא נפתח.
+/// היד רעדה קלות אינה מגיעה ללחצן שבקובייה — הכלי לא נפתח והתפריט לא נפתח.
 const double _kToolDragSlop = 12;
 
-/// עומק אזור הקצה שגרירה בתוכו גוללת את הרשימה, כמו ברצועת הכרטיסיות.
-const double _kListAutoScrollEdge = 40;
+/// עומק אזור הקצה שגרירה בתוכו גוללת את הרשת, כמו ברצועת הכרטיסיות.
+const double _kGridAutoScrollEdge = 40;
 
 /// קצב גלילת הקצה — פיקסלים לכל פעימה (פעימה לכל פריים בקירוב).
-const double _kListAutoScrollStep = 8;
+const double _kGridAutoScrollStep = 8;
 
-const Duration _kListAutoScrollTick = Duration(milliseconds: 16);
+const Duration _kGridAutoScrollTick = Duration(milliseconds: 16);
 
 /// מזהה גרירה מיידי עם סף תזוזה גדול מברירת המחדל. תומך במצביע מדויק בלבד:
 /// במגע הגרירה מתחילה בלחיצה ארוכה, כדי לא לחטוף את הגלילה.
@@ -1051,13 +1118,13 @@ class _SlopDraggable<T extends Object> extends Draggable<T> {
   ) => _SlopMultiDragGestureRecognizer(debugOwner: this)..onStart = onStart;
 }
 
-/// מפתח קו ההוספה שמוצג בגרירה, בצד שאליו השורה תיפול.
+/// מפתח קו ההוספה שמוצג בגרירה, בצד שאליו הקובייה תיפול.
 @visibleForTesting
 const Key kToolDropIndicatorKey = Key('tool-drop-indicator');
 
-/// קו ההוספה בקצה השורה. [placeAfter] ריק = הגרירה אינה מעל השורה הזאת.
+/// קו ההוספה בקצה הקובייה. [placeAfter] ריק = הגרירה אינה מעל הקובייה הזאת.
 class _DropInsertionIndicator extends StatelessWidget {
-  static const double lineHeight = 3;
+  static const double lineWidth = 3;
 
   final bool? placeAfter;
   final Widget child;
@@ -1077,17 +1144,16 @@ class _DropInsertionIndicator extends StatelessWidget {
       children: [
         child,
         PositionedDirectional(
-          // הקו נעצר בשוליים האופקיים של הכרטיס, ולא נמשך אל דופן החלונית.
-          start: kNavTreeSideInset,
-          end: kNavTreeSideInset,
-          top: side ? null : 0,
-          bottom: side ? 0 : null,
+          top: 2,
+          bottom: 2,
+          start: side ? null : 0,
+          end: side ? 0 : null,
           child: Container(
             key: kToolDropIndicatorKey,
-            height: lineHeight,
+            width: lineWidth,
             decoration: BoxDecoration(
               color: cs.primary,
-              borderRadius: BorderRadius.circular(lineHeight),
+              borderRadius: BorderRadius.circular(lineWidth),
             ),
           ),
         ),
@@ -1096,7 +1162,7 @@ class _DropInsertionIndicator extends StatelessWidget {
   }
 }
 
-/// מה שצף מתחת לסמן בזמן גרירת שורה.
+/// מה שצף מתחת לסמן בזמן גרירת קובייה.
 class _ToolDragFeedback extends StatelessWidget {
   final ToolCatalogEntry entry;
 
@@ -1138,21 +1204,34 @@ class _ToolDragFeedback extends StatelessWidget {
   }
 }
 
-/// שורת כלי בעץ הניווט של הפאנל, בעיצוב שורות מסך הספרייה.
+/// קובייה בודדת ברשת הכלים.
 class ToolTile extends StatelessWidget {
-  static const double menuButtonSize = 26;
-  static const double menuIconSize = 15;
+  static const double maxIconSize = 36;
+  static const double minIconSize = 20;
+  static const double menuButtonSize = 24;
+  static const double menuIconSize = 13;
+
+  /// התווית קטנה ובשתי שורות, כדי שרוב הקובייה תישאר לאייקון.
+  static const double labelFontSize = 11;
+  static const double labelLineHeight = 1.2;
+  static const double labelBlockHeight = labelFontSize * labelLineHeight * 2;
+
+  /// גודל האייקון לגובה הפנוי בקובייה: כל מה שנשאר אחרי שתי שורות התווית.
+  /// כך פאנל מצומצם מקטין את האייקון במקום לחתוך את הכתב.
+  static double iconSizeFor(double availableHeight) {
+    if (!availableHeight.isFinite) return maxIconSize;
+    return (availableHeight - AppTokens.spaceXS - labelBlockHeight).clamp(
+      minIconSize,
+      maxIconSize,
+    );
+  }
 
   final ToolCatalogEntry entry;
   final bool isOpen;
   final bool isHighlighted;
   final VoidCallback onTap;
 
-  /// קצות הכרטיס המקובץ — כל קבוצה (כלים / תוספים) נראית ככרטיס אחד רציף.
-  final bool isGroupStart;
-  final bool isGroupEnd;
-
-  /// פעולות תפריט ⋯. ריק = השורה מוצגת בלי כפתור פעולות.
+  /// פעולות תפריט ⋯. ריק = הקובייה מוצגת בלי כפתור פעולות.
   final List<ToolTileAction> actions;
 
   /// מזהה פעימת ההזזה: כל שינוי מריץ אנימציית הדגשה קצרה. 0 = ללא פעימה.
@@ -1167,8 +1246,6 @@ class ToolTile extends StatelessWidget {
     required this.isOpen,
     required this.isHighlighted,
     required this.onTap,
-    this.isGroupStart = true,
-    this.isGroupEnd = true,
     this.actions = const [],
     this.movePulse = 0,
     this.onMenuClosed,
@@ -1176,54 +1253,70 @@ class ToolTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final cs = Theme.of(context).colorScheme;
+    final theme = Theme.of(context);
+    final cs = theme.colorScheme;
     return _MovePulse(
       nonce: movePulse,
-      child: NavTreeGroupCard(
-        isGroupStart: isGroupStart,
-        isGroupEnd: isGroupEnd,
-        child: NavTreeTile.book(
-          title: entry.label,
-          level: 0,
-          isSelected: isHighlighted,
-          icon: entry.icon ?? FluentIcons.puzzle_piece_24_regular,
-          leading: entry.imageIcon == null ? null : _buildImageLeading(context),
-          trailing: _buildTrailing(cs),
-          onTap: onTap,
+      child: AppCard(
+        onTap: onTap,
+        selected: isHighlighted,
+        child: Stack(
+          children: [
+            // האייקון והכותרת ממורכזים כגוש אחד.
+            Center(
+              child: Padding(
+                padding: const EdgeInsets.all(AppTokens.spaceXS),
+                child: LayoutBuilder(
+                  builder: (context, constraints) => Column(
+                    mainAxisSize: MainAxisSize.min,
+                    crossAxisAlignment: CrossAxisAlignment.center,
+                    children: [
+                      _buildIcon(cs, iconSizeFor(constraints.maxHeight)),
+                      const SizedBox(height: AppTokens.spaceXS),
+                      Flexible(
+                        child: Text(
+                          entry.label,
+                          textAlign: TextAlign.center,
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
+                          style: theme.textTheme.bodySmall?.copyWith(
+                            fontSize: labelFontSize,
+                            height: labelLineHeight,
+                            fontWeight: FontWeight.w600,
+                            color: cs.onSurface,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+            if (actions.isNotEmpty)
+              PositionedDirectional(
+                top: 0,
+                end: 0,
+                child: _buildMenuButton(cs),
+              ),
+            if (entry.isDevelopment)
+              PositionedDirectional(
+                bottom: 2,
+                start: 4,
+                child: _Badge(label: 'DEV', color: cs.tertiary),
+              ),
+            if (isOpen)
+              PositionedDirectional(
+                top: 4,
+                start: 4,
+                child: Icon(
+                  FluentIcons.checkmark_circle_16_filled,
+                  size: 12,
+                  color: cs.primary,
+                ),
+              ),
+          ],
         ),
       ),
-    );
-  }
-
-  Widget _buildImageLeading(BuildContext context) => NavTreeTile.iconBox(
-    context,
-    child: ImageIcon(
-      AssetImage(entry.imageIcon!),
-      size: NavTreeTile.iconContentSize,
-      color: Theme.of(context).colorScheme.onSecondaryContainer,
-    ),
-  );
-
-  Widget _buildTrailing(ColorScheme cs) {
-    return Row(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        if (isOpen)
-          Padding(
-            padding: const EdgeInsetsDirectional.only(end: AppTokens.spaceXS),
-            child: Icon(
-              FluentIcons.checkmark_circle_16_filled,
-              size: 14,
-              color: cs.primary,
-            ),
-          ),
-        if (entry.isDevelopment)
-          Padding(
-            padding: const EdgeInsetsDirectional.only(end: AppTokens.spaceXS),
-            child: _Badge(label: 'DEV', color: cs.tertiary),
-          ),
-        if (actions.isNotEmpty) _buildMenuButton(cs),
-      ],
     );
   }
 
@@ -1293,9 +1386,20 @@ class ToolTile extends StatelessWidget {
       null,
     );
   }
+
+  Widget _buildIcon(ColorScheme cs, double iconSize) {
+    if (entry.imageIcon != null) {
+      return ImageIcon(
+        AssetImage(entry.imageIcon!),
+        size: iconSize,
+        color: cs.primary,
+      );
+    }
+    return Icon(entry.icon, size: iconSize, color: cs.primary);
+  }
 }
 
-/// פעימת הדגשה קצרה על שורה שזזה — מראה למשתמש לאן היא נחתה.
+/// פעימת הדגשה קצרה על קובייה שזזה — מראה למשתמש לאן היא נחתה.
 class _MovePulse extends StatefulWidget {
   final int nonce;
   final Widget child;
@@ -1338,20 +1442,23 @@ class _MovePulseState extends State<_MovePulse>
     return AnimatedBuilder(
       animation: _progress,
       // מבנה העץ קבוע גם במנוחה: החלפת מבנה בתחילת הפעימה ובסופה הייתה בונה
-      // את השורה מחדש ומאפסת את מצב הריחוף שלה.
+      // את הקובייה מחדש ומאפסת את מצב הריחוף שלה.
       builder: (context, child) {
         final remaining = 1.0 - _progress.value;
-        return DecoratedBox(
-          decoration: BoxDecoration(
-            borderRadius: AppTokens.borderRadiusAll,
-            boxShadow: [
-              BoxShadow(
-                color: cs.primary.withValues(alpha: 0.35 * remaining),
-                blurRadius: 12 * remaining,
-              ),
-            ],
+        return Transform.scale(
+          scale: 1.0 - 0.06 * remaining,
+          child: DecoratedBox(
+            decoration: BoxDecoration(
+              borderRadius: AppTokens.borderRadiusAll,
+              boxShadow: [
+                BoxShadow(
+                  color: cs.primary.withValues(alpha: 0.35 * remaining),
+                  blurRadius: 12 * remaining,
+                ),
+              ],
+            ),
+            child: child,
           ),
-          child: child,
         );
       },
       child: widget.child,

--- a/lib/tools/view/tools_launcher_panel.dart
+++ b/lib/tools/view/tools_launcher_panel.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:otzaria/plugins/bloc/plugin_system_bloc.dart';
 import 'package:otzaria/plugins/bloc/plugin_system_event.dart';
 import 'package:otzaria/plugins/bloc/plugin_system_state.dart';
@@ -755,8 +756,6 @@ class _ToolsLauncherPanelState extends State<ToolsLauncherPanel> {
         );
         _keyboardColumns = columns;
         final groups = groupToolEntries(entries);
-        var runningIndex = 0;
-
         final theme = Theme.of(context);
         return Focus(
           autofocus: false,
@@ -771,66 +770,109 @@ class _ToolsLauncherPanelState extends State<ToolsLauncherPanel> {
             onAcceptWithDetails: (details) => _dropAtEndOfGroup(details.data),
             builder: (context, _, _) => ScrollConfiguration(
               behavior: const EdgeScrollbarBehavior.right(),
-              child: ListView(
+              child: CustomScrollView(
                 controller: _gridScrollController,
-                // הרווח בימין שמור לפס הגלילה, כדי שלא יעלה על הקוביות.
-                padding: EdgeInsets.only(
-                  right: kToolGridScrollbarGutter,
-                  bottom: bottomInset,
+                slivers: _buildGridSlivers(
+                  groups: groups,
+                  columns: columns,
+                  openToolIds: openToolIds,
+                  bottomInset: bottomInset,
+                  theme: theme,
                 ),
-                children: [
-                  for (var i = 0; i < groups.length; i++) ...[
-                    // קבוצות עוקבות באותה תווית (תוספים לפני/אחרי הכלים המובנים)
-                    // נראות כמקטע אחד — הכותרת והמפריד מוצגים רק במעבר תווית.
-                    if (i > 0 && groups[i].label != groups[i - 1].label)
-                      const Padding(
-                        padding: EdgeInsets.only(
-                          top: AppTokens.spaceMD,
-                          bottom: AppTokens.spaceSM,
-                        ),
-                        child: Divider(height: 1),
-                      ),
-                    if (i == 0 || groups[i].label != groups[i - 1].label)
-                      Padding(
-                        padding: const EdgeInsets.only(
-                          top: AppTokens.spaceSM,
-                          bottom: AppTokens.spaceSM,
-                        ),
-                        child: Text(
-                          groups[i].label,
-                          style: theme.textTheme.titleSmall?.copyWith(
-                            color: theme.colorScheme.secondary,
-                            fontWeight: FontWeight.bold,
-                          ),
-                        ),
-                      ),
-                    GridView.count(
-                      crossAxisCount: columns,
-                      shrinkWrap: true,
-                      physics: const NeverScrollableScrollPhysics(),
-                      mainAxisSpacing: AppTokens.spaceSM,
-                      crossAxisSpacing: AppTokens.spaceSM,
-                      childAspectRatio: 1.0,
-                      children: [
-                        for (var j = 0; j < groups[i].entries.length; j++)
-                          _buildTile(
-                            group: groups[i].entries,
-                            indexInGroup: j,
-                            flatIndex: runningIndex++,
-                            openToolIds: openToolIds,
-                          ),
-                      ],
-                    ),
-                  ],
-                  SizedBox(key: _gridEndKey, height: 0),
-                  const SizedBox(height: AppTokens.spaceMD),
-                ],
               ),
             ),
           ),
         );
       },
     );
+  }
+
+  List<Widget> _buildGridSlivers({
+    required List<ToolGroup> groups,
+    required int columns,
+    required Set<String> openToolIds,
+    required double bottomInset,
+    required ThemeData theme,
+  }) {
+    final slivers = <Widget>[];
+    var runningIndex = 0;
+    for (var i = 0; i < groups.length; i++) {
+      final group = groups[i];
+      final isNewLabel = i == 0 || group.label != groups[i - 1].label;
+      if (i > 0 && isNewLabel) {
+        slivers.add(
+          const SliverPadding(
+            padding: EdgeInsets.only(
+              top: AppTokens.spaceMD,
+              right: kToolGridScrollbarGutter,
+              bottom: AppTokens.spaceSM,
+            ),
+            sliver: SliverToBoxAdapter(child: Divider(height: 1)),
+          ),
+        );
+      }
+      if (isNewLabel) {
+        slivers.add(
+          SliverPadding(
+            padding: const EdgeInsets.only(
+              top: AppTokens.spaceSM,
+              right: kToolGridScrollbarGutter,
+              bottom: AppTokens.spaceSM,
+            ),
+            sliver: SliverToBoxAdapter(
+              child: Text(
+                group.label,
+                style: theme.textTheme.titleSmall?.copyWith(
+                  color: theme.colorScheme.secondary,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ),
+          ),
+        );
+      }
+      final groupStartIndex = runningIndex;
+      runningIndex += group.entries.length;
+      slivers.add(
+        SliverPadding(
+          padding: const EdgeInsets.only(right: kToolGridScrollbarGutter),
+          sliver: SliverGrid(
+            gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+              crossAxisCount: columns,
+              mainAxisSpacing: AppTokens.spaceSM,
+              crossAxisSpacing: AppTokens.spaceSM,
+              childAspectRatio: 1.0,
+            ),
+            delegate: SliverChildBuilderDelegate(
+              (context, index) => _buildTile(
+                group: group.entries,
+                indexInGroup: index,
+                flatIndex: groupStartIndex + index,
+                openToolIds: openToolIds,
+              ),
+              childCount: group.entries.length,
+            ),
+          ),
+        ),
+      );
+    }
+    slivers.add(
+      SliverPadding(
+        padding: EdgeInsets.only(
+          right: kToolGridScrollbarGutter,
+          bottom: bottomInset,
+        ),
+        sliver: SliverToBoxAdapter(
+          child: Column(
+            children: [
+              SizedBox(key: _gridEndKey, height: 0),
+              const SizedBox(height: AppTokens.spaceMD),
+            ],
+          ),
+        ),
+      ),
+    );
+    return slivers;
   }
 
   Widget _buildTile({

--- a/test/tools/tools_launcher_panel_test.dart
+++ b/test/tools/tools_launcher_panel_test.dart
@@ -1148,9 +1148,11 @@ void main() {
       tester,
     ) async {
       await pumpPanel(tester);
-      final listView = tester.widget<ListView>(find.byType(ListView));
+      final padding = tester.widget<SliverPadding>(
+        find.byType(SliverPadding).last,
+      );
       expect(
-        listView.padding,
+        padding.padding,
         EdgeInsets.only(
           right: kToolGridScrollbarGutter,
           bottom: AppInputTokens.height(false) + AppTokens.spaceMD,
@@ -1164,7 +1166,9 @@ void main() {
       await pumpPanel(tester, width: _kDefaultPanelContentWidth);
       expect(tester.takeException(), isNull);
 
-      for (final grid in tester.widgetList<GridView>(find.byType(GridView))) {
+      for (final grid in tester.widgetList<SliverGrid>(
+        find.byType(SliverGrid),
+      )) {
         final delegate =
             grid.gridDelegate as SliverGridDelegateWithFixedCrossAxisCount;
         expect(delegate.crossAxisCount, 4);
@@ -1187,11 +1191,26 @@ void main() {
       );
     });
 
+    testWidgets('רשת ארוכה בונה רק קוביות באזור הנראה', (tester) async {
+      const pluginCount = 120;
+      await pumpPanel(
+        tester,
+        pluginState: PluginSystemLoaded([
+          for (var i = 0; i < pluginCount; i++)
+            _pluginEntry('com.example.p$i', 'תוסף מספר $i').plugin!,
+        ]),
+      );
+
+      expect(find.byType(ToolTile).evaluate().length, greaterThan(0));
+      expect(
+        find.byType(ToolTile).evaluate().length,
+        lessThan(kBuiltInToolsCatalog.length + pluginCount),
+      );
+    });
+
     testWidgets('פס הגלילה מוצמד לימין בשולחן העבודה', (tester) async {
       await _asDesktop(() async {
         await pumpPanel(tester);
-        // הרשת מכילה גם GridView-ים פנימיים, ולכל אחד נבנה פס משלו — כולם
-        // חייבים לשבת בימין, אחרת פס אחד היה מצטייר על הקוביות.
         final scrollbars = tester.widgetList<Scrollbar>(
           find.byType(Scrollbar),
         );
@@ -1606,13 +1625,11 @@ void main() {
 
     // ── issue #929: שחרור בשטח הריק וגלילת קצה ──────────────────────────────
 
-    /// ה-Scrollable של הרשת החיצונית. ה-GridView-ים הפנימיים בונים Scrollable
-    /// משלהם (מושבת), ולכן חייבים את הראשון ולא את כולם.
     ScrollPosition gridPosition(WidgetTester tester) => tester
         .state<ScrollableState>(
           find
               .descendant(
-                of: find.byType(ListView),
+                of: find.byType(CustomScrollView),
                 matching: find.byType(Scrollable),
               )
               .first,
@@ -1629,7 +1646,7 @@ void main() {
         kind: PointerDeviceKind.mouse,
       );
       await tester.pump(const Duration(milliseconds: 50));
-      final grid = tester.getRect(find.byType(ListView));
+      final grid = tester.getRect(find.byType(CustomScrollView));
       await gesture.moveTo(Offset(grid.center.dx, grid.bottom - 8));
       await tester.pump();
       return gesture;
@@ -1728,7 +1745,7 @@ void main() {
           kind: PointerDeviceKind.mouse,
         );
         await tester.pump(const Duration(milliseconds: 50));
-        final grid = tester.getRect(find.byType(ListView));
+        final grid = tester.getRect(find.byType(CustomScrollView));
         await gesture.moveTo(Offset(grid.center.dx, grid.bottom - 10));
         await tester.pump();
         for (var i = 0; i < 10; i++) {
@@ -1757,9 +1774,7 @@ void main() {
         position.jumpTo(200);
         await tester.pump();
 
-        final grid = tester.getRect(find.byType(ListView));
-        // הרשת בונה גם קוביות שמעל ה-viewport, ולכן הקובייה נבחרת לפי מיקומה
-        // בפועל: גרירה אל הקצה מקובייה סמוכה קצרה מסף ה-slop ואינה מזוהה.
+        final grid = tester.getRect(find.byType(CustomScrollView));
         final tiles = find.byType(ToolTile);
         final index = List.generate(tiles.evaluate().length, (i) => i)
             .firstWhere(

--- a/test/tools/tools_launcher_panel_test.dart
+++ b/test/tools/tools_launcher_panel_test.dart
@@ -12,7 +12,6 @@ import 'package:otzaria/plugins/bloc/plugin_system_event.dart';
 import 'package:otzaria/plugins/bloc/plugin_system_state.dart';
 import 'package:otzaria/plugins/models/installed_plugin.dart';
 import 'package:otzaria/plugins/models/plugin_manifest.dart';
-import 'package:otzaria/plugins/view/widgets/plugin_drop_zone.dart';
 import 'package:otzaria/settings/engine/settings_bloc.dart';
 import 'package:otzaria/settings/engine/settings_event.dart';
 import 'package:otzaria/settings/engine/settings_state.dart';
@@ -23,8 +22,8 @@ import 'package:otzaria/theme/theme_exports.dart';
 import 'package:otzaria/tools/built_in_tools_catalog.dart';
 import 'package:otzaria/tools/tool_catalog_entry.dart';
 import 'package:otzaria/tools/view/tools_launcher_panel.dart';
+import 'package:otzaria/widgets/layout/app_card.dart';
 import 'package:otzaria/widgets/layout/context_overlay_panel.dart';
-import 'package:otzaria/widgets/lists/nav_tree_tile.dart';
 
 class _MockSettingsBloc extends MockBloc<SettingsEvent, SettingsState>
     implements SettingsBloc {}
@@ -45,7 +44,7 @@ ToolCatalogEntry _entry(
   toolId: toolId,
   label: label,
   order: 10,
-  icon: icon ?? OtzariaIcons.calendar_24_regular,
+  icon: icon ?? FluentIcons.calendar_24_regular,
   imageIcon: imageIcon,
 );
 
@@ -99,14 +98,15 @@ ToolCatalogEntry _pluginEntry(
   ),
 );
 
-/// עוטף שורה בודדת ברוחב פאנל, כמו שהרשימה נותנת לה.
-Widget _tileHost(ToolTile tile, {double width = 320}) => MaterialApp(
+/// עוטף קובייה בודדת בקופסה מרובעת, כדי שהבדיקות ימדדו את אותן אילוצים
+/// שהרשת נותנת (childAspectRatio: 1.0).
+Widget _tileHost(ToolTile tile, {double size = 100}) => MaterialApp(
   theme: ThemeData(colorSchemeSeed: Colors.blue),
   home: Directionality(
     textDirection: TextDirection.rtl,
     child: Scaffold(
       body: Center(
-        child: SizedBox(width: width, child: tile),
+        child: SizedBox(width: size, height: size, child: tile),
       ),
     ),
   ),
@@ -148,23 +148,21 @@ Widget _launcherHost({
   ),
 );
 
-/// מציאת כפתור ⋯ של שורה לפי התווית שכתובה בה.
+/// מציאת כפתור ⋯ של קובייה לפי התווית שכתובה בה.
 Finder _menuButtonOf(String label) => find.descendant(
   of: find.ancestor(of: find.text(label), matching: find.byType(ToolTile)),
   matching: find.byIcon(FluentIcons.more_vertical_24_regular),
 );
 
-bool _isRowSelected(WidgetTester tester, String label) => tester
-    .widget<NavTreeTile>(
-      find
-          .ancestor(of: find.text(label), matching: find.byType(NavTreeTile))
-          .first,
+bool _isCardSelected(WidgetTester tester, String label) => tester
+    .widget<AppCard>(
+      find.ancestor(of: find.text(label), matching: find.byType(AppCard)).first,
     )
-    .isSelected;
+    .selected;
 
-int _selectedRowCount(WidgetTester tester) => tester
-    .widgetList<NavTreeTile>(find.byType(NavTreeTile))
-    .where((tile) => tile.isSelected)
+int _selectedCardCount(WidgetTester tester) => tester
+    .widgetList<AppCard>(find.byType(AppCard))
+    .where((card) => card.selected)
     .length;
 
 /// מריץ גוף בדיקה כפלטפורמת שולחן עבודה. האיפוס חייב לקרות בתוך גוף הבדיקה,
@@ -275,7 +273,7 @@ void main() {
     expect(backgroundFocusNode.hasFocus, isFalse);
   });
 
-  testWidgets('חצים ו-Enter פותחים את השורה המסומנת משדה החיפוש', (
+  testWidgets('חצים ו-Enter פותחים את הקובייה המסומנת משדה החיפוש', (
     tester,
   ) async {
     final settingsBloc = _MockSettingsBloc();
@@ -314,7 +312,7 @@ void main() {
 
     await tester.enterText(find.byType(TextField), 'ה');
     await tester.pump();
-    await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+    await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
     await tester.pump();
     await tester.sendKeyEvent(LogicalKeyboardKey.enter);
     await tester.pump();
@@ -535,6 +533,26 @@ void main() {
     });
   });
 
+  group('toolGridColumns', () {
+    test('רוחב צר נעצר על מינימום 2 עמודות', () {
+      expect(toolGridColumns(0), 2);
+      expect(toolGridColumns(kToolTileTargetWidth), 2);
+    });
+
+    test('גדל עם הרוחב', () {
+      expect(toolGridColumns(kToolTileTargetWidth * 3), 3);
+      expect(toolGridColumns(kToolTileTargetWidth * 4), 4);
+    });
+
+    test('רוחב גדול נעצר על מקסימום 5 עמודות', () {
+      expect(toolGridColumns(kToolTileTargetWidth * 20), 5);
+    });
+
+    test('רוחב חלקי מעגל כלפי מטה', () {
+      expect(toolGridColumns(kToolTileTargetWidth * 3.9), 3);
+    });
+  });
+
   group('nextHighlightIndex', () {
     test('זז בתוך הטווח', () {
       expect(nextHighlightIndex(current: 0, delta: 1, total: 5), 1);
@@ -560,8 +578,8 @@ void main() {
     });
 
     // ממצב "אין סימון" כל חץ מסמן את הראשונה; בלי זה חץ למטה היה מדלג שורה
-    // שלמה ומסמן את השורה החמישית.
-    test('ממצב ללא סימון כל חץ מסמן את השורה הראשונה', () {
+    // שלמה ומסמן את הקובייה החמישית.
+    test('ממצב ללא סימון כל חץ מסמן את הקובייה הראשונה', () {
       expect(nextHighlightIndex(current: -1, delta: 1, total: 7), 0);
       expect(nextHighlightIndex(current: -1, delta: 5, total: 7), 0);
       expect(nextHighlightIndex(current: -1, delta: -5, total: 7), 0);
@@ -573,8 +591,6 @@ void main() {
       ToolCatalogEntry? entry,
       bool isOpen = false,
       bool isHighlighted = false,
-      bool isGroupStart = true,
-      bool isGroupEnd = true,
       VoidCallback? onTap,
       List<ToolTileAction> actions = const [],
       int movePulse = 0,
@@ -582,8 +598,6 @@ void main() {
       entry: entry ?? _entry('builtin.calendar', 'לוח שנה'),
       isOpen: isOpen,
       isHighlighted: isHighlighted,
-      isGroupStart: isGroupStart,
-      isGroupEnd: isGroupEnd,
       onTap: onTap ?? () {},
       actions: actions,
       movePulse: movePulse,
@@ -594,52 +608,101 @@ void main() {
       expect(find.text('לוח שנה'), findsOneWidget);
     });
 
-    // השורה היא שורת עץ ניווט בכרטיס מקובץ, כמו בעץ הספרייה ובחלוניות הניווט.
-    testWidgets('בנויה מ-NavTreeTile בתוך NavTreeGroupCard', (tester) async {
+    // אותו כרטיס כמו בקוביות הספרייה — צבע הכרטיס שבערכת הנושא, בלי מסגרת.
+    testWidgets('הקובייה על צבע הכרטיס של הספרייה', (tester) async {
       await tester.pumpWidget(_tileHost(buildTile()));
-      expect(find.byType(NavTreeGroupCard), findsOneWidget);
-      expect(find.byType(NavTreeTile), findsOneWidget);
+      expect(find.byType(AppCard), findsOneWidget);
+
+      final context = tester.element(find.byType(ToolTile));
+      final material = tester.widget<Material>(
+        find.descendant(
+          of: find.byType(AppCard),
+          matching: find.byType(Material),
+        ),
+      );
+      expect(material.color, AppSurfaces.card(context));
+      expect(material.shape, isNull);
     });
 
-    // קצות הכרטיס נקבעים בקצות הקבוצה — שורה באמצע נשארת מחוברת לשכנותיה.
-    testWidgets('קצות הכרטיס עוברים לשורה', (tester) async {
-      await tester.pumpWidget(
-        _tileHost(buildTile(isGroupStart: false, isGroupEnd: false)),
+    // סדר גודל של סמל תוכנה: בקובייה רגילה האייקון מגיע לגודלו המרבי.
+    testWidgets('האייקון מגיע לגודל המרבי בקובייה רגילה', (tester) async {
+      await tester.pumpWidget(_tileHost(buildTile()));
+
+      final icon = tester.widget<Icon>(
+        find.byIcon(FluentIcons.calendar_24_regular),
       );
-      final card = tester.widget<NavTreeGroupCard>(
-        find.byType(NavTreeGroupCard),
-      );
-      expect(card.isGroupStart, isFalse);
-      expect(card.isGroupEnd, isFalse);
+      expect(icon.size, ToolTile.iconSizeFor(100 - AppTokens.spaceXS * 2));
+      expect(icon.size, ToolTile.maxIconSize);
     });
 
-    // האייקון יושב בקופסת האייקון של שורת העץ, ולא כסמל גדול על רקע החלונית.
-    testWidgets('האייקון בקופסת האייקון של שורת העץ', (tester) async {
+    // בפאנל מצומצם האייקון מתכווץ, אחרת שתי שורות התווית נחתכות.
+    testWidgets('קובייה קטנה מקבלת אייקון קטן ללא חריגת פריסה', (tester) async {
+      await tester.pumpWidget(_tileHost(buildTile(), size: 70));
+      expect(tester.takeException(), isNull);
+
+      final icon = tester.widget<Icon>(
+        find.byIcon(FluentIcons.calendar_24_regular),
+      );
+      expect(icon.size, lessThan(ToolTile.maxIconSize));
+      expect(icon.size, greaterThanOrEqualTo(ToolTile.minIconSize));
+    });
+
+    // התווית קטנה מברירת המחדל של bodySmall, כדי לפנות מקום לאייקון.
+    testWidgets('תווית הקובייה בגודל 11', (tester) async {
+      await tester.pumpWidget(_tileHost(buildTile()));
+      final label = tester.widget<Text>(find.text('לוח שנה'));
+      expect(label.style?.fontSize, ToolTile.labelFontSize);
+    });
+
+    // האייקון עומד על רקע הכרטיס עצמו — בלי מעטפת מרובעת סביבו.
+    testWidgets('האייקון בצבע primary ובלי מעטפת מרובעת', (tester) async {
       await tester.pumpWidget(_tileHost(buildTile()));
       final context = tester.element(find.byType(ToolTile));
       final cs = Theme.of(context).colorScheme;
 
       final icon = tester.widget<Icon>(
-        find.byIcon(OtzariaIcons.calendar_24_regular),
+        find.byIcon(FluentIcons.calendar_24_regular),
       );
-      expect(icon.color, cs.onSecondaryContainer);
-      expect(icon.size, NavTreeTile.iconContentSize);
+      expect(icon.color, cs.primary);
+      expect(
+        find.ancestor(
+          of: find.byIcon(FluentIcons.calendar_24_regular),
+          matching: find.byType(Container),
+        ),
+        findsNothing,
+      );
     });
 
-    // בשורה האייקון מוביל את הטקסט — ב-RTL הוא מימינו.
-    testWidgets('האייקון מימין לתווית ובאותו גובה', (tester) async {
+    testWidgets('האייקון והטקסט ממורכזים אופקית בקובייה', (tester) async {
       await tester.pumpWidget(_tileHost(buildTile()));
 
+      final tileCenter = tester.getCenter(find.byType(ToolTile));
       final iconCenter = tester.getCenter(
-        find.byIcon(OtzariaIcons.calendar_24_regular),
+        find.byIcon(FluentIcons.calendar_24_regular),
       );
       final textCenter = tester.getCenter(find.text('לוח שנה'));
 
-      expect(iconCenter.dx, greaterThan(textCenter.dx));
-      expect(iconCenter.dy, moreOrLessEquals(textCenter.dy, epsilon: 1));
+      expect(iconCenter.dx, moreOrLessEquals(tileCenter.dx, epsilon: 0.5));
+      expect(textCenter.dx, moreOrLessEquals(tileCenter.dx, epsilon: 0.5));
     });
 
-    testWidgets('תווית ארוכה אינה גולשת מהשורה', (tester) async {
+    // גוש האייקון+טקסט ממורכז אנכית כיחידה אחת — לא כל רכיב לחוד.
+    testWidgets('גוש התוכן ממורכז אנכית', (tester) async {
+      await tester.pumpWidget(_tileHost(buildTile()));
+
+      final tileCenter = tester.getCenter(find.byType(ToolTile));
+      final iconBoxRect = tester.getRect(
+        find.byIcon(FluentIcons.calendar_24_regular),
+      );
+      final textRect = tester.getRect(find.text('לוח שנה'));
+
+      final blockCenter = (iconBoxRect.top + textRect.bottom) / 2;
+      expect(iconBoxRect.top, lessThan(tileCenter.dy));
+      expect(textRect.bottom, greaterThan(tileCenter.dy));
+      expect(blockCenter, moreOrLessEquals(tileCenter.dy, epsilon: 1));
+    });
+
+    testWidgets('תווית ארוכה אינה גולשת מהקובייה', (tester) async {
       await tester.pumpWidget(
         _tileHost(
           buildTile(
@@ -664,7 +727,7 @@ void main() {
       );
       expect(find.byType(ImageIcon), findsOneWidget);
       final imageIcon = tester.widget<ImageIcon>(find.byType(ImageIcon));
-      expect(imageIcon.size, NavTreeTile.iconContentSize);
+      expect(imageIcon.size, ToolTile.iconSizeFor(100 - AppTokens.spaceXS * 2));
     });
 
     testWidgets('לחיצה מפעילה את onTap', (tester) async {
@@ -721,8 +784,8 @@ void main() {
       expect(find.text('DEV'), findsOneWidget);
     });
 
-    // התווית כתובה בשורה — טולטיפ ריחוף עליה היה כפילות מציקה.
-    testWidgets('אין טולטיפ ריחוף על השורה', (tester) async {
+    // התווית כתובה בקובייה — טולטיפ ריחוף עליה היה כפילות מציקה.
+    testWidgets('אין טולטיפ ריחוף על הקובייה', (tester) async {
       await tester.pumpWidget(_tileHost(buildTile()));
       expect(find.byType(Tooltip), findsNothing);
 
@@ -734,7 +797,7 @@ void main() {
       expect(find.byType(Tooltip), findsNothing);
     });
 
-    // הטולטיפ היחיד שנשאר בשורה הוא של כפתור הפעולות, כמו בספרייה.
+    // הטולטיפ היחיד שנשאר בקובייה הוא של כפתור הפעולות, כמו בספרייה.
     testWidgets('הטולטיפ היחיד הוא של כפתור הפעולות', (tester) async {
       await tester.pumpWidget(
         _tileHost(
@@ -755,12 +818,12 @@ void main() {
       );
     });
 
-    testWidgets('סימון מקלדת מסמן את השורה כנבחרת', (tester) async {
+    testWidgets('סימון מקלדת מסמן את הכרטיס כנבחר', (tester) async {
       await tester.pumpWidget(_tileHost(buildTile()));
-      expect(_isRowSelected(tester, 'לוח שנה'), isFalse);
+      expect(tester.widget<AppCard>(find.byType(AppCard)).selected, isFalse);
 
       await tester.pumpWidget(_tileHost(buildTile(isHighlighted: true)));
-      expect(_isRowSelected(tester, 'לוח שנה'), isTrue);
+      expect(tester.widget<AppCard>(find.byType(AppCard)).selected, isTrue);
     });
 
     testWidgets('בלי פעולות אין כפתור ⋯', (tester) async {
@@ -784,6 +847,7 @@ void main() {
               ),
             ],
           ),
+          size: 140,
         ),
       );
 
@@ -797,7 +861,7 @@ void main() {
     });
 
     // לחיצה על ⋯ אינה אמורה לפתוח את הכלי.
-    testWidgets('לחיצה על ⋯ אינה מפעילה את onTap של השורה', (tester) async {
+    testWidgets('לחיצה על ⋯ אינה מפעילה את onTap של הקובייה', (tester) async {
       var taps = 0;
       await tester.pumpWidget(
         _tileHost(
@@ -811,6 +875,7 @@ void main() {
               ),
             ],
           ),
+          size: 140,
         ),
       );
 
@@ -826,11 +891,12 @@ void main() {
             actions: const [
               ToolTileAction(
                 icon: FluentIcons.arrow_left_24_regular,
-                label: 'הזז למעלה',
+                label: 'הזז אחורה',
                 onTap: null,
               ),
             ],
           ),
+          size: 140,
         ),
       );
 
@@ -838,15 +904,15 @@ void main() {
       await tester.pumpAndSettle();
       final item = tester.widget<PopupMenuItem<VoidCallback>>(
         find.ancestor(
-          of: find.text('הזז למעלה'),
+          of: find.text('הזז אחורה'),
           matching: find.byType(PopupMenuItem<VoidCallback>),
         ),
       );
       expect(item.enabled, isFalse);
     });
 
-    // סדר הזנב: סימן "פתוח" ואחריו הכפתור, בקצה השמאלי של השורה ב-RTL.
-    testWidgets('כפתור ⋯ בקצה השורה, וסימן "פתוח" לפניו', (tester) async {
+    // מקום הכפתור נבחר כך שלא יתנגש בסימן "פתוח" שבפינה הנגדית.
+    testWidgets('כפתור ⋯ יושב בפינה השמאלית-עליונה של הקובייה', (tester) async {
       await tester.pumpWidget(
         _tileHost(
           buildTile(
@@ -859,6 +925,7 @@ void main() {
               ),
             ],
           ),
+          size: 140,
         ),
       );
 
@@ -870,11 +937,11 @@ void main() {
         find.byIcon(FluentIcons.checkmark_circle_16_filled),
       );
       expect(button.center.dx, lessThan(tile.center.dx));
-      expect(button.center.dy, moreOrLessEquals(tile.center.dy, epsilon: 2));
+      expect(button.center.dy, lessThan(tile.center.dy));
       expect(
         button.center.dx,
         lessThan(openMark.center.dx),
-        reason: 'סימן "פתוח" קודם לכפתור בזנב השורה',
+        reason: 'סימן "פתוח" יושב בפינה הנגדית ואינו מתנגש בכפתור',
       );
       // האייקון קטן משטח הלחיצה — הכפתור נשאר נוח ללחיצה גם כשהנקודות זעירות.
       expect(button.width, lessThan(ToolTile.menuButtonSize));
@@ -899,24 +966,25 @@ void main() {
                 children: [
                   ToolTileAction(
                     icon: FluentIcons.arrow_left_24_regular,
-                    label: 'הזז למעלה',
+                    label: 'הזז אחורה',
                     onTap: () => moved++,
                   ),
                 ],
               ),
             ],
           ),
+          size: 140,
         ),
       );
 
       await tester.tap(find.byIcon(FluentIcons.more_vertical_24_regular));
       await tester.pumpAndSettle();
       expect(find.text('הזזה'), findsOneWidget);
-      expect(find.text('הזז למעלה'), findsNothing);
+      expect(find.text('הזז אחורה'), findsNothing);
 
       await tester.tap(find.text('הזזה'));
       await tester.pumpAndSettle();
-      await tester.tap(find.text('הזז למעלה'));
+      await tester.tap(find.text('הזז אחורה'));
       await tester.pumpAndSettle();
       expect(moved, 1);
     });
@@ -933,13 +1001,14 @@ void main() {
                 children: [
                   ToolTileAction(
                     icon: FluentIcons.arrow_left_24_regular,
-                    label: 'הזז למעלה',
+                    label: 'הזז אחורה',
                     onTap: null,
                   ),
                 ],
               ),
             ],
           ),
+          size: 140,
         ),
       );
 
@@ -951,7 +1020,7 @@ void main() {
       // היא מרונדרת כשורה רגילה מעומעמת — בלי תת-פעולות בכלל.
       await tester.tap(find.text('הזזה'));
       await tester.pumpAndSettle();
-      expect(find.text('הזז למעלה'), findsNothing);
+      expect(find.text('הזז אחורה'), findsNothing);
     });
 
     testWidgets('פעימת הזזה אינה זורקת ומתייצבת', (tester) async {
@@ -1020,43 +1089,30 @@ void main() {
       await tester.pumpAndSettle();
     }
 
-    /// פותח את תפריט השורה ואת תת-תפריט "הזזה" שבתוכו.
+    /// פותח את תפריט הקובייה ואת תת-תפריט "הזזה" שבתוכו.
     Future<void> openMoveSubmenu(WidgetTester tester, String label) async {
       await openMenu(tester, label);
       await tester.tap(find.text('הזזה'));
       await tester.pumpAndSettle();
     }
 
-    testWidgets('עיצוב הרשימה נשאר בתוך אזור השלכת תוספים', (tester) async {
-      await pumpPanel(tester);
+    // ── סימון מקלדת ─────────────────────────────────────────────────────────
 
-      expect(find.byType(PluginDropZone), findsOneWidget);
-      expect(
-        find.descendant(
-          of: find.byType(PluginDropZone),
-          matching: find.byType(NavTreeTile),
-        ),
-        findsWidgets,
-      );
-    });
-
-    // ── סימון מקלדת ────────────────────────────────────────────────────────
-
-    testWidgets('בפתיחה אין שורה מסומנת — לוח שנה לא נראה נבחר', (
+    testWidgets('בפתיחה אין קובייה מסומנת — לוח שנה לא נראה נבחר', (
       tester,
     ) async {
       await pumpPanel(tester);
-      expect(_selectedRowCount(tester), 0);
-      expect(_isRowSelected(tester, 'לוח שנה'), isFalse);
+      expect(_selectedCardCount(tester), 0);
+      expect(_isCardSelected(tester, 'לוח שנה'), isFalse);
     });
 
-    testWidgets('החץ הראשון מסמן את השורה הראשונה', (tester) async {
+    testWidgets('החץ הראשון מסמן את הקובייה הראשונה', (tester) async {
       await pumpPanel(tester);
-      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
       await tester.pump();
 
-      expect(_selectedRowCount(tester), 1);
-      expect(_isRowSelected(tester, 'לוח שנה'), isTrue);
+      expect(_selectedCardCount(tester), 1);
+      expect(_isCardSelected(tester, 'לוח שנה'), isTrue);
     });
 
     testWidgets('חיפוש מסמן את התוצאה הראשונה', (tester) async {
@@ -1064,8 +1120,8 @@ void main() {
       await tester.enterText(find.byType(TextField), 'גימ');
       await tester.pump();
 
-      expect(_selectedRowCount(tester), 1);
-      expect(_isRowSelected(tester, 'גימטריה'), isTrue);
+      expect(_selectedCardCount(tester), 1);
+      expect(_isCardSelected(tester, 'גימטריה'), isTrue);
     });
 
     testWidgets('ניקוי החיפוש מחזיר למצב ללא סימון', (tester) async {
@@ -1075,7 +1131,7 @@ void main() {
       await tester.enterText(find.byType(TextField), '');
       await tester.pump();
 
-      expect(_selectedRowCount(tester), 0);
+      expect(_selectedCardCount(tester), 0);
     });
 
     testWidgets('Enter בלי סימון פותח את הכלי הראשון', (tester) async {
@@ -1088,68 +1144,54 @@ void main() {
 
     // ── פס הגלילה ───────────────────────────────────────────────────────────
 
-    // השוליים האופקיים נמצאים בכרטיסי העץ עצמם, ולכן הרשימה מוסיפה רק את
-    // שולי העץ האנכיים ואת המקום לסרגל הצף.
-    testWidgets('הרשימה מקבלת את שולי העץ ומרווח מתחת לסרגל הצף', (
+    testWidgets('הרשת שומרת מרווח בימין לפס הגלילה ומתחת לסרגל הצף', (
       tester,
     ) async {
       await pumpPanel(tester);
       final listView = tester.widget<ListView>(find.byType(ListView));
       expect(
         listView.padding,
-        kNavTreeListPadding +
-            EdgeInsets.only(
-              bottom: AppInputTokens.height(false) + AppTokens.spaceMD,
-            ),
-      );
-    });
-
-    // ברוחב הפאנל שבברירת מחדל השורות תופסות את כל רוחב הרשימה, פחות שוליי
-    // כרטיסי העץ.
-    testWidgets('השורות תופסות את רוחב הפאנל פחות שולי העץ', (tester) async {
-      await pumpPanel(tester, width: _kDefaultPanelContentWidth);
-      expect(tester.takeException(), isNull);
-
-      final rowWidth = tester.getSize(find.byType(NavTreeTile).first).width;
-      expect(
-        rowWidth,
-        moreOrLessEquals(
-          _kDefaultPanelContentWidth - kNavTreeSideInset * 2,
-          epsilon: 0.5,
+        EdgeInsets.only(
+          right: kToolGridScrollbarGutter,
+          bottom: AppInputTokens.height(false) + AppTokens.spaceMD,
         ),
       );
     });
 
-    testWidgets('כל קבוצה מוצגת תחת כותרת עץ אחת', (tester) async {
-      await pumpPanel(tester);
-      expect(find.byType(NavTreeHeader), findsNWidgets(2));
-      expect(find.text(kBuiltInToolsGroupLabel), findsOneWidget);
-      expect(find.text(kPluginsGroupLabel), findsOneWidget);
-    });
+    // ברוחב הפאנל שבברירת מחדל נכנסות ארבע קוביות בשורה, הקובייה נשארת
+    // ריבוע, והאייקון נכנס בה בשלמותו יחד עם שתי שורות התווית.
+    testWidgets('ברוחב הפאנל שבברירת מחדל — 4 קוביות בשורה', (tester) async {
+      await pumpPanel(tester, width: _kDefaultPanelContentWidth);
+      expect(tester.takeException(), isNull);
 
-    // קצות הכרטיס מסמנים גם את קצות הקבוצה — הקבוצה נראית ככרטיס אחד רציף.
-    testWidgets('רק השורה הראשונה והאחרונה בקבוצה מעוגלות', (tester) async {
-      await pumpPanel(tester);
-      final cards = tester
-          .widgetList<NavTreeGroupCard>(find.byType(NavTreeGroupCard))
-          .toList();
-      final builtIns = cards.take(kBuiltInToolsCatalog.length).toList();
+      for (final grid in tester.widgetList<GridView>(find.byType(GridView))) {
+        final delegate =
+            grid.gridDelegate as SliverGridDelegateWithFixedCrossAxisCount;
+        expect(delegate.crossAxisCount, 4);
+        expect(delegate.childAspectRatio, 1.0);
+      }
 
-      expect(builtIns.first.isGroupStart, isTrue);
-      expect(builtIns.last.isGroupEnd, isTrue);
-      expect(
-        builtIns.sublist(1).every((card) => !card.isGroupStart),
-        isTrue,
+      final tileSize = tester.getSize(find.byType(ToolTile).first);
+      expect(tileSize.width, moreOrLessEquals(tileSize.height, epsilon: 0.01));
+      final tileHeight = tileSize.height;
+      final icon = tester.widget<Icon>(
+        find.descendant(
+          of: find.byType(ToolTile).first,
+          matching: find.byIcon(OtzariaIcons.calendar_24_regular),
+        ),
       );
+      expect(icon.size, ToolTile.maxIconSize);
       expect(
-        builtIns.sublist(0, builtIns.length - 1).every((c) => !c.isGroupEnd),
-        isTrue,
+        ToolTile.maxIconSize + AppTokens.spaceXS + ToolTile.labelBlockHeight,
+        lessThan(tileHeight - AppTokens.spaceXS * 2),
       );
     });
 
     testWidgets('פס הגלילה מוצמד לימין בשולחן העבודה', (tester) async {
       await _asDesktop(() async {
         await pumpPanel(tester);
+        // הרשת מכילה גם GridView-ים פנימיים, ולכל אחד נבנה פס משלו — כולם
+        // חייבים לשבת בימין, אחרת פס אחד היה מצטייר על הקוביות.
         final scrollbars = tester.widgetList<Scrollbar>(
           find.byType(Scrollbar),
         );
@@ -1165,7 +1207,7 @@ void main() {
 
     // ── תוכן תפריט ⋯ ────────────────────────────────────────────────────────
 
-    testWidgets('לכל שורה יש כפתור ⋯', (tester) async {
+    testWidgets('לכל קובייה יש כפתור ⋯', (tester) async {
       await pumpPanel(tester);
       expect(
         find.byIcon(FluentIcons.more_vertical_24_regular),
@@ -1184,7 +1226,7 @@ void main() {
       expect(find.text('מחק תוסף'), findsNothing);
       expect(find.text('השבת'), findsNothing);
       // פעולות ההזזה עצמן חבויות בתת-תפריט ואינן מציפות את התפריט הראשי.
-      expect(find.text('הזז למטה'), findsNothing);
+      expect(find.text('הזז אחורה'), findsNothing);
       expect(find.text('הזז לסוף'), findsNothing);
     });
 
@@ -1192,8 +1234,8 @@ void main() {
       await pumpPanel(tester);
       await openMoveSubmenu(tester, 'גימטריה');
 
-      expect(find.text('הזז למטה'), findsOneWidget);
-      expect(find.text('הזז למעלה'), findsOneWidget);
+      expect(find.text('הזז אחורה'), findsOneWidget);
+      expect(find.text('הזז קדימה'), findsOneWidget);
       expect(find.text('הזז לתחילה'), findsOneWidget);
       expect(find.text('הזז לסוף'), findsOneWidget);
     });
@@ -1238,11 +1280,11 @@ void main() {
       expect(find.text('הסר מסרגל הניווט'), findsOneWidget);
     });
 
-    // בראש הקבוצה אין "קדימה" — הלחיצה על פריט מושבת אינה משנה סדר.
-    testWidgets('בראש הקבוצה "הזז למעלה" אינו עושה דבר', (tester) async {
+    // בראש הקבוצה אין "אחורה" — הלחיצה על פריט מושבת אינה משנה סדר.
+    testWidgets('בראש הקבוצה "הזז אחורה" אינו עושה דבר', (tester) async {
       await pumpPanel(tester);
       await openMoveSubmenu(tester, 'לוח שנה');
-      await tapMenuItem(tester, 'הזז למעלה');
+      await tapMenuItem(tester, 'הזז אחורה');
 
       expect(
         settingsBloc.recorded.whereType<UpdateBuiltInToolsOrder>(),
@@ -1250,10 +1292,10 @@ void main() {
       );
     });
 
-    testWidgets('בסוף הקבוצה "הזז למטה" אינו עושה דבר', (tester) async {
+    testWidgets('בסוף הקבוצה "הזז קדימה" אינו עושה דבר', (tester) async {
       await pumpPanel(tester);
       await openMoveSubmenu(tester, 'ביוגרפיות');
-      await tapMenuItem(tester, 'הזז למטה');
+      await tapMenuItem(tester, 'הזז קדימה');
 
       expect(
         settingsBloc.recorded.whereType<UpdateBuiltInToolsOrder>(),
@@ -1263,10 +1305,10 @@ void main() {
 
     // ── פעולות בפועל ────────────────────────────────────────────────────────
 
-    testWidgets('"הזז למטה" על כלי מובנה שומר סדר חדש', (tester) async {
+    testWidgets('"הזז קדימה" על כלי מובנה שומר סדר חדש', (tester) async {
       await pumpPanel(tester);
       await openMoveSubmenu(tester, 'לוח שנה');
-      await tapMenuItem(tester, 'הזז למטה');
+      await tapMenuItem(tester, 'הזז קדימה');
 
       final event = settingsBloc.recorded.whereType<UpdateBuiltInToolsOrder>();
       expect(event, hasLength(1));
@@ -1281,10 +1323,10 @@ void main() {
       );
     });
 
-    testWidgets('"הזז למעלה" על כלי מובנה מקדים אותו לשכנו', (tester) async {
+    testWidgets('"הזז אחורה" על כלי מובנה מקדים אותו לשכנו', (tester) async {
       await pumpPanel(tester);
       await openMoveSubmenu(tester, 'הערות אישיות');
-      await tapMenuItem(tester, 'הזז למעלה');
+      await tapMenuItem(tester, 'הזז אחורה');
 
       final order = settingsBloc.recorded
           .whereType<UpdateBuiltInToolsOrder>()
@@ -1381,10 +1423,10 @@ void main() {
       expect(event.builtInToolsPinnedToNavRail, {'builtin.gematria'});
     });
 
-    testWidgets('"הזז למטה" על תוסף משגר סידור תוספים', (tester) async {
+    testWidgets('"הזז קדימה" על תוסף משגר סידור תוספים', (tester) async {
       await pumpPanel(tester);
       await openMoveSubmenu(tester, 'תוסף א');
-      await tapMenuItem(tester, 'הזז למטה');
+      await tapMenuItem(tester, 'הזז קדימה');
 
       final event = pluginSystemBloc.recorded
           .whereType<ReorderPluginsRequested>()
@@ -1408,8 +1450,8 @@ void main() {
 
     // ── גרירה לסידור ────────────────────────────────────────────────────────
 
-    /// לחיצה, גרירה ועזיבה. [beforeTarget] קובע לאיזה חצי של שורת היעד
-    /// מגיעים — החצי העליון מציב לפניה והתחתון אחריה.
+    /// לחיצה, גרירה ועזיבה. [beforeTarget] קובע לאיזה חצי של קוביית היעד
+    /// מגיעים — בכיוון RTL החצי הימני מציב לפניה והשמאלי אחריה.
     Future<TestGesture> dragTileTo(
       WidgetTester tester,
       String from,
@@ -1418,7 +1460,7 @@ void main() {
       bool release = true,
     }) async {
       // עכבר ולא מגע: בשולחן העבודה הגרירה מוגבלת למצביע מדויק, כדי שהחלקה
-      // במגע תמשיך לגלול את הרשימה.
+      // במגע תמשיך לגלול את הרשת.
       final gesture = await tester.startGesture(
         tester.getCenter(find.text(from)),
         kind: PointerDeviceKind.mouse,
@@ -1427,8 +1469,8 @@ void main() {
       final target = tester.getRect(
         find.ancestor(of: find.text(to), matching: find.byType(ToolTile)),
       );
-      final dy = beforeTarget ? -target.height / 4 : target.height / 4;
-      await gesture.moveTo(target.center + Offset(0, dy));
+      final dx = beforeTarget ? target.width / 4 : -target.width / 4;
+      await gesture.moveTo(target.center + Offset(dx, 0));
       await tester.pump();
       if (release) {
         await gesture.up();
@@ -1437,7 +1479,7 @@ void main() {
       return gesture;
     }
 
-    testWidgets('גרירה לחצי העליון של היעד מציבה לפניו', (tester) async {
+    testWidgets('גרירה לחצי הימני של היעד מציבה לפניו', (tester) async {
       await _asDesktop(() async {
         await pumpPanel(tester);
         await dragTileTo(tester, 'ראשי תיבות', 'גימטריה', beforeTarget: true);
@@ -1453,7 +1495,7 @@ void main() {
       });
     });
 
-    testWidgets('גרירה לחצי התחתון של היעד מציבה אחריו', (tester) async {
+    testWidgets('גרירה לחצי השמאלי של היעד מציבה אחריו', (tester) async {
       await _asDesktop(() async {
         await pumpPanel(tester);
         await dragTileTo(tester, 'לוח שנה', 'גימטריה', beforeTarget: false);
@@ -1470,8 +1512,8 @@ void main() {
       });
     });
 
-    // קו ההוספה הוא החיווי שהמשתמש רואה — היכן השורה תיפול.
-    testWidgets('בגרירה מוצג קו הוספה אחד בצד שאליו תיפול השורה', (
+    // קו ההוספה הוא החיווי שהמשתמש רואה — היכן הקובייה תיפול.
+    testWidgets('בגרירה מוצג קו הוספה אחד בצד שאליו תיפול הקובייה', (
       tester,
     ) async {
       await _asDesktop(() async {
@@ -1493,9 +1535,9 @@ void main() {
           ),
         );
         expect(
-          line.center.dy,
-          lessThan(target.center.dy),
-          reason: '"לפני" הוא הקצה העליון של שורת היעד',
+          line.center.dx,
+          greaterThan(target.center.dx),
+          reason: 'ב-RTL "לפני" הוא הקצה הימני של קובייית היעד',
         );
 
         await gesture.up();
@@ -1564,7 +1606,20 @@ void main() {
 
     // ── issue #929: שחרור בשטח הריק וגלילת קצה ──────────────────────────────
 
-    /// גורר שורה אל השטח הריק שמתחת לרשימה, בלי לשחרר.
+    /// ה-Scrollable של הרשת החיצונית. ה-GridView-ים הפנימיים בונים Scrollable
+    /// משלהם (מושבת), ולכן חייבים את הראשון ולא את כולם.
+    ScrollPosition gridPosition(WidgetTester tester) => tester
+        .state<ScrollableState>(
+          find
+              .descendant(
+                of: find.byType(ListView),
+                matching: find.byType(Scrollable),
+              )
+              .first,
+        )
+        .position;
+
+    /// גורר קובייה אל השטח הריק שמתחת לרשת, בלי לשחרר.
     Future<TestGesture> dragTileToEmptySpace(
       WidgetTester tester,
       String from,
@@ -1574,13 +1629,13 @@ void main() {
         kind: PointerDeviceKind.mouse,
       );
       await tester.pump(const Duration(milliseconds: 50));
-      final list = tester.getRect(find.byType(ListView));
-      await gesture.moveTo(Offset(list.center.dx, list.bottom - 8));
+      final grid = tester.getRect(find.byType(ListView));
+      await gesture.moveTo(Offset(grid.center.dx, grid.bottom - 8));
       await tester.pump();
       return gesture;
     }
 
-    testWidgets('שחרור בשטח הריק שמתחת לרשימה מעביר תוסף לסוף קבוצתו', (
+    testWidgets('שחרור בשטח הריק שמתחת לרשת מעביר תוסף לסוף קבוצתו', (
       tester,
     ) async {
       await _asDesktop(() async {
@@ -1589,16 +1644,17 @@ void main() {
         await pumpPanel(tester, height: 900);
         final gesture = await dragTileToEmptySpace(tester, 'תוסף א');
 
-        // קו ההוספה מוצג על סוף קבוצת התוספים — חיווי שהשחרור יתקבל.
+        // קו ההוספה מוצג בקצה ה-end של הקובייה האחרונה בקבוצה — ב-RTL
+        // הצד השמאלי, כלומר "אחריה".
         expect(find.byKey(kToolDropIndicatorKey), findsOneWidget);
         final line = tester.getRect(find.byKey(kToolDropIndicatorKey));
-        final lastRow = tester.getRect(
+        final lastTile = tester.getRect(
           find.ancestor(
             of: find.text('תוסף ב'),
             matching: find.byType(ToolTile),
           ),
         );
-        expect(line.center.dy, greaterThan(lastRow.center.dy));
+        expect(line.center.dx, lessThan(lastTile.center.dx));
 
         await gesture.up();
         await tester.pumpAndSettle();
@@ -1655,9 +1711,7 @@ void main() {
       });
     });
 
-    testWidgets('גרירה אל הקצה התחתון גוללת את הרשימה אוטומטית', (
-      tester,
-    ) async {
+    testWidgets('גרירה אל הקצה התחתון גוללת את הרשת אוטומטית', (tester) async {
       await _asDesktop(() async {
         await pumpPanel(
           tester,
@@ -1666,14 +1720,7 @@ void main() {
               _pluginEntry('com.example.p$i', 'תוסף מספר $i').plugin!,
           ]),
         );
-        final position = tester
-            .state<ScrollableState>(
-              find.descendant(
-                of: find.byType(ListView),
-                matching: find.byType(Scrollable),
-              ),
-            )
-            .position;
+        final position = gridPosition(tester);
         expect(position.pixels, 0);
 
         final gesture = await tester.startGesture(
@@ -1681,8 +1728,8 @@ void main() {
           kind: PointerDeviceKind.mouse,
         );
         await tester.pump(const Duration(milliseconds: 50));
-        final list = tester.getRect(find.byType(ListView));
-        await gesture.moveTo(Offset(list.center.dx, list.bottom - 10));
+        final grid = tester.getRect(find.byType(ListView));
+        await gesture.moveTo(Offset(grid.center.dx, grid.bottom - 10));
         await tester.pump();
         for (var i = 0; i < 10; i++) {
           await tester.pump(const Duration(milliseconds: 16));
@@ -1695,7 +1742,7 @@ void main() {
       });
     });
 
-    testWidgets('גרירה אל הקצה העליון גוללת את הרשימה חזרה למעלה', (
+    testWidgets('גרירה אל הקצה העליון גוללת את הרשת חזרה למעלה', (
       tester,
     ) async {
       await _asDesktop(() async {
@@ -1706,26 +1753,27 @@ void main() {
               _pluginEntry('com.example.p$i', 'תוסף מספר $i').plugin!,
           ]),
         );
-        final position = tester
-            .state<ScrollableState>(
-              find.descendant(
-                of: find.byType(ListView),
-                matching: find.byType(Scrollable),
-              ),
-            )
-            .position;
+        final position = gridPosition(tester);
         position.jumpTo(200);
         await tester.pump();
 
-        // שורה רחוקה מהקצה — גרירה מהשורה העליונה אל הקצה קצרה מסף ה-slop
-        // והמחווה אינה מזוהה כגרירה.
+        final grid = tester.getRect(find.byType(ListView));
+        // הרשת בונה גם קוביות שמעל ה-viewport, ולכן הקובייה נבחרת לפי מיקומה
+        // בפועל: גרירה אל הקצה מקובייה סמוכה קצרה מסף ה-slop ואינה מזוהה.
+        final tiles = find.byType(ToolTile);
+        final index = List.generate(tiles.evaluate().length, (i) => i)
+            .firstWhere(
+              (i) {
+                final dy = tester.getRect(tiles.at(i)).center.dy;
+                return dy > grid.top + 80 && dy < grid.bottom - 80;
+              },
+            );
         final gesture = await tester.startGesture(
-          tester.getCenter(find.byType(ToolTile).at(3)),
+          tester.getCenter(tiles.at(index)),
           kind: PointerDeviceKind.mouse,
         );
         await tester.pump(const Duration(milliseconds: 50));
-        final list = tester.getRect(find.byType(ListView));
-        await gesture.moveTo(Offset(list.center.dx, list.top + 10));
+        await gesture.moveTo(Offset(grid.center.dx, grid.top + 10));
         await tester.pump();
         for (var i = 0; i < 10; i++) {
           await tester.pump(const Duration(milliseconds: 16));
@@ -1805,19 +1853,19 @@ void main() {
         final searchField = tester.widget<TextField>(find.byType(TextField));
         expect(searchField.focusNode!.hasFocus, isTrue);
 
-        await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
         await tester.pump();
-        expect(_selectedRowCount(tester), 1);
+        expect(_selectedCardCount(tester), 1);
       });
     });
 
     testWidgets('סימון שיצא מהטווח מתאפס כשהרשימה מתקצרת', (tester) async {
       await pumpPanel(tester);
       for (var i = 0; i < kBuiltInToolsCatalog.length + 2; i++) {
-        await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
       }
       await tester.pump();
-      expect(_selectedRowCount(tester), 1);
+      expect(_selectedCardCount(tester), 1);
 
       await pumpPanel(
         tester,
@@ -1826,7 +1874,7 @@ void main() {
           hiddenBuiltInToolIds: const {'builtin.acronyms_dictionary'},
         ),
       );
-      expect(_selectedRowCount(tester), 0);
+      expect(_selectedCardCount(tester), 0);
       expect(tester.takeException(), isNull);
     });
 
@@ -1838,7 +1886,7 @@ void main() {
       });
     });
 
-    // בחיפוש השורות מסוננות, ולכן "השכן" על המסך אינו השכן האמיתי בסדר.
+    // בחיפוש הקוביות מסוננות, ולכן "השכן" על המסך אינו השכן האמיתי בסדר.
     testWidgets('בחיפוש פעיל הסידור מושבת', (tester) async {
       await pumpPanel(tester);
       await tester.enterText(find.byType(TextField), 'ו');
@@ -1852,13 +1900,13 @@ void main() {
     });
 
     // שאילתה של פיסוק בלבד מתנרמלת לריקה ואינה מסננת דבר, ולכן אין סיבה
-    // להשבית את הסידור או לסמן שורה.
+    // להשבית את הסידור או לסמן קובייה.
     testWidgets('שאילתת פיסוק בלבד אינה מצב חיפוש', (tester) async {
       await pumpPanel(tester);
       await tester.enterText(find.byType(TextField), '״');
       await tester.pump();
 
-      expect(_selectedRowCount(tester), 0);
+      expect(_selectedCardCount(tester), 0);
       expect(
         find.byType(ToolTile),
         findsNWidgets(kBuiltInToolsCatalog.length + 2),
@@ -1867,15 +1915,15 @@ void main() {
       expect(_menuItemEnabled(tester, 'הזזה'), isTrue);
     });
 
-    testWidgets('חץ למטה ראשון מסמן את השורה הראשונה', (
+    testWidgets('חץ למטה ראשון מסמן את הקובייה הראשונה, לא את השורה הבאה', (
       tester,
     ) async {
       await pumpPanel(tester);
       await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
       await tester.pump();
 
-      expect(_selectedRowCount(tester), 1);
-      expect(_isRowSelected(tester, 'לוח שנה'), isTrue);
+      expect(_selectedCardCount(tester), 1);
+      expect(_isCardSelected(tester, 'לוח שנה'), isTrue);
     });
 
     testWidgets('הפאנל מצייר את הסדר השמור', (tester) async {
@@ -1944,7 +1992,7 @@ void main() {
     ) async {
       await pumpPanel(tester);
       await openMoveSubmenu(tester, 'לוח שנה');
-      await tapMenuItem(tester, 'הזז למטה');
+      await tapMenuItem(tester, 'הזז קדימה');
 
       expect(tester.takeException(), isNull);
       expect(


### PR DESCRIPTION
ביטול `e6186f52c` "חלונית כלים: עיצוב מחדש", שהחליף את רשת הקוביות בשורות `NavTreeTile` — שלוש שעות אחרי שמוזג #764, שהעמיד את מראה הקוביות במקומו.

## מה חוזר

בדיוק המראה של #764: אייקון גדול וכתב קטן, ארבע קוביות בשורה בחלון של 440, קובייה בצבע כרטיסי הספרייה, ⋯ בגודל 13 בשטח לחיצה של 24.

## למה לא `git revert`

ארבעה קומיטים נגעו ב-`tools_launcher_panel.dart` מאז, ושניים מהם חייבים להישאר. לכן קוד הרשת שוחזר מ-`e6186f52c^`, ומה שנוסף אחריו הוחל עליו מחדש:

| מאז העיצוב מחדש | גורל |
|---|---|
| `b1ab9988a` — דגל `--dev-plugins` | **נשמר** — `showDevTools` נשאר nullable, וכלי הפיתוח מוצגים בגרסה מקומפלת |
| `9f3ba2182` — `OtzariaIcons` | **נשמר** — שדה החיפוש מקבל את האייקון מברירת המחדל של `OtzariaSearchField` |
| `fbd0391e2` — שחרור בשטח הריק וגלילת קצה (#929) | **הותאם לרשת** — ראו למטה |
| `a9596b648` — חיצים אנכיים בתפריט "הזזה" | **חוזר לאופקי** — ברשת ההזזה אופקית; החיצים האנכיים היו בשביל הרשימה בלבד |

`00bf7384e` (הסתרת תוסף מוצמד, #966) לא נוגע בקובץ הזה וההתנהגות נשמרה — הטסט שקיבע את ההתנהגות הישנה הוחלף בגרסה העדכנית.

## שלוש נקודות לסקירה

**issue #929 עובד גם ברשת.** `DragTarget` עוטף מאחורי הרשת וקולט שחרור מתחת לקובייה האחרונה, וריחוף ב-40px מקצה הרשת גולל אותה — אותו דפוס, על אותו `ScrollController` (הרשת היא `ListView` שבתוכו `GridView`-ים עם `shrinkWrap`, כך שהגלילה החיצונית זהה). ההבדל היחיד: קו ההוספה ברשת אנכי ויושב בקצה ה-`end` של סוף הקבוצה, ולא אופקי מתחתיה.

**חמשת הטסטים של #929 נכתבו מחדש מול הרשת.** שניים מהם נדרשו התאמה אמיתית ולא רק שינוי שם: הבדיקה של קו ההוספה עברה מ-`dy` ל-`dx` (הקו אנכי), והבחירה של הקובייה הנגררת בטסט הקצה העליון נעשית לפי מיקומה בפועל — הרשת בונה בזכות `shrinkWrap` גם קוביות שמעל ה-viewport, ואינדקס קבוע היה נופל עליהן.

**`NavTreeTile.iconBox` לא בוטל.** הרפקטור הזה נוסף ב-`e6186f52c` וכרגע אין לו קוראים, אבל הוא אינו שובר דבר; מחיקתו הייתה מרחיבה את הדיף אל מחוץ לחלונית הכלים.

## בדיקות

452 הטסטים ב-`test/tools/` עוברים, ו-`flutter analyze` נקי על `lib/` ועל `test/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
