### PR TITLE
לוח שנה: תיקון "לא נמצאו לוחות שנה" בסנכרון גוגל (fixes #1075)

### DIFF
--- a/lib/tools/calendar/services/google_calendar_service.dart
+++ b/lib/tools/calendar/services/google_calendar_service.dart
@@ -73,15 +73,13 @@ class GoogleCalendarService {
     final storedJson = _settingsRepository.getGoogleCalendarCredentialsJson();
 
     if (storedJson.isNotEmpty) {
-      try {
-        final decoded = jsonDecode(storedJson) as Map<String, dynamic>;
-        final creds = auth.AccessCredentials.fromJson(decoded);
+      final creds = _parseStoredCredentials(storedJson);
+      if (creds != null &&
+          canUseStoredCredentials(creds, interactive: interactive)) {
         return auth_io.autoRefreshingClient(id, creds, http.Client());
-      } catch (e) {
-        // fall through to interactive flow if parsing failed
-        // Clear invalid credentials
-        await _settingsRepository.updateGoogleCalendarCredentialsJson('');
       }
+      // JSON פגום או טוקן שאינו מכסה את כל ה-scopes — הסכמה מחדש
+      await _settingsRepository.updateGoogleCalendarCredentialsJson('');
     }
 
     if (!interactive) return null;
@@ -102,6 +100,23 @@ class GoogleCalendarService {
       return authClient;
     } catch (e) {
       throw Exception('Failed to authenticate with Google: $e');
+    }
+  }
+
+  /// האם להשתמש בהרשאות השמורות במקום לפתוח מסך הסכמה מחדש. טוקן שנשמר
+  /// לפני הוספת scope נדחה רק בפעולה יזומה, כדי לא לנתק סנכרון רקע תקין.
+  static bool canUseStoredCredentials(
+    auth.AccessCredentials credentials, {
+    required bool interactive,
+  }) => !interactive || scopes.every(credentials.scopes.contains);
+
+  static auth.AccessCredentials? _parseStoredCredentials(String storedJson) {
+    try {
+      return auth.AccessCredentials.fromJson(
+        jsonDecode(storedJson) as Map<String, dynamic>,
+      );
+    } catch (_) {
+      return null;
     }
   }
 

--- a/lib/tools/calendar/services/google_calendar_service.dart
+++ b/lib/tools/calendar/services/google_calendar_service.dart
@@ -22,8 +22,11 @@ class GoogleCalendarService {
     SettingsRepository? settingsRepository,
   }) : _settingsRepository = settingsRepository ?? SettingsRepository();
 
-  static const List<String> _scopes = <String>[
+  // calendarList.list דורש scope נפרד מ-calendar.events — בלעדיו בחירת
+  // היומנים מחזירה תמיד רשימה ריקה (403, issue #1075)
+  static const List<String> scopes = <String>[
     cal.CalendarApi.calendarEventsScope,
+    cal.CalendarApi.calendarCalendarlistReadonlyScope,
   ];
 
   final SettingsRepository _settingsRepository;
@@ -86,7 +89,7 @@ class GoogleCalendarService {
     try {
       final authClient = await auth_io.clientViaUserConsent(
         id,
-        _scopes,
+        scopes,
         (url) async {
           await launchUrl(
             Uri.parse(url),

--- a/lib/tools/calendar/utils/calendar_cubit.dart
+++ b/lib/tools/calendar/utils/calendar_cubit.dart
@@ -1210,7 +1210,7 @@ class CalendarCubit extends Cubit<CalendarState> {
 
   Future<List<GoogleCalendarInfo>> getAvailableCalendars() async {
     final apiClient = await _googleCalendarService.getApiClient(
-      interactive: false,
+      interactive: true,
     );
     if (apiClient == null) return [];
 

--- a/test/tools/calendar/services/google_calendar_service_scopes_test.dart
+++ b/test/tools/calendar/services/google_calendar_service_scopes_test.dart
@@ -1,6 +1,18 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:googleapis/calendar/v3.dart' as cal;
+import 'package:googleapis_auth/googleapis_auth.dart' as auth;
 import 'package:otzaria/tools/calendar/services/google_calendar_service.dart';
+
+auth.AccessCredentials credentialsWithScopes(List<String> scopes) =>
+    auth.AccessCredentials(
+      auth.AccessToken(
+        'Bearer',
+        'token',
+        DateTime.now().toUtc().add(const Duration(hours: 1)),
+      ),
+      'refresh-token',
+      scopes,
+    );
 
 void main() {
   group('GoogleCalendarService scopes', () {
@@ -17,6 +29,64 @@ void main() {
       expect(
         GoogleCalendarService.scopes,
         contains(cal.CalendarApi.calendarCalendarlistReadonlyScope),
+      );
+    });
+  });
+
+  group('canUseStoredCredentials', () {
+    final oldToken = credentialsWithScopes([
+      cal.CalendarApi.calendarEventsScope,
+    ]);
+    final currentToken = credentialsWithScopes(GoogleCalendarService.scopes);
+
+    test('טוקן ישן נדחה בפעולה יזומה כדי לחדש הסכמה', () {
+      expect(
+        GoogleCalendarService.canUseStoredCredentials(
+          oldToken,
+          interactive: true,
+        ),
+        isFalse,
+      );
+    });
+
+    test('טוקן ישן ממשיך לשמש סנכרון רקע ולא מנתק את החשבון', () {
+      expect(
+        GoogleCalendarService.canUseStoredCredentials(
+          oldToken,
+          interactive: false,
+        ),
+        isTrue,
+      );
+    });
+
+    test('טוקן מעודכן מתקבל בשני המסלולים', () {
+      expect(
+        GoogleCalendarService.canUseStoredCredentials(
+          currentToken,
+          interactive: true,
+        ),
+        isTrue,
+      );
+      expect(
+        GoogleCalendarService.canUseStoredCredentials(
+          currentToken,
+          interactive: false,
+        ),
+        isTrue,
+      );
+    });
+
+    test('הרשאות רחבות יותר מהנדרש מתקבלות', () {
+      final broadToken = credentialsWithScopes([
+        ...GoogleCalendarService.scopes,
+        'https://www.googleapis.com/auth/userinfo.email',
+      ]);
+      expect(
+        GoogleCalendarService.canUseStoredCredentials(
+          broadToken,
+          interactive: true,
+        ),
+        isTrue,
       );
     });
   });

--- a/test/tools/calendar/services/google_calendar_service_scopes_test.dart
+++ b/test/tools/calendar/services/google_calendar_service_scopes_test.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:googleapis/calendar/v3.dart' as cal;
+import 'package:otzaria/tools/calendar/services/google_calendar_service.dart';
+
+void main() {
+  group('GoogleCalendarService scopes', () {
+    test('כולל הרשאת אירועים לסנכרון', () {
+      expect(
+        GoogleCalendarService.scopes,
+        contains(cal.CalendarApi.calendarEventsScope),
+      );
+    });
+
+    // בלי scope לרשימת היומנים calendarList.list מחזיר 403 ובחירת
+    // היומנים מציגה תמיד "לא נמצאו לוחות שנה" (issue #1075)
+    test('כולל הרשאת קריאה לרשימת היומנים', () {
+      expect(
+        GoogleCalendarService.scopes,
+        contains(cal.CalendarApi.calendarCalendarlistReadonlyScope),
+      );
+    });
+  });
+}


### PR DESCRIPTION
Fixes #1075

## הבאג
בחירת היומנים בהגדרות לוח השנה החזירה תמיד **"לא נמצאו לוחות שנה. נסה להתחבר מחדש."** — גם אחרי התחברות מוצלחת וניסיונות חוזרים בכמה גרסאות.

## שורש הבעיה
ה-OAuth ביקש הרשאה אחת בלבד — `calendar.events`. אבל `calendarList.list()` (שליפת רשימת היומנים של המשתמש) **אינו מורשה** תחת ה-scope הזה ודורש scope נפרד. גוגל החזיר 403, ה-`catch` ב-`getAvailableCalendars` בלע אותו בשקט והחזיר רשימה ריקה — ולכן ההודעה הופיעה בכל פעם, ללא תלות בגרסה. מאותו שורש גם `_loadGoogleCalendarColorIndices` נכשל בשקט וצבעי היומנים מגוגל מעולם לא נטענו.

## התיקון
**1. ה-scope החסר**
- נוסף `calendar.calendarlist.readonly` (ה-scope המצומצם ביותר שמכסה את `calendarList.list`) לצד `calendar.events` הקיים.

**2. חידוש הסכמה לטוקנים קיימים**
טוקן שנשמר לפני התיקון נושא את ה-scope הישן, ו-`_getAuthClient` היה מחזיר אותו מיד — כלומר משתמש ותיק היה ממשיך לקבל 403 עד שיתנתק ידנית. כעת ההרשאות השמורות נבדקות מול `scopes`:
- **בפעולה יזומה** (התחברות / "סנכרן") — טוקן חסר-scope נדחה, נמחק, ונפתח מסך הסכמה מחדש אוטומטית.
- **בסנכרון רקע** — הטוקן הישן ממשיך לשמש כרגיל, כדי לא לנתק סנכרון אירועים שעובד תקין ולא להקפיץ שגיאה שהמשתמש לא ביקש.

**3. בדיקות**
`test/tools/calendar/services/google_calendar_service_scopes_test.dart` מכסה את שני ה-scopes וגם את החלטת חידוש ההסכמה על טוקן ישן אמיתי (`AccessCredentials` עם ה-scope הישן בלבד), בשני המסלולים.

`flutter analyze` נקי, 208 בדיקות לוח השנה עוברות, `dart format` הורץ.

## ⚠️ נדרש לפני המיזוג — הגדרה ב-Google Cloud Console
**התיקון לא יעבוד בפרודקשן בלי זה:**
1. במסך ההסכמה (OAuth consent screen) של פרויקט האפליקציה יש **להוסיף את ה-scope**:
   `https://www.googleapis.com/auth/calendar.calendarlist.readonly`
2. אם האפליקציה עברה verification מול גוגל — הוספת scope עשויה לדרוש **אימות מחודש**. כדאי לוודא זאת מראש כדי שמשתמשים לא יקבלו מסך "אפליקציה לא מאומתת".

## הערה להערות השחרור
משתמש שכבר מחובר יקבל מסך הסכמה מחודש בפעם הבאה שילחץ "סנכרן" או "התחברות לחשבון" — זו התנהגות מכוונת ולא תקלה. אין צורך בהתנתקות ידנית.

🤖 Generated with [Claude Code](https://claude.com/claude-code)