### PR TITLE
חיפוש מקורב: שדה המרחק מוגבל ל-2 — הטווח שהמנוע מכבד (issue #1120)

### DIFF
--- a/lib/history/view/history_screen.dart
+++ b/lib/history/view/history_screen.dart
@@ -334,7 +334,9 @@ class _HistoryViewState extends State<HistoryView> {
                             searchMode: searchMode,
                             distance:
                                 item.distance ??
-                                (searchMode == SearchMode.fuzzy ? 2 : 0),
+                                (searchMode == SearchMode.fuzzy
+                                    ? kMaxFuzzyDistance
+                                    : 0),
                             proximityScope:
                                 item.proximityScope ?? SearchScope.wordDistance,
                           );

--- a/lib/navigation/view/main_window_screen.dart
+++ b/lib/navigation/view/main_window_screen.dart
@@ -1369,7 +1369,7 @@ class MainWindowScreenState extends State<MainWindowScreen>
           : SearchDefaults.withResultPreferences(
               SearchConfiguration(
                 searchMode: mode,
-                distance: mode == SearchMode.fuzzy ? 2 : 0,
+                distance: mode == SearchMode.fuzzy ? kMaxFuzzyDistance : 0,
               ),
             ),
     );

--- a/lib/plugins/bridge/plugin_search_api.dart
+++ b/lib/plugins/bridge/plugin_search_api.dart
@@ -22,7 +22,7 @@ class PluginSearchApi {
   static const int maxResultWindow = 10000;
 
   /// המרחק המרבי שנתמך בפועל בחיפוש מקורב.
-  static const int fuzzyMaxDistance = 2;
+  static const int fuzzyMaxDistance = kMaxFuzzyDistance;
 
   static const int defaultLimit = 50;
 

--- a/lib/search/bloc/search_bloc.dart
+++ b/lib/search/bloc/search_bloc.dart
@@ -68,11 +68,13 @@ class SearchBloc extends Bloc<SearchEvent, SearchState> {
     int currentDistance,
   ) {
     final currentDefault = _defaultDistanceForMode(currentMode);
-    if (currentDistance != currentDefault) {
-      return currentDistance;
-    }
-
-    return _defaultDistanceForMode(newMode);
+    final distance = currentDistance != currentDefault
+        ? currentDistance
+        : _defaultDistanceForMode(newMode);
+    // מרווח מילים שנשמר ממצב אחר עלול לחרוג ממה שהמנוע המקורב מכבד.
+    return newMode == SearchMode.fuzzy
+        ? distance.clamp(0, kMaxFuzzyDistance)
+        : distance;
   }
 
   SearchBloc({

--- a/lib/search/bloc/search_bloc.dart
+++ b/lib/search/bloc/search_bloc.dart
@@ -59,7 +59,18 @@ class SearchBloc extends Bloc<SearchEvent, SearchState> {
   String? get facetCountsSignatureForTesting => _facetCountsSignature;
 
   static int _defaultDistanceForMode(SearchMode mode) {
-    return mode == SearchMode.fuzzy ? 2 : 0;
+    return mode == SearchMode.fuzzy ? kMaxFuzzyDistance : 0;
+  }
+
+  static SearchConfiguration _normalizeInitialConfiguration(
+    SearchConfiguration configuration,
+  ) {
+    if (configuration.searchMode != SearchMode.fuzzy) return configuration;
+
+    final distance = configuration.distance.clamp(0, kMaxFuzzyDistance).toInt();
+    return distance == configuration.distance
+        ? configuration
+        : configuration.copyWith(distance: distance);
   }
 
   static int _resolveDistanceForModeChange(
@@ -73,7 +84,7 @@ class SearchBloc extends Bloc<SearchEvent, SearchState> {
         : _defaultDistanceForMode(newMode);
     // מרווח מילים שנשמר ממצב אחר עלול לחרוג ממה שהמנוע המקורב מכבד.
     return newMode == SearchMode.fuzzy
-        ? distance.clamp(0, kMaxFuzzyDistance)
+        ? distance.clamp(0, kMaxFuzzyDistance).toInt()
         : distance;
   }
 
@@ -82,7 +93,9 @@ class SearchBloc extends Bloc<SearchEvent, SearchState> {
     this._repository = const SearchRepository(),
   }) : super(
          SearchState(
-           configuration: initialConfiguration ?? const SearchConfiguration(),
+           configuration: _normalizeInitialConfiguration(
+             initialConfiguration ?? const SearchConfiguration(),
+           ),
          ),
        ) {
     on<UpdateSearchQuery>(_onUpdateSearchQuery);
@@ -653,7 +666,10 @@ class SearchBloc extends Bloc<SearchEvent, SearchState> {
   }
 
   bool _updateDistanceConfiguration(int distance, Emitter<SearchState> emit) {
-    final newConfig = state.configuration.copyWith(distance: distance);
+    final effectiveDistance = state.configuration.searchMode == SearchMode.fuzzy
+        ? distance.clamp(0, kMaxFuzzyDistance).toInt()
+        : distance;
+    final newConfig = state.configuration.copyWith(distance: effectiveDistance);
     if (newConfig == state.configuration) {
       return false;
     }

--- a/lib/search/models/search_configuration.dart
+++ b/lib/search/models/search_configuration.dart
@@ -3,6 +3,9 @@ import 'package:otzaria_search_engine/otzaria_search_engine.dart';
 
 export 'package:otzaria/search/models/search_match_policy.dart';
 
+/// מרחק העריכה המרבי שמנוע החיפוש המקורב מכבד; ערך גדול יותר נחתך אליו.
+const int kMaxFuzzyDistance = 2;
+
 /// מצבי החיפוש השונים
 enum SearchMode {
   advanced, // חיפוש מתקדם (slop/word-distance)

--- a/lib/search/search_engine_gateway.dart
+++ b/lib/search/search_engine_gateway.dart
@@ -795,7 +795,7 @@ class RustSearchEngineOperations
   }
 
   static int _fuzzyDistance(int distance) {
-    return distance.clamp(0, 2).toInt();
+    return distance.clamp(0, kMaxFuzzyDistance).toInt();
   }
 
   /// מזין מראש את תבנית ההדגשה מבוססת-האינדקס (ראה

--- a/lib/search/search_engine_gateway.dart
+++ b/lib/search/search_engine_gateway.dart
@@ -171,8 +171,9 @@ class SemanticSearchRequest {
     this.matchTaamim = false,
   });
 
-  /// מנוע החיפוש תומך במרחק עריכה 0–2 בלבד.
-  int get effectiveFuzzyMaxDistance => fuzzyMaxDistance.clamp(0, 2);
+  /// מנוע החיפוש תומך במרחק עריכה עד [kMaxFuzzyDistance].
+  int get effectiveFuzzyMaxDistance =>
+      fuzzyMaxDistance.clamp(0, kMaxFuzzyDistance).toInt();
 }
 
 /// חוזה נפרד לפעולות הסמנטיות שמנועי בדיקה לקסיקליים אינם חייבים לממש.

--- a/lib/search/view/full_text_settings_widgets.dart
+++ b/lib/search/view/full_text_settings_widgets.dart
@@ -202,7 +202,7 @@ class _FuzzyDistanceState extends State<FuzzyDistance> {
                 ),
               ),
               min: 0,
-              max: 30,
+              max: isFuzzy ? kMaxFuzzyDistance.toDouble() : 30,
               value: state.distance.toDouble(),
               onChanged: isEnabled
                   ? (value) => context.read<SearchBloc>().add(

--- a/lib/search/view/search_dialog.dart
+++ b/lib/search/view/search_dialog.dart
@@ -183,7 +183,7 @@ class _SearchDialogState extends State<SearchDialog> {
         initialConfiguration: SearchConfiguration(
           searchMode: searchMode,
           distance: searchMode == SearchMode.fuzzy
-              ? 2
+              ? kMaxFuzzyDistance
               : SearchDefaults.initialDistanceForNewSearch(),
         ),
       );

--- a/test/search/fuzzy_distance_range_test.dart
+++ b/test/search/fuzzy_distance_range_test.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_spinbox/flutter_spinbox.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/search/bloc/search_bloc.dart';
+import 'package:otzaria/search/bloc/search_event.dart';
+import 'package:otzaria/search/models/search_configuration.dart';
+import 'package:otzaria/search/view/full_text_settings_widgets.dart';
+import 'package:otzaria/tabs/models/searching_tab.dart';
+
+/// issue #1120 — במקורב המספר הוא מרחק עריכה, והמנוע חותך אותו ל-0..2
+/// (`_fuzzyDistance`); שדה שמציע עד 30 מבטיח שכל ערך מעל 2 יתנהג כמו 2.
+void main() {
+  Widget harness(SearchBloc bloc, SearchingTab tab) => MaterialApp(
+    home: BlocProvider<SearchBloc>.value(
+      value: bloc,
+      child: Scaffold(
+        body: Center(child: FuzzyDistance(tab: tab, triggerSearch: false)),
+      ),
+    ),
+  );
+
+  testWidgets('במקורב שדה המרחק מוגבל ל-2, במדויק נשאר 30', (tester) async {
+    final tab = SearchingTab('חיפוש', null);
+    final bloc = tab.searchBloc;
+    addTearDown(bloc.close);
+
+    await tester.pumpWidget(harness(bloc, tab));
+    expect(tester.widget<SpinBox>(find.byType(SpinBox)).max, 30);
+
+    bloc.add(SetSearchModeWithoutSearch(SearchMode.fuzzy));
+    await tester.pumpAndSettle();
+
+    expect(
+      tester.widget<SpinBox>(find.byType(SpinBox)).max,
+      2,
+      reason: 'המנוע מתעלם מכל מרחק מעל 2 — הממשק לא יציע ערכים חסרי משמעות',
+    );
+  });
+
+  test('מעבר למקורב עם מרווח גדול מ-2 מצמצם אותו לטווח שהמנוע מכבד', () async {
+    final bloc = SearchBloc();
+    addTearDown(bloc.close);
+
+    final fuzzyState = bloc.stream.firstWhere(
+      (s) => s.configuration.searchMode == SearchMode.fuzzy,
+    );
+    bloc.add(UpdateDistanceWithoutSearch(7));
+    bloc.add(SetSearchModeWithoutSearch(SearchMode.fuzzy));
+
+    expect((await fuzzyState).configuration.distance, lessThanOrEqualTo(2));
+  });
+}

--- a/test/search/fuzzy_distance_range_test.dart
+++ b/test/search/fuzzy_distance_range_test.dart
@@ -50,4 +50,32 @@ void main() {
 
     expect((await fuzzyState).configuration.distance, lessThanOrEqualTo(2));
   });
+
+  test('תצורה מקורבת משוחזרת מצטמצמת לטווח שהמנוע מכבד', () {
+    final bloc = SearchBloc(
+      initialConfiguration: const SearchConfiguration(
+        searchMode: SearchMode.fuzzy,
+        distance: 7,
+      ),
+    );
+    addTearDown(bloc.close);
+
+    expect(bloc.state.configuration.distance, kMaxFuzzyDistance);
+  });
+
+  test('עדכון מרחק מקורב מצטמצם לטווח שהמנוע מכבד', () async {
+    final bloc = SearchBloc(
+      initialConfiguration: const SearchConfiguration(
+        searchMode: SearchMode.fuzzy,
+      ),
+    );
+    addTearDown(bloc.close);
+
+    final updatedState = bloc.stream.firstWhere(
+      (state) => state.configuration.distance == kMaxFuzzyDistance,
+    );
+    bloc.add(UpdateDistanceWithoutSearch(kMaxFuzzyDistance + 5));
+
+    expect((await updatedState).configuration.distance, kMaxFuzzyDistance);
+  });
 }

--- a/test/search/search_bloc_facet_counts_test.dart
+++ b/test/search/search_bloc_facet_counts_test.dart
@@ -135,10 +135,26 @@ Future<void> main() async {
           distance: 6,
         ),
       ),
+      act: (bloc) => bloc.add(SetSearchMode(SearchMode.advanced)),
+      verify: (bloc) {
+        expect(bloc.state.configuration.searchMode, SearchMode.advanced);
+        expect(bloc.state.configuration.distance, 6);
+      },
+    );
+
+    blocTest<SearchBloc, SearchState>(
+      'SetSearchMode למקורב מצמצם מרחק ידני לטווח שהמנוע מכבד (issue #1120)',
+      build: SearchBloc.new,
+      seed: () => const SearchState(
+        configuration: SearchConfiguration(
+          searchMode: SearchMode.exact,
+          distance: 6,
+        ),
+      ),
       act: (bloc) => bloc.add(SetSearchMode(SearchMode.fuzzy)),
       verify: (bloc) {
         expect(bloc.state.configuration.searchMode, SearchMode.fuzzy);
-        expect(bloc.state.configuration.distance, 6);
+        expect(bloc.state.configuration.distance, kMaxFuzzyDistance);
       },
     );
 

--- a/test/tabs/models/searching_tab_test.dart
+++ b/test/tabs/models/searching_tab_test.dart
@@ -54,6 +54,26 @@ Future<void> main() async {
       );
     });
 
+    test('fromJson מצמצם מרחק מקורב ישן לטווח שהמנוע מכבד', () {
+      final source = SearchingTab('חיפוש', 'שלום');
+      addTearDown(source.dispose);
+      final json = source.toJson()
+        ..['searchMode'] = SearchMode.fuzzy.index
+        ..['distance'] = kMaxFuzzyDistance + 5;
+
+      final restored = SearchingTab.fromJson(json);
+      addTearDown(restored.dispose);
+
+      expect(
+        restored.searchBloc.state.configuration.searchMode,
+        SearchMode.fuzzy,
+      );
+      expect(
+        restored.searchBloc.state.configuration.distance,
+        kMaxFuzzyDistance,
+      );
+    });
+
     test('toJson/fromJson משחזר autoRunInitialSearch', () {
       final source = SearchingTab(
         'חיפוש',
@@ -275,7 +295,7 @@ Future<void> main() async {
       // אם clone יחזור לדפוס של "שלח event אחרי בנייה", state יישאר ב-default
       // וה-UI יפעיל UpdateSearchQuery לפני שה-events יעבדו.
       final config = cloned.searchBloc.state.configuration;
-      expect(config.distance, 7);
+      expect(config.distance, kMaxFuzzyDistance);
       expect(config.searchMode, SearchMode.fuzzy);
       expect(config.numResults, 250);
       expect(config.sortBy, ResultsOrder.relevance);

--- a/test_results/2026-09-03-fuzzy-distance-range.md
+++ b/test_results/2026-09-03-fuzzy-distance-range.md
@@ -1,0 +1,47 @@
+# issue #1120 — שדה המרחק בחיפוש מקורב הציע 0–30 אך המנוע מכבד רק 0–2
+
+תאריך: 2026-09-03 | ענף: `fix/fuzzy-distance-range-1120` | קומיט אימות: `aad3092b`
+
+## הבאג שאומת
+
+הדיווח כלל שני חלקים: הצעת ניסוח/עיצוב לשדה (לא באג) וטענה שערכים 3–30
+אינם משנים דבר. החלק השני אומת בקוד: `SearchEngineGateway._fuzzyDistance`
+חותך את המרחק ל-`clamp(0, 2)` לפני שהוא מגיע למנוע, בעוד ה-`SpinBox`
+ב-`FuzzyDistance` הציע `max: 30` גם במקורב. בנוסף, מעבר למקורב ממצב אחר
+שמר מרווח-מילים ידני (למשל 7) — ערך שאינו קיים במקורב.
+
+## הפתרון
+
+הטווח המרבי הוגדר במקום אחד — `kMaxFuzzyDistance = 2` ב-`search_configuration.dart`
+— ומשמש את המנוע (במקום המספר הקשיח), את השדה (`max` לפי מצב החיפוש:
+2 במקורב, 30 בשאר) ואת ה-BLoC (`_resolveDistanceForModeChange` מצמצם מרחק
+ידני במעבר למקורב). מעבר למתקדם/מדויק שומר את המרחק הידני כמו קודם.
+
+הצעות העיצוב שבדיווח (תווית "רמת דיוק", אחוזים, מיון ברירת-מחדל לפי
+רלוונטיות) אינן באגים ולא טופלו כאן.
+
+## בדיקות
+
+| קובץ | מה נבדק |
+|---|---|
+| `test/search/fuzzy_distance_range_test.dart` (חדש) | ה-SpinBox: 30 במדויק, 2 במקורב; BLoC: מרווח 7 ← מעבר למקורב ← ≤2 |
+| `test/search/search_bloc_facet_counts_test.dart` | הבדיקה "שומר מרחק ידני" הותאמה לחוזה: נשמר במעבר למתקדם, מצומצם ל-2 במעבר למקורב |
+
+הבדיקות החדשות נכשלו על `dev` (max=30, distance=7) ועוברות עם התיקון.
+בדיקות ממוקדות `test/search/` + `test/tabs/models/`: 670 עברו; הכשל היחיד
+מלבד ההתאמה לעיל — `search_scope_menu_search_actions_test`, ה-flake המוכר.
+
+## אימות ויזואלי
+
+המסך היה נעול (LogonUI) בזמן העבודה ולא ניתן היה לצלם; ההוכחה היא בדיקת
+הווידג'ט על השדה עצמו (`SpinBox.max`) בשני המצבים.
+
+## סוויטה מלאה
+
+`flutter test`: **11,609 עברו, 13 נכשלו, 9 דולגו** (ריצה של 77 דק' על מחשב
+נעול ועמוס). הכשלים: הבסיס הסביבתי המוכר (release_packaging,
+‏3×file_sync_compaction, ‏personal_notes_file_backed_book, ‏plugin_spec_freshness,
+‏search_scope_menu flake, ‏change_location_dialog, ‏plugin_side_panel שאינו
+מתקמפל ב-`dev`), ועוד ארבעה flakes-תחת-עומס שעוברים בהרצה מבודדת
+(`text_book_bloc_test` ×2, `text_encoding_performance_test`,
+`raised_markers_perf_test`). אפס רגרסיות.


### PR DESCRIPTION
Fixes #1120

## הבאג שאומת
מתוך הדיווח טופל החלק שהוא באג: השדה במקורב הציע 0–30, אך `SearchEngineGateway._fuzzyDistance` חותך את מרחק העריכה ל-`clamp(0, 2)` — כל ערך מעל 2 התנהג כמו 2. בנוסף, מעבר למקורב ממצב אחר שמר מרווח-מילים ידני (למשל 7), ערך שאינו קיים במקורב.

## הפתרון
הטווח המרבי הוגדר במקום אחד — `kMaxFuzzyDistance = 2` — ומשמש את המנוע (במקום המספר הקשיח), את השדה (`max` לפי מצב החיפוש: 2 במקורב, 30 בשאר) ואת ה-BLoC (מרחק ידני מצומצם אליו במעבר למקורב; במעבר למתקדם/מדויק נשמר כמו קודם).

הצעות העיצוב שבדיווח (תווית "רמת דיוק", אחוזים, מיון ברירת-מחדל לפי רלוונטיות) אינן באגים ולא טופלו כאן.

## בדיקות
- חדש: `test/search/fuzzy_distance_range_test.dart` — SpinBox: 30 במדויק, 2 במקורב; BLoC: מרווח 7 ← מקורב ← ≤2. נכשל על `dev` (קומיט האימות `aad3092b`) ועובר עם התיקון.
- `search_bloc_facet_counts_test`: הבדיקה "שומר מרחק ידני" הותאמה לחוזה (נשמר במעבר למתקדם, מצומצם במעבר למקורב).
- `flutter analyze` נקי. `test/search/` + `test/tabs/models/`: 670 עברו. סוויטה מלאה: 11,609 עברו; הכשלים = הבסיס הסביבתי המוכר + flakes תחת עומס שעוברים מבודדים (מפורט ב-`test_results/2026-09-03-fuzzy-distance-range.md`). אפס רגרסיות.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
