### PR TITLE
מפרשים: בלי הבזק "לא נמצאו מפרשים" בין הטעינה לתוצאות בפתיחת ספר (issue #1130)

### DIFF
--- a/lib/text_book/bloc/text_book_bloc.dart
+++ b/lib/text_book/bloc/text_book_bloc.dart
@@ -1002,7 +1002,9 @@ class TextBookBloc extends Bloc<TextBookEvent, TextBookState> {
         supportsContinuousReadingMode: supportsContinuousReading,
         continuousReadingMode: effectiveContinuousReading,
         readingSegments: readingSegments,
-        linksLoading: false,
+        // בלי בחירת מפרשים הקישורים נטענים רק אחרי שהבחירה נפתרה (ראה למטה),
+        // והחלונית מציגה "טוען" עד אז ולא "לא נמצאו" (issue #1130).
+        linksLoading: event.loadCommentators && commentators.isEmpty,
         visibleIndices: visibleIndices,
         pinLeftPane:
             preservedPinLeftPane ??
@@ -1068,7 +1070,11 @@ class TextBookBloc extends Bloc<TextBookEvent, TextBookState> {
       _loadContentRangeInBackground(book, visibleIndices);
       _warmContentCacheInBackground(book);
 
-      _loadLinksInBackground(book, visibleIndices);
+      // טעינת קישורים לפני שבחירת המפרשים ידועה יוצאת בלי יעדים, וחלונית
+      // המפרשים מציגה לרגע "לא נמצאו מפרשים" עד לטעינה החוזרת (issue #1130).
+      if (!event.loadCommentators || commentators.isNotEmpty) {
+        _loadLinksInBackground(book, visibleIndices);
+      }
 
       if (event.loadCommentators) {
         _loadCommentatorsInBackground(book);
@@ -1264,7 +1270,10 @@ class TextBookBloc extends Bloc<TextBookEvent, TextBookState> {
       // בחירה אוטומטית (ברירת מחדל) ושחזור שמור גוברים על בחירה אוטומטית
       // קודמת (כגון אוטו-בחירת 'הערות'), כל עוד המשתמש לא בחר ידנית בסשן זה.
       if (!event.isUserAction) {
-        if (_userTouchedCommentators) return;
+        if (_userTouchedCommentators) {
+          _loadLinksAfterCommentatorsResolved(currentState.book);
+          return;
+        }
         // שחזור בחירה שמורה הוא בחירת המשתמש האמיתית — נועלים אותה מפני
         // אוטו-בחירה מאוחרת (כולל הוספת 'הערות' אוטומטית), גם כשהיא ריקה.
         if (event.isRestore) _userTouchedCommentators = true;
@@ -2966,10 +2975,22 @@ class TextBookBloc extends Bloc<TextBookEvent, TextBookState> {
       );
       if (initialSelection.isNotEmpty && !isClosed) {
         add(UpdateCommentators(initialSelection, isUserAction: false));
+        return;
       }
+      _loadLinksAfterCommentatorsResolved(book);
     } catch (e) {
       debugPrint('⚠️ Failed to load commentators in background: $e');
+      _loadLinksAfterCommentatorsResolved(book);
     }
+  }
+
+  /// טעינת הקישורים שנדחתה ב-[_onLoadContent] עד לפתרון בחירת המפרשים,
+  /// במסלולים שבהם לא נשלח UpdateCommentators (ואיתו הטעינה).
+  void _loadLinksAfterCommentatorsResolved(TextBook book) {
+    final current = state;
+    if (isClosed || current is! TextBookLoaded) return;
+    if (current.book.title != book.title) return;
+    _loadLinksInBackground(book, current.visibleIndices);
   }
 
   /// שומר את בחירת המפרשים פר-ספר (תמיד, ללא תלות ב-enablePerBookSettings),

--- a/test/text_book/bloc/commentary_links_no_not_found_flash_test.dart
+++ b/test/text_book/bloc/commentary_links_no_not_found_flash_test.dart
@@ -1,0 +1,167 @@
+import 'dart:async';
+
+import 'package:flutter_settings_screens/flutter_settings_screens.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/data/data_providers/file_system_data_provider.dart';
+import 'package:otzaria/models/books.dart';
+import 'package:otzaria/models/links.dart';
+import 'package:otzaria/text_book/bloc/text_book_bloc.dart';
+import 'package:otzaria/text_book/bloc/text_book_event.dart';
+import 'package:otzaria/text_book/bloc/text_book_state.dart';
+import 'package:otzaria/text_book/text_book_repository.dart';
+import 'package:otzaria/utils/text/text_manipulation.dart' as utils;
+import 'package:scrollable_positioned_list/scrollable_positioned_list.dart';
+
+import '../../test_helpers/memory_cache_provider.dart';
+
+const _commentator = 'רש"י על ספר בדיקה';
+
+/// ספר עם מפרש יחיד; הקישורים אליו מוחזרים רק כשהוא ברשימת היעדים.
+class _Repository extends TextBookRepository {
+  _Repository() : super(fileSystem: FileSystemData.instance);
+
+  @override
+  Future<String> getBookContent(TextBook book) async =>
+      List.generate(40, (i) => 'שורה $i').join('\n');
+
+  @override
+  Future<BookContentRange?> getBookContentRange(
+    TextBook book, {
+    required int startLine,
+    required int endLine,
+  }) async {
+    final lines = List.generate(40, (i) => 'שורה $i');
+    final start = startLine.clamp(0, lines.length - 1);
+    final end = endLine.clamp(start, lines.length - 1);
+    return BookContentRange(
+      startLine: start,
+      endLine: end,
+      totalLines: lines.length,
+      lines: lines.sublist(start, end + 1),
+    );
+  }
+
+  @override
+  Future<List<TocEntry>> getTableOfContents(TextBook book) async => const [];
+
+  @override
+  Future<({List<String> all, Set<String> rare})> getCommentatorsWithRarity(
+    TextBook book,
+  ) async {
+    // רשימת המפרשים נטענת מה-DB ואיטית מטעינת הקישורים לחלון הנראה.
+    await Future<void>.delayed(const Duration(milliseconds: 40));
+    return (all: const [_commentator], rare: const <String>{});
+  }
+
+  @override
+  Future<List<Link>> getBookLinksInRange(
+    TextBook book, {
+    required int startIndex,
+    required int endIndex,
+    Iterable<String>? targetBookTitles,
+  }) async {
+    await Future<void>.delayed(const Duration(milliseconds: 5));
+    final wanted =
+        targetBookTitles == null || targetBookTitles.contains(_commentator);
+    if (!wanted) return const [];
+    return [
+      for (var line = startIndex; line <= endIndex; line++)
+        Link(
+          heRef: '$_commentator $line',
+          index1: line + 1,
+          path2: 'מפרשים/$_commentator',
+          index2: line + 1,
+          connectionType: 'commentary',
+        ),
+    ];
+  }
+}
+
+/// התנאי שבו חלונית המפרשים מציגה "לא נמצאו מפרשים" (commentary_list_base):
+/// הטעינה הסתיימה ואין קישור מהמפרשים הפעילים לשורות הנראות.
+bool _panelSaysNotFound(TextBookLoaded state) {
+  if (state.linksLoading) return false;
+  final hasRelevant = state.visibleIndices.any((idx) {
+    final lineLinks = state.linksByLine[idx + 1];
+    if (lineLinks == null) return false;
+    return lineLinks.any(
+      (link) => state.activeCommentators.contains(
+        utils.getTitleFromPath(link.path2),
+      ),
+    );
+  });
+  return !hasRelevant;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    await Settings.init(cacheProvider: MemoryCacheProvider());
+  });
+
+  test(
+    'פתיחת ספר בלי בחירת מפרשים: אין מצב "לא נמצאו מפרשים" בין הטעינה לתוצאות '
+    '(issue #1130)',
+    () async {
+      final book = TextBook(title: 'ספר בדיקה', isUserBook: true);
+      final bloc = TextBookBloc(
+        repository: _Repository(),
+        initialState: TextBookInitial.named(
+          book,
+          10,
+          false,
+          const [],
+        ),
+        scrollController: ItemScrollController(),
+        positionsListener: ItemPositionsListener.create(),
+      );
+      addTearDown(bloc.close);
+
+      final loadedStates = <TextBookLoaded>[];
+      final done = Completer<void>();
+      final sub = bloc.stream.listen((state) {
+        if (state is! TextBookLoaded) return;
+        loadedStates.add(state);
+        if (!done.isCompleted &&
+            state.activeCommentators.isNotEmpty &&
+            !_panelSaysNotFound(state)) {
+          done.complete();
+        }
+      });
+      addTearDown(sub.cancel);
+
+      bloc.add(
+        const LoadContent(
+          fontSize: 20,
+          showSplitView: false,
+          removeNikud: false,
+          loadCommentators: true,
+        ),
+      );
+      await done.future.timeout(
+        const Duration(seconds: 10),
+        onTimeout: () => fail('המפרשים לא הוצגו כלל'),
+      );
+
+      // מרגע שהחלונית הציגה "טוען מפרשים..." היא חייבת להישאר בטעינה עד
+      // שיש תוצאות — כל מצב "לא נמצאו" באמצע הוא ההבזק שדווח.
+      final firstLoading = loadedStates.indexWhere((s) => s.linksLoading);
+      expect(firstLoading, isNonNegative, reason: 'צפוי מצב "טוען מפרשים..."');
+      final flashes = loadedStates
+          .skip(firstLoading)
+          .takeWhile(
+            (s) => s.activeCommentators.isEmpty || _panelSaysNotFound(s),
+          )
+          .where(_panelSaysNotFound)
+          .toList();
+      expect(
+        flashes,
+        isEmpty,
+        reason:
+            'לפני שהמפרשים נבחרו נטענו קישורים בלי יעדים והחלונית הציגה '
+            '"לא נמצאו מפרשים" (issue #1130)',
+      );
+    },
+  );
+}

--- a/test/text_book/bloc/commentary_links_no_not_found_flash_test.dart
+++ b/test/text_book/bloc/commentary_links_no_not_found_flash_test.dart
@@ -77,11 +77,8 @@ class _Repository extends TextBookRepository {
   }
 }
 
-/// התנאי שבו חלונית המפרשים מציגה "לא נמצאו מפרשים" (commentary_list_base):
-/// הטעינה הסתיימה ואין קישור מהמפרשים הפעילים לשורות הנראות.
-bool _panelSaysNotFound(TextBookLoaded state) {
-  if (state.linksLoading) return false;
-  final hasRelevant = state.visibleIndices.any((idx) {
+bool _hasRelevantCommentaryLinks(TextBookLoaded state) {
+  return state.visibleIndices.any((idx) {
     final lineLinks = state.linksByLine[idx + 1];
     if (lineLinks == null) return false;
     return lineLinks.any(
@@ -90,8 +87,12 @@ bool _panelSaysNotFound(TextBookLoaded state) {
       ),
     );
   });
-  return !hasRelevant;
 }
+
+/// התנאי שבו חלונית המפרשים מציגה "לא נמצאו מפרשים" (commentary_list_base):
+/// הטעינה הסתיימה ואין קישור מהמפרשים הפעילים לשורות הנראות.
+bool _panelSaysNotFound(TextBookLoaded state) =>
+    !state.linksLoading && !_hasRelevantCommentaryLinks(state);
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -125,7 +126,8 @@ void main() {
         loadedStates.add(state);
         if (!done.isCompleted &&
             state.activeCommentators.isNotEmpty &&
-            !_panelSaysNotFound(state)) {
+            !state.linksLoading &&
+            _hasRelevantCommentaryLinks(state)) {
           done.complete();
         }
       });

--- a/test_results/2026-09-02-commentary-panel-not-found-flash.md
+++ b/test_results/2026-09-02-commentary-panel-not-found-flash.md
@@ -1,0 +1,56 @@
+# issue #1130 — הבזק "לא נמצאו מפרשים" בין "טוען מפרשים..." לתוצאות
+
+תאריך: 2026-09-02 | ענף: `fix/commentary-panel-not-found-flash-1130` | קומיט אימות: `bc325ddc`
+
+## שורש הבאג
+
+בפתיחת ספר `_onLoadContent` מפעיל במקביל את טעינת הקישורים ואת טעינת
+המפרשים. כשעדיין אין בחירת מפרשים (ספר שנפתח בלי כרטיסייה משוחזרת),
+`_resolveTargetBookTitlesForLinks` מחזיר רשימת יעדים ריקה — הקישורים חוזרים
+בלי מפרשים, `linksLoading` יורד ל-false, וחלונית המפרשים מסיקה "לא נמצאו
+מפרשים לקטע הנבחר". רק אחר כך מגיעה בחירת ברירת-המחדל (`UpdateCommentators`)
+שמפעילה טעינה חוזרת — "טוען" שוב ואז התוצאות. בדיוק ההקלטה שבדיווח.
+
+רצף המצבים שנמדד ב-`dev` (בדיקת ה-BLoC, לפני התיקון):
+
+```
+loading=true  active=[]         links=0   ← "טוען מפרשים..."
+loading=false active=[]         links=0   ← "לא נמצאו מפרשים"  (ההבזק)
+loading=false active=[רש"י ...] links=0   ← עדיין "לא נמצאו"
+loading=true  active=[רש"י ...] links=0   ← "טוען" שוב
+loading=false active=[רש"י ...] links=N   ← התוצאות
+```
+
+## הפתרון
+
+כשנדרשת טעינת מפרשים והבחירה עדיין ריקה, טעינת הקישורים נדחית עד שהבחירה
+נפתרת: המצב ההתחלתי מסומן `linksLoading: true` (החלונית מציגה "טוען"),
+והטעינה יוצאת מ-`UpdateCommentators` — או, במסלולים שבהם לא נשלחת בחירה
+(אין מפרשים לספר, בחירה אוטומטית שנדחתה כי המשתמש כבר בחר, כשל בטעינת
+המפרשים), מ-`_loadLinksAfterCommentatorsResolved`. כרטיסייה שנפתחת עם
+מפרשים ידועים ממשיכה לטעון קישורים מיד כמו קודם.
+
+## בדיקות
+
+`test/text_book/bloc/commentary_links_no_not_found_flash_test.dart` — מריץ
+`LoadContent` על BLoC אמיתי עם מאגר מזויף שבו רשימת המפרשים איטית מהקישורים
+(כמו במציאות), ומוודא שמרגע "טוען" אין אף מצב שבו החלונית הייתה מציגה
+"לא נמצאו" לפני התוצאות. נכשלת על `dev` ועוברת עם התיקון.
+
+בדיקות ממוקדות: `test/text_book/`, `test/tabs/`, `test/plugins/bridge/` —
+**2,354 עברו, 0 נכשלו**.
+
+## אימות ויזואלי
+
+ההבזק נמשך פריים אחד ואינו ניתן לצילום אמין; ההוכחה היא רצף המצבים
+שנמדד מה-BLoC לפני התיקון (למעלה) ובדיקת הרגרסיה שמוודאת שהוא אינו חוזר.
+
+## סוויטה מלאה
+
+`flutter test`: **11,609 עברו, 11 נכשלו, 9 דולגו**. הכשלים: הבסיס הסביבתי
+המוכר (release_packaging, ‏3×file_sync_compaction, ‏personal_notes_file_backed_book,
+‏plugin_spec_freshness, ‏search_scope_menu flake, ‏change_location_dialog),
+‏`plugin_side_panel_test` שאינו מתקמפל ב-`dev` מאז עדכון file_picker
+(`_FakePlatformFile` חסר `lengthSync`), ושני flakes-תחת-עומס שעוברים בהרצה
+מבודדת (`index_freshness_warner_test`, `raised_markers_perf_test`). אפס
+רגרסיות.


### PR DESCRIPTION
Fixes #1130

## שורש הבאג
בפתיחת ספר `_onLoadContent` מפעיל במקביל את טעינת הקישורים ואת טעינת המפרשים. כשעדיין אין בחירת מפרשים, `_resolveTargetBookTitlesForLinks` מחזיר רשימת יעדים ריקה — הקישורים חוזרים בלי מפרשים, `linksLoading` יורד ל-false, וחלונית המפרשים מסיקה "לא נמצאו מפרשים לקטע הנבחר". רק אחר כך מגיעה בחירת ברירת-המחדל (`UpdateCommentators`) ומפעילה טעינה חוזרת — "טוען" שוב ואז התוצאות. רצף המצבים שנמדד מה-BLoC ב-`dev` מתועד ב-`test_results/2026-09-02-commentary-panel-not-found-flash.md`.

## הפתרון
כשנדרשת טעינת מפרשים והבחירה עדיין ריקה, טעינת הקישורים נדחית עד שהבחירה נפתרת: המצב ההתחלתי מסומן `linksLoading: true` (החלונית מציגה "טוען"), והטעינה יוצאת מ-`UpdateCommentators` — או, במסלולים שבהם לא נשלחת בחירה (אין מפרשים לספר, בחירה אוטומטית שנדחתה כי המשתמש כבר בחר, כשל בטעינת המפרשים), מ-`_loadLinksAfterCommentatorsResolved`. כרטיסייה שנפתחת עם מפרשים ידועים ממשיכה לטעון קישורים מיד כמו קודם.

## בדיקות
- חדש: `test/text_book/bloc/commentary_links_no_not_found_flash_test.dart` — BLoC אמיתי עם מאגר מזויף שבו רשימת המפרשים איטית מהקישורים (כמו במציאות); מוודא שמרגע "טוען" אין אף מצב "לא נמצאו" לפני התוצאות. נכשל על `dev` (קומיט האימות `bc325ddc`) ועובר עם התיקון.
- `test/text_book/`, `test/tabs/`, `test/plugins/bridge/`: 2,354 עברו.
- `flutter analyze` נקי. סוויטה מלאה: 11,609 עברו; 11 כשלים = הבסיס הסביבתי המוכר, `plugin_side_panel_test` שאינו מתקמפל ב-`dev` מאז עדכון file_picker, ושני flakes תחת עומס שעוברים מבודדים. אפס רגרסיות.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
