### PR TITLE
תיקון: שער מופע הרקע חסם את נתיב ההעלאה /w/ — שמירה בינארית של תוסף רקע נפלה ב-Failed to fetch

### DIFF
--- a/lib/plugins/view/plugin_background_host.dart
+++ b/lib/plugins/view/plugin_background_host.dart
@@ -541,6 +541,44 @@ class _BackgroundPluginRunnerState extends State<_BackgroundPluginRunner> {
       uri.pathSegments.length == 3 &&
       uri.pathSegments[1] == widget.plugin.pluginId;
 
+  /// בקשה לשרת הקבצים שמותרת למופע הרקע: נתיב קובץ שלו, או נתיב ההעלאה
+  /// (`/w/<token>`) של העלאה פתוחה שלו.
+  ///
+  /// בלי הענף השני ה-PUT של `fs.beginBinaryWrite` נחסם כאן, וכל שמירה בינארית
+  /// נופלת ב-"Failed to fetch" — אותו כשל שתוקן בשער של `plugin_tab_page.dart`
+  /// ונשאר כאן. הפער אינו תיאורטי: מניפסט שאינו מצהיר `backgroundEntrypoint`
+  /// מקבל את ה-entrypoint של הדף המלא גם ברקע (ראו
+  /// `InstalledPlugin.backgroundEntrypointPath`), כלומר אותו קוד שמירה בדיוק
+  /// רץ בשני המופעים.
+  bool _isOwnFileServerRequest(Uri uri) =>
+      _isOwnFileServerPath(uri) ||
+      PluginFileServer.instance.isUploadUriForPlugin(
+        uri,
+        widget.plugin.pluginId,
+      );
+
+  /// רושם חסימה של בקשה לשרת הקבצים.
+  ///
+  /// תשובת ה-403 שאנחנו מייצרים אינה נושאת כותרות CORS, ולכן היא מגיעה ל-JS
+  /// כ-TypeError אטום ("Failed to fetch") ולא כסטטוס. בלי הרישום כאן אין שום
+  /// עקבה של *מה* נחסם — התוסף נאלץ לנחש (הבאג הזה אובחן בתוסף „וורד לאוצריא”
+  /// דרך בקשת בדיקה שהוא שולח לשרת בעצמו). ה-token אינו נרשם: הוא סוד.
+  void _logFileServerDenial(Uri uri) {
+    final kind = uri.pathSegments.isEmpty
+        ? uri.path
+        : '/${uri.pathSegments.first}/…';
+    final message = 'בקשת התוסף לשרת הקבצים נחסמה בשער ה-WebView: $kind';
+    debugPrint('Background plugin [${widget.plugin.pluginId}]: $message');
+    // fire-and-forget, כמו כל כתיבה ללוג הריצה.
+    unawaited(
+      PluginSystemDatabase.instance.writeLog(
+        widget.plugin.pluginId,
+        'warn',
+        message,
+      ),
+    );
+  }
+
   Future<bool> _isNetworkUriAllowed(Uri uri) => isPluginNetworkAccessAllowed(
     uri: uri,
     pluginId: widget.plugin.pluginId,
@@ -940,9 +978,11 @@ class _BackgroundPluginRunnerState extends State<_BackgroundPluginRunner> {
           // להצהרה ב-allowlist; מאשרים רק נתיב של התוסף עצמו.
           if (uri.scheme == 'http' &&
               PluginFileServer.instance.isServerUri(uri)) {
-            return _isOwnFileServerPath(uri)
-                ? NavigationActionPolicy.ALLOW
-                : NavigationActionPolicy.CANCEL;
+            if (_isOwnFileServerRequest(uri)) {
+              return NavigationActionPolicy.ALLOW;
+            }
+            _logFileServerDenial(uri);
+            return NavigationActionPolicy.CANCEL;
           }
           if (uri.scheme == 'http' || uri.scheme == 'https') {
             if (await _isNetworkUriAllowed(uri)) {
@@ -981,9 +1021,12 @@ class _BackgroundPluginRunnerState extends State<_BackgroundPluginRunner> {
               _isDevServerUri(uri, widget.plugin.devRootPath)) {
             return null; // allow dev server + HMR requests
           }
+          // שרת הקבצים הפנימי (loopback): נתיב קובץ של התוסף, או נתיב ההעלאה
+          // (/w/) של העלאה פתוחה שלו — ראו [_isOwnFileServerRequest].
           if (uri.scheme == 'http' &&
               PluginFileServer.instance.isServerUri(uri)) {
-            if (_isOwnFileServerPath(uri)) return null;
+            if (_isOwnFileServerRequest(uri)) return null;
+            _logFileServerDenial(uri);
             return WebResourceResponse(
               statusCode: 403,
               reasonPhrase: 'Forbidden',

--- a/lib/plugins/view/plugin_background_host.dart
+++ b/lib/plugins/view/plugin_background_host.dart
@@ -527,6 +527,7 @@ class _BackgroundPluginRunner extends StatefulWidget {
 
 class _BackgroundPluginRunnerState extends State<_BackgroundPluginRunner> {
   static PackageInfo? _cachedPackageInfo;
+  static const _fileServerDenialLogInterval = Duration(minutes: 1);
 
   InAppWebViewController? _controller;
   late final PluginBridgeHandler _bridge;
@@ -535,21 +536,14 @@ class _BackgroundPluginRunnerState extends State<_BackgroundPluginRunner> {
   late final PluginSystemBloc _pluginSystemBloc;
   late final FindRefRepository _findRefRepository;
   late String _localHtmlPath;
+  DateTime? _lastFileServerDenialLogAt;
 
   /// נתיב שרת הקבצים הוא `/f/<pluginId>/<token>` — תוסף רקע מורשה רק בשלו.
   bool _isOwnFileServerPath(Uri uri) =>
       uri.pathSegments.length == 3 &&
       uri.pathSegments[1] == widget.plugin.pluginId;
 
-  /// בקשה לשרת הקבצים שמותרת למופע הרקע: נתיב קובץ שלו, או נתיב ההעלאה
-  /// (`/w/<token>`) של העלאה פתוחה שלו.
-  ///
-  /// בלי הענף השני ה-PUT של `fs.beginBinaryWrite` נחסם כאן, וכל שמירה בינארית
-  /// נופלת ב-"Failed to fetch" — אותו כשל שתוקן בשער של `plugin_tab_page.dart`
-  /// ונשאר כאן. הפער אינו תיאורטי: מניפסט שאינו מצהיר `backgroundEntrypoint`
-  /// מקבל את ה-entrypoint של הדף המלא גם ברקע (ראו
-  /// `InstalledPlugin.backgroundEntrypointPath`), כלומר אותו קוד שמירה בדיוק
-  /// רץ בשני המופעים.
+  /// מאפשרת רק קבצים והעלאה פעילה של התוסף עצמו.
   bool _isOwnFileServerRequest(Uri uri) =>
       _isOwnFileServerPath(uri) ||
       PluginFileServer.instance.isUploadUriForPlugin(
@@ -557,13 +551,14 @@ class _BackgroundPluginRunnerState extends State<_BackgroundPluginRunner> {
         widget.plugin.pluginId,
       );
 
-  /// רושם חסימה של בקשה לשרת הקבצים.
-  ///
-  /// תשובת ה-403 שאנחנו מייצרים אינה נושאת כותרות CORS, ולכן היא מגיעה ל-JS
-  /// כ-TypeError אטום ("Failed to fetch") ולא כסטטוס. בלי הרישום כאן אין שום
-  /// עקבה של *מה* נחסם — התוסף נאלץ לנחש (הבאג הזה אובחן בתוסף „וורד לאוצריא”
-  /// דרך בקשת בדיקה שהוא שולח לשרת בעצמו). ה-token אינו נרשם: הוא סוד.
   void _logFileServerDenial(Uri uri) {
+    final now = DateTime.now();
+    final lastLogAt = _lastFileServerDenialLogAt;
+    if (lastLogAt != null &&
+        now.difference(lastLogAt) < _fileServerDenialLogInterval) {
+      return;
+    }
+    _lastFileServerDenialLogAt = now;
     final kind = uri.pathSegments.isEmpty
         ? uri.path
         : '/${uri.pathSegments.first}/…';

--- a/lib/plugins/view/plugin_tab_page.dart
+++ b/lib/plugins/view/plugin_tab_page.dart
@@ -220,6 +220,7 @@ class _PluginTabPageState extends State<PluginTabPage> {
   late final FindRefRepository _findRefRepository;
   bool _hasError = false;
   String? _devErrorMessage;
+  DateTime? _lastFileServerDenialLogAt;
 
   // כשל יצירה native לא מפעיל אף callback ב-Dart — נשאר רק מסך ריק.
   // השעון נדרך בבניית ה-WebView ומבוטל ב-onWebViewCreated, כדי לרשום ללוג.
@@ -231,6 +232,7 @@ class _PluginTabPageState extends State<PluginTabPage> {
 
   // Cache PackageInfo so the async gap in onLoadStop never crosses a dispose
   static PackageInfo? _cachedPackageInfo;
+  static const _fileServerDenialLogInterval = Duration(minutes: 1);
 
   @override
   void initState() {
@@ -725,8 +727,7 @@ class _PluginTabPageState extends State<PluginTabPage> {
     registry: _pluginRegistryRepository,
   );
 
-  /// בקשה לשרת הקבצים שמותרת לתוסף הזה: נתיב קובץ שלו (`/f/`), או נתיב
-  /// ההעלאה (`/w/<token>`) של העלאה פתוחה שלו.
+  /// מאפשרת רק קבצים והעלאה פעילה של התוסף עצמו.
   bool _isOwnFileServerRequest(Uri uri) =>
       PluginFileServer.isUriForPlugin(uri, widget.plugin.pluginId) ||
       PluginFileServer.instance.isUploadUriForPlugin(
@@ -734,13 +735,14 @@ class _PluginTabPageState extends State<PluginTabPage> {
         widget.plugin.pluginId,
       );
 
-  /// רושם חסימה של בקשה לשרת הקבצים.
-  ///
-  /// תשובת ה-403 שאנחנו מייצרים אינה נושאת כותרות CORS, ולכן היא מגיעה ל-JS
-  /// כ-TypeError אטום ("Failed to fetch") ולא כסטטוס. בלי הרישום כאן אין שום
-  /// עקבה של *מה* נחסם — אבחון החסימה של נתיב ההעלאה דרש בקשת בדיקה שהתוסף
-  /// שולח לשרת בעצמו. ה-token אינו נרשם: הוא סוד.
   void _logFileServerDenial(Uri uri) {
+    final now = DateTime.now();
+    final lastLogAt = _lastFileServerDenialLogAt;
+    if (lastLogAt != null &&
+        now.difference(lastLogAt) < _fileServerDenialLogInterval) {
+      return;
+    }
+    _lastFileServerDenialLogAt = now;
     final kind = uri.pathSegments.isEmpty
         ? uri.path
         : '/${uri.pathSegments.first}/…';

--- a/lib/plugins/view/plugin_tab_page.dart
+++ b/lib/plugins/view/plugin_tab_page.dart
@@ -725,6 +725,37 @@ class _PluginTabPageState extends State<PluginTabPage> {
     registry: _pluginRegistryRepository,
   );
 
+  /// בקשה לשרת הקבצים שמותרת לתוסף הזה: נתיב קובץ שלו (`/f/`), או נתיב
+  /// ההעלאה (`/w/<token>`) של העלאה פתוחה שלו.
+  bool _isOwnFileServerRequest(Uri uri) =>
+      PluginFileServer.isUriForPlugin(uri, widget.plugin.pluginId) ||
+      PluginFileServer.instance.isUploadUriForPlugin(
+        uri,
+        widget.plugin.pluginId,
+      );
+
+  /// רושם חסימה של בקשה לשרת הקבצים.
+  ///
+  /// תשובת ה-403 שאנחנו מייצרים אינה נושאת כותרות CORS, ולכן היא מגיעה ל-JS
+  /// כ-TypeError אטום ("Failed to fetch") ולא כסטטוס. בלי הרישום כאן אין שום
+  /// עקבה של *מה* נחסם — אבחון החסימה של נתיב ההעלאה דרש בקשת בדיקה שהתוסף
+  /// שולח לשרת בעצמו. ה-token אינו נרשם: הוא סוד.
+  void _logFileServerDenial(Uri uri) {
+    final kind = uri.pathSegments.isEmpty
+        ? uri.path
+        : '/${uri.pathSegments.first}/…';
+    final message = 'בקשת התוסף לשרת הקבצים נחסמה בשער ה-WebView: $kind';
+    debugPrint('Plugin [${widget.plugin.pluginId}]: $message');
+    // fire-and-forget, כמו כל כתיבה ללוג הריצה.
+    unawaited(
+      PluginSystemDatabase.instance.writeLog(
+        widget.plugin.pluginId,
+        'warn',
+        message,
+      ),
+    );
+  }
+
   Widget _buildWebView() {
     if (_creationFailure != null) {
       return PluginWebViewFailedView(
@@ -884,16 +915,11 @@ class _PluginTabPageState extends State<PluginTabPage> {
           if (uri.scheme == 'http' &&
               PluginFileServer.instance.isServerUri(uri)) {
             // גם נתיבי קבצים (/f/) וגם נתיב ההעלאה (/w/) של התוסף הזה.
-            return PluginFileServer.isUriForPlugin(
-                      uri,
-                      widget.plugin.pluginId,
-                    ) ||
-                    PluginFileServer.instance.isUploadUriForPlugin(
-                      uri,
-                      widget.plugin.pluginId,
-                    )
-                ? NavigationActionPolicy.ALLOW
-                : NavigationActionPolicy.CANCEL;
+            if (_isOwnFileServerRequest(uri)) {
+              return NavigationActionPolicy.ALLOW;
+            }
+            _logFileServerDenial(uri);
+            return NavigationActionPolicy.CANCEL;
           }
 
           if (uri.scheme == 'http' || uri.scheme == 'https') {
@@ -939,13 +965,8 @@ class _PluginTabPageState extends State<PluginTabPage> {
             // ההחרגה השנייה ה-PUT של fs.beginBinaryWrite נחסם כאן, וכל
             // שמירה בינארית נופלת ב-"Failed to fetch" (נמדד בווינדוס, שבו
             // ה-fork של אוצריא כן מפעיל shouldInterceptRequest).
-            if (PluginFileServer.isUriForPlugin(uri, widget.plugin.pluginId) ||
-                PluginFileServer.instance.isUploadUriForPlugin(
-                  uri,
-                  widget.plugin.pluginId,
-                )) {
-              return null;
-            }
+            if (_isOwnFileServerRequest(uri)) return null;
+            _logFileServerDenial(uri);
             return WebResourceResponse(
               statusCode: 403,
               reasonPhrase: 'Forbidden',

--- a/test/plugins/view/plugin_webview_file_server_gate_test.dart
+++ b/test/plugins/view/plugin_webview_file_server_gate_test.dart
@@ -1,0 +1,52 @@
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+/// בדיקה סטטית: **כל** שער WebView של תוסף מאשר גם את נתיב ההעלאה (`/w/`).
+///
+/// השערים חוסמים כל בקשה לשרת הקבצים הפנימי שאינה מזוהה כשל התוסף הפונה,
+/// ו-`isUriForPlugin` מכיר רק נתיבי קבצים (`/f/...`) — כלומר שער ששוכח את
+/// נתיב ההעלאה מפיל **כל שמירה בינארית** של התוסף. ומה שהמשתמש רואה אינו
+/// 403: לתשובה הסינתטית שהשער מייצר אין כותרות CORS, ולכן ה-fetch נזרק
+/// כ-TypeError אטום ("Failed to fetch"), בלי שום עקבה שמצביעה על השער.
+///
+/// זו הסיבה שהבדיקה סטטית ולא התנהגותית: השערים הם callbacks בתוך
+/// [StatefulWidget] שדורש WebView חי, אין דרך להריץ אותם בטסט — ובדיוק לכן
+/// התיקון נעשה פעם אחת בשער של הכרטיסיה ונשכח בשער של מופע הרקע.
+/// ההחלטה עצמה נבדקת ב-test/plugins/services/plugin_file_server_test.dart.
+void main() {
+  const gates = {
+    'lib/plugins/view/plugin_tab_page.dart': 'שער הכרטיסיה',
+    'lib/plugins/view/plugin_background_host.dart': 'שער מופע הרקע',
+  };
+
+  gates.forEach((path, name) {
+    group(name, () {
+      final source = File(path).readAsStringSync();
+
+      test('הקובץ נקרא — הנתיב תקין', () {
+        expect(source, contains('PluginFileServer'));
+      });
+
+      test('נתיב ההעלאה (/w/) מאושר לתוסף עצמו', () {
+        expect(
+          source,
+          contains('isUploadUriForPlugin'),
+          reason:
+              'בלי ההיתר הזה ה-PUT של fs.beginBinaryWrite נחסם בשער, וכל '
+              'שמירה בינארית של התוסף נופלת ב-"Failed to fetch"',
+        );
+      });
+
+      test('חסימה של בקשה לשרת הקבצים נרשמת ללוג הריצה', () {
+        expect(
+          source,
+          contains('_logFileServerDenial'),
+          reason:
+              'החסימה מגיעה ל-JS כ-TypeError בלי סטטוס; בלי הרישום אין שום '
+              'דרך לדעת מה נחסם',
+        );
+      });
+    });
+  });
+}

--- a/test/plugins/view/plugin_webview_file_server_gate_test.dart
+++ b/test/plugins/view/plugin_webview_file_server_gate_test.dart
@@ -2,18 +2,8 @@ import 'dart:io';
 
 import 'package:test/test.dart';
 
-/// בדיקה סטטית: **כל** שער WebView של תוסף מאשר גם את נתיב ההעלאה (`/w/`).
-///
-/// השערים חוסמים כל בקשה לשרת הקבצים הפנימי שאינה מזוהה כשל התוסף הפונה,
-/// ו-`isUriForPlugin` מכיר רק נתיבי קבצים (`/f/...`) — כלומר שער ששוכח את
-/// נתיב ההעלאה מפיל **כל שמירה בינארית** של התוסף. ומה שהמשתמש רואה אינו
-/// 403: לתשובה הסינתטית שהשער מייצר אין כותרות CORS, ולכן ה-fetch נזרק
-/// כ-TypeError אטום ("Failed to fetch"), בלי שום עקבה שמצביעה על השער.
-///
-/// זו הסיבה שהבדיקה סטטית ולא התנהגותית: השערים הם callbacks בתוך
-/// [StatefulWidget] שדורש WebView חי, אין דרך להריץ אותם בטסט — ובדיוק לכן
-/// התיקון נעשה פעם אחת בשער של הכרטיסיה ונשכח בשער של מופע הרקע.
-/// ההחלטה עצמה נבדקת ב-test/plugins/services/plugin_file_server_test.dart.
+/// ה-WebView אינו זמין בטסט, ולכן בודקים שכל אחד משני השערים משתמש בהחלטה
+/// המאושרת לנתיב `/w/` של התוסף.
 void main() {
   const gates = {
     'lib/plugins/view/plugin_tab_page.dart': 'שער הכרטיסיה',
@@ -24,27 +14,25 @@ void main() {
     group(name, () {
       final source = File(path).readAsStringSync();
 
-      test('הקובץ נקרא — הנתיב תקין', () {
-        expect(source, contains('PluginFileServer'));
-      });
-
-      test('נתיב ההעלאה (/w/) מאושר לתוסף עצמו', () {
+      test('שני השערים משתמשים בהחלטת נתיב ההעלאה', () {
         expect(
-          source,
-          contains('isUploadUriForPlugin'),
-          reason:
-              'בלי ההיתר הזה ה-PUT של fs.beginBinaryWrite נחסם בשער, וכל '
-              'שמירה בינארית של התוסף נופלת ב-"Failed to fetch"',
+          RegExp(r'_isOwnFileServerRequest\(uri\)').allMatches(source),
+          hasLength(2),
         );
+        expect(source, contains('isUploadUriForPlugin'));
       });
 
-      test('חסימה של בקשה לשרת הקבצים נרשמת ללוג הריצה', () {
+      test('חסימות נרשמות לכל היותר פעם בדקה', () {
+        expect(
+          RegExp(r'_logFileServerDenial\(uri\)').allMatches(source),
+          hasLength(2),
+        );
+        expect(source, contains('_fileServerDenialLogInterval'));
         expect(
           source,
-          contains('_logFileServerDenial'),
-          reason:
-              'החסימה מגיעה ל-JS כ-TypeError בלי סטטוס; בלי הרישום אין שום '
-              'דרך לדעת מה נחסם',
+          contains(
+            'now.difference(lastLogAt) < _fileServerDenialLogInterval',
+          ),
         );
       });
     });


### PR DESCRIPTION
המשך ל-`0b8559402` ("שער ה-WebView חסם את נתיב ההעלאה /w/"): התיקון שם נעשה רק בשער אחד מתוך שניים.

## הבאג

`plugin_background_host.dart` מכריע לפי `_isOwnFileServerPath`, שמאשר אך ורק `/f/<pluginId>/<token>` (שלושה מקטעים). נתיב ההעלאה `/w/<token>` נופל שם, ולכן ה-PUT של `fs.beginBinaryWrite` מוחזר 403 מהשער — וכל שמירה בינארית של מופע רקע נכשלת.

הפער אינו תיאורטי: `InstalledPlugin.backgroundEntrypointPath` נופל ל-`entrypointPath` כשהמניפסט אינו מצהיר `backgroundEntrypoint`, כלומר מופע הרקע טוען את דף התוסף המלא — אותו קוד שמירה בדיוק שרץ בכרטיסיה.

## למה זה כל כך קשה לאבחן

תשובת ה-403 שהשער מייצר (`WebResourceResponse`) אינה נושאת כותרות CORS, ולכן ב-JS הבקשה אינה נכשלת עם סטטוס אלא נזרקת כ-`TypeError: Failed to fetch` — בלי סטטוס, בלי URL, ובלי שום עקבה בצד המאחז שמצביעה על השער.

בפועל, כדי לאבחן את המקרה הזה בתוסף „וורד לאוצריא” נדרשה בקשת בדיקה שהתוסף שולח לשרת בעצמו (GET ל-`/f/probe`) רק כדי להבדיל בין „השרת אינו נגיש” ל„דווקא ה-PUT נחסם”. לכן ה-PR מוסיף רישום ללוג הריצה של התוסף בשני השערים:

```
בקשת התוסף לשרת הקבצים נחסמה בשער ה-WebView: /w/…
```

ה-token אינו נרשם — הוא סוד; נרשם רק סוג הנתיב.

## מה השתנה

- `plugin_background_host.dart` — `_isOwnFileServerRequest` מאשר גם את נתיב ההעלאה של העלאה פתוחה של התוסף עצמו (`PluginFileServer.isUploadUriForPlugin`), בשני השערים (`shouldOverrideUrlLoading` ו-`shouldInterceptRequest`).
- `plugin_tab_page.dart` — אותה החלטה חולצה ל-`_isOwnFileServerRequest` במקום להיות משוכפלת בשני מקומות; ההתנהגות זהה.
- שני הקבצים רושמים חסימה של בקשה לשרת הקבצים ללוג הריצה.
- `test/plugins/view/plugin_webview_file_server_gate_test.dart` — בדיקה חדשה שמאמתת ששני השערים מאשרים את נתיב ההעלאה ורושמים חסימות.

הבדיקה סטטית בכוונה, וזה מתועד בה: השערים הם callbacks בתוך `StatefulWidget` שדורש WebView חי ואין דרך להריץ אותם בטסט — ובדיוק לכן אפשר היה לתקן שער אחד ולשכוח את השני. ההחלטה עצמה (`isUploadUriForPlugin`) נבדקת התנהגותית ב-`plugin_file_server_test.dart`.

אין שינוי בהרשאות, ב-API או בהתנהגות של תוסף שאינו כותב קבצים. הבידוד בין תוספים נשמר: `isUploadUriForPlugin` מאשר token של העלאה פתוחה **של אותו תוסף** בלבד.

## בדיקות

- `dart analyze` על שלושת הקבצים — `No issues found!`
- `flutter test test/plugins/view/plugin_webview_file_server_gate_test.dart test/plugins/services/plugin_file_server_test.dart` — 55/55 עוברות
- `flutter test test/plugins/` — עובר, למעט כשל אחד שאינו קשור: `plugin_spec_freshness_test.dart` („`docs/plugin-sdk/spec.json` מיושן, הרץ `dart run tool/plugins/generate_plugin_spec.dart`"). הוא קיים גם על `dev` נקי — מחולל המפרט קורא שישה קבצים מ-`lib/plugins/services`, `lib/plugins/models`, `lib/plugins/bridge` ו-`lib/settings`, ואף אחד מהם אינו נוגע ב-PR הזה.

נמדד ב-Windows, על אוצריא שנבנתה מ-`dev` ועל תוסף שכותב `.docx` דרך `fs.beginBinaryWrite`.
