### PR TITLE
תצוגה מקדימה בחיפוש: העברת פרמטרי החיפוש לטאב, לא רק השאילתה

### DIFF
--- a/lib/library/view/book_preview_panel.dart
+++ b/lib/library/view/book_preview_panel.dart
@@ -10,6 +10,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:otzaria/core/messages/messages_exports.dart';
 import 'package:otzaria/core/ui_snack.dart';
 import 'package:otzaria/models/books.dart';
+import 'package:otzaria/search/models/search_configuration.dart';
 import 'package:otzaria/tabs/models/text_tab.dart';
 import 'package:otzaria/text_book/view/combined_view/combined_book_screen.dart';
 import 'package:otzaria/text_book/bloc/text_book_event.dart';
@@ -47,6 +48,16 @@ class BookPreviewPanel extends StatefulWidget {
   /// טקסט להדגשה בסעיף היעד (שאילתת החיפוש שבוצעה).
   final String? searchText;
 
+  /// פרמטרי החיפוש שהניבו את התוצאה. בלעדיהם ההדגשה בתצוגה המקדימה מכירה
+  /// רק את השאילתה המילולית, וכל תוצאה שנמצאה דרך קידומת, מילה חלופית או
+  /// מרחק בין מילים מוצגת בלי הדגשה (issue #1147).
+  final Map<String, Map<String, bool>> searchOptions;
+  final Map<int, List<String>> alternativeWords;
+  final Map<String, String> spacingValues;
+  final SearchMode searchMode;
+  final int searchDistance;
+  final SearchMatchPolicy matchPolicy;
+
   const BookPreviewPanel({
     super.key,
     this.book,
@@ -54,10 +65,47 @@ class BookPreviewPanel extends StatefulWidget {
     this.initialTextIndex,
     this.initialPdfPage,
     this.searchText,
+    this.searchOptions = const {},
+    this.alternativeWords = const {},
+    this.spacingValues = const {},
+    this.searchMode = SearchMode.exact,
+    this.searchDistance = 0,
+    this.matchPolicy = SearchMatchPolicy.standard,
   });
 
   @override
   State<BookPreviewPanel> createState() => _BookPreviewPanelState();
+}
+
+/// טאב הטקסט שהתצוגה המקדימה מרנדרת. חשוף לבדיקה כדי לנעול את העברת
+/// פרמטרי החיפוש — הם קובעים אילו תוצאות מודגשות, ולא רק מה נמצא.
+@visibleForTesting
+TextBookTab buildPreviewTextTab({
+  required TextBook book,
+  required int? targetIndex,
+  String? searchText,
+  Map<String, Map<String, bool>> searchOptions = const {},
+  Map<int, List<String>> alternativeWords = const {},
+  Map<String, String> spacingValues = const {},
+  SearchMode searchMode = SearchMode.exact,
+  int searchDistance = 0,
+  SearchMatchPolicy matchPolicy = SearchMatchPolicy.standard,
+}) {
+  final hasTarget = targetIndex != null;
+  return TextBookTab(
+    book: book,
+    index: targetIndex ?? 0,
+    searchText: hasTarget ? (searchText ?? '') : '',
+    searchOptions: hasTarget ? searchOptions : const {},
+    alternativeWords: hasTarget ? alternativeWords : const {},
+    spacingValues: hasTarget ? spacingValues : const {},
+    searchMode: hasTarget ? searchMode : SearchMode.exact,
+    searchDistance: hasTarget ? searchDistance : 0,
+    matchPolicy: hasTarget ? matchPolicy : SearchMatchPolicy.standard,
+    initialSearchResultLines: hasTarget ? {targetIndex} : null,
+    openLeftPane: false,
+    splitedView: Settings.getValue<bool>('key-splited-view') ?? true,
+  );
 }
 
 class _BookPreviewPanelState extends State<BookPreviewPanel> {
@@ -198,16 +246,18 @@ class _BookPreviewPanelState extends State<BookPreviewPanel> {
   }
 
   void _createTextTab(TextBook textBook) {
-    final targetIndex = widget.initialTextIndex;
     setState(() {
       _isPdfViewerReady = false;
-      _currentTextTab = TextBookTab(
+      _currentTextTab = buildPreviewTextTab(
         book: textBook,
-        index: targetIndex ?? 0,
-        searchText: targetIndex != null ? (widget.searchText ?? '') : '',
-        initialSearchResultLines: targetIndex != null ? {targetIndex} : null,
-        openLeftPane: false,
-        splitedView: Settings.getValue<bool>('key-splited-view') ?? true,
+        targetIndex: widget.initialTextIndex,
+        searchText: widget.searchText,
+        searchOptions: widget.searchOptions,
+        alternativeWords: widget.alternativeWords,
+        spacingValues: widget.spacingValues,
+        searchMode: widget.searchMode,
+        searchDistance: widget.searchDistance,
+        matchPolicy: widget.matchPolicy,
       );
     });
   }

--- a/lib/library/view/book_preview_panel.dart
+++ b/lib/library/view/book_preview_panel.dart
@@ -7,6 +7,7 @@ import 'package:fluentui_system_icons/fluentui_system_icons.dart';
 import 'package:otzaria_icons/otzaria_icons.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:collection/collection.dart';
 import 'package:otzaria/core/messages/messages_exports.dart';
 import 'package:otzaria/core/ui_snack.dart';
 import 'package:otzaria/models/books.dart';
@@ -48,9 +49,8 @@ class BookPreviewPanel extends StatefulWidget {
   /// טקסט להדגשה בסעיף היעד (שאילתת החיפוש שבוצעה).
   final String? searchText;
 
-  /// פרמטרי החיפוש שהניבו את התוצאה. בלעדיהם ההדגשה בתצוגה המקדימה מכירה
-  /// רק את השאילתה המילולית, וכל תוצאה שנמצאה דרך קידומת, מילה חלופית או
-  /// מרחק בין מילים מוצגת בלי הדגשה (issue #1147).
+  /// פרמטרי החיפוש שהניבו את התוצאה. בלעדיהם ההדגשה מכירה רק את השאילתה
+  /// המילולית, ותוצאה שהותאמה דרך קידומת או מרחק מוצגת בלי הדגשה (issue #1147).
   final Map<String, Map<String, bool>> searchOptions;
   final Map<int, List<String>> alternativeWords;
   final Map<String, String> spacingValues;
@@ -75,6 +75,26 @@ class BookPreviewPanel extends StatefulWidget {
 
   @override
   State<BookPreviewPanel> createState() => _BookPreviewPanelState();
+}
+
+/// האם פרמטרי החיפוש של התצוגה המקדימה השתנו. ההשוואה עמוקה: המפות נבנות
+/// מחדש בכל רינדור, והשוואת זהות הייתה בונה את הטאב מחדש בלי סוף.
+@visibleForTesting
+bool previewSearchParametersChanged(
+  BookPreviewPanel oldWidget,
+  BookPreviewPanel newWidget,
+) {
+  const equality = DeepCollectionEquality();
+  return oldWidget.searchText != newWidget.searchText ||
+      oldWidget.searchMode != newWidget.searchMode ||
+      oldWidget.searchDistance != newWidget.searchDistance ||
+      oldWidget.matchPolicy != newWidget.matchPolicy ||
+      !equality.equals(oldWidget.searchOptions, newWidget.searchOptions) ||
+      !equality.equals(
+        oldWidget.alternativeWords,
+        newWidget.alternativeWords,
+      ) ||
+      !equality.equals(oldWidget.spacingValues, newWidget.spacingValues);
 }
 
 /// טאב הטקסט שהתצוגה המקדימה מרנדרת. חשוף לבדיקה כדי לנעול את העברת
@@ -135,6 +155,14 @@ class _BookPreviewPanelState extends State<BookPreviewPanel> {
       if (widget.book != null) {
         _createNewTab();
       }
+      return;
+    }
+
+    // אותה תוצאה, פרמטרי חיפוש אחרים: שינוי מצב/מרחק/אפשרויות והרצה חוזרת
+    // של אותה שאילתה אינם סוגרים את החלונית, והטאב היה מדגיש לפי הישנים.
+    if (previewSearchParametersChanged(oldWidget, widget)) {
+      _disposeCurrentTab();
+      _createNewTab();
       return;
     }
 

--- a/lib/search/view/tantivy_search_results.dart
+++ b/lib/search/view/tantivy_search_results.dart
@@ -559,6 +559,21 @@ class _TantivySearchResultsState extends State<TantivySearchResults> {
         return ValueListenableBuilder<SearchPreviewTarget?>(
           valueListenable: widget.tab.previewTarget,
           builder: (context, target, _) {
+            // אותם פרמטרים שפתיחה בחלון מלא מעבירה, כדי שההדגשה בשתי
+            // התצוגות תזהה את אותן התאמות (issue #1147).
+            final configuration = widget.tab.searchBloc.state.configuration;
+            final previewQuery = widget.tab.searchBloc.state.searchQuery;
+            final previewOptions = widget.tab.effectiveSearchOptions(
+              query: previewQuery,
+            );
+            final previewParameters = InBookSearchRouting.resolveForReadingTab(
+              searchMode: configuration.searchMode,
+              distance: configuration.distance,
+              searchOptions: previewOptions,
+              alternativeWords: widget.tab.alternativeWords,
+              spacingValues: widget.tab.spacingValues,
+              matchPolicy: configuration.matchPolicy,
+            );
             final available = constraints.maxWidth;
             final minWidth = available < 280 ? available : 280.0;
             final maxWidth = (available - 320).clamp(minWidth, available);
@@ -577,6 +592,12 @@ class _TantivySearchResultsState extends State<TantivySearchResults> {
                     ? target.segment + 1
                     : null,
                 searchText: widget.tab.searchBloc.state.searchQuery,
+                searchOptions: previewOptions,
+                alternativeWords: widget.tab.alternativeWords,
+                spacingValues: widget.tab.spacingValues,
+                searchMode: previewParameters.searchMode,
+                searchDistance: previewParameters.distance,
+                matchPolicy: previewParameters.matchPolicy,
                 onOpenInReader: (_, {bool? forcePdf}) {
                   final openTarget = widget.tab.previewTarget.value;
                   if (openTarget == null) return;

--- a/test/library/view/book_preview_search_parameters_test.dart
+++ b/test/library/view/book_preview_search_parameters_test.dart
@@ -1,0 +1,93 @@
+import 'package:flutter_settings_screens/flutter_settings_screens.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/library/models/library.dart';
+import 'package:otzaria/library/view/book_preview_panel.dart';
+import 'package:otzaria/models/books.dart';
+import 'package:otzaria/search/models/search_configuration.dart';
+import 'package:otzaria_search_engine/otzaria_search_engine.dart'
+    show SearchScope;
+
+import '../../helpers/memory_settings_cache.dart';
+
+TextBook _book() => TextBook(
+  title: 'ברכות',
+  category: Category(
+    title: 'סדר זרעים',
+    description: '',
+    shortDescription: '',
+    order: 0,
+    subCategories: [],
+    books: [],
+    parent: null,
+  ),
+  categoryId: 10,
+);
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    await Settings.init(cacheProvider: MemorySettingsCache());
+  });
+
+  group('טאב התצוגה המקדימה — פרמטרי חיפוש (issue #1147)', () {
+    test('שאילתה פשוטה מגיעה לטאב', () {
+      final tab = buildPreviewTextTab(
+        book: _book(),
+        targetIndex: 7,
+        searchText: 'אבל',
+      );
+
+      expect(tab.searchText, 'אבל');
+      expect(tab.index, 7);
+    });
+
+    test('אפשרויות החיפוש המתקדמות מגיעות לטאב', () {
+      final tab = buildPreviewTextTab(
+        book: _book(),
+        targetIndex: 7,
+        searchText: 'אבל',
+        searchOptions: const {
+          'אבל': {'prefixes': true},
+        },
+        alternativeWords: const {
+          0: ['ברם'],
+        },
+        spacingValues: const {'0': '2'},
+        searchMode: SearchMode.fuzzy,
+        searchDistance: 3,
+        matchPolicy: const SearchMatchPolicy(
+          proximityScope: SearchScope.sameParagraph,
+        ),
+      );
+
+      expect(tab.searchOptions, {
+        'אבל': {'prefixes': true},
+      });
+      expect(tab.alternativeWords, {
+        0: ['ברם'],
+      });
+      expect(tab.spacingValues, {'0': '2'});
+      expect(tab.searchMode, SearchMode.fuzzy);
+      expect(tab.searchDistance, 3);
+      expect(tab.matchPolicy.proximityScope, SearchScope.sameParagraph);
+    });
+
+    test('תצוגה מקדימה ללא תוצאה נבחרת אינה נושאת חיפוש', () {
+      final tab = buildPreviewTextTab(
+        book: _book(),
+        targetIndex: null,
+        searchText: 'אבל',
+        searchOptions: const {
+          'אבל': {'prefixes': true},
+        },
+        searchDistance: 3,
+      );
+
+      expect(tab.searchText, isEmpty);
+      expect(tab.searchOptions, isEmpty);
+      expect(tab.searchDistance, 0);
+      expect(tab.initialSearchResultLines, isNull);
+    });
+  });
+}

--- a/test/library/view/book_preview_search_parameters_test.dart
+++ b/test/library/view/book_preview_search_parameters_test.dart
@@ -90,4 +90,69 @@ void main() {
       expect(tab.initialSearchResultLines, isNull);
     });
   });
+
+  group('זיהוי שינוי בפרמטרי החיפוש', () {
+    BookPreviewPanel panel({
+      String searchText = 'אבל',
+      Map<String, Map<String, bool>> searchOptions = const {},
+      int searchDistance = 0,
+      SearchMode searchMode = SearchMode.exact,
+    }) => BookPreviewPanel(
+      book: _book(),
+      initialTextIndex: 7,
+      searchText: searchText,
+      searchOptions: searchOptions,
+      searchDistance: searchDistance,
+      searchMode: searchMode,
+    );
+
+    test('מפות שוות בתוכן אך אינסטנסים שונים — אין שינוי', () {
+      // effectiveSearchOptions בונה מפה חדשה בכל קריאה; השוואת זהות הייתה
+      // מזהה כאן "שינוי" ובונה את הטאב מחדש בכל רינדור.
+      final before = panel(
+        searchOptions: {
+          'אבל': {'prefixes': true},
+        },
+      );
+      final after = panel(
+        searchOptions: {
+          'אבל': {'prefixes': true},
+        },
+      );
+
+      expect(previewSearchParametersChanged(before, after), isFalse);
+    });
+
+    test('שינוי באפשרויות מזוהה', () {
+      expect(
+        previewSearchParametersChanged(
+          panel(),
+          panel(
+            searchOptions: {
+              'אבל': {'prefixes': true},
+            },
+          ),
+        ),
+        isTrue,
+      );
+    });
+
+    test('שינוי במרחק או במצב החיפוש מזוהה', () {
+      expect(
+        previewSearchParametersChanged(panel(), panel(searchDistance: 3)),
+        isTrue,
+      );
+      expect(
+        previewSearchParametersChanged(
+          panel(),
+          panel(searchMode: SearchMode.fuzzy),
+        ),
+        isTrue,
+      );
+    });
+
+    test('אותם פרמטרים בדיוק — אין שינוי', () {
+      expect(previewSearchParametersChanged(panel(), panel()), isFalse);
+    });
+  });
 }


### PR DESCRIPTION
# מה השינוי?

בתצוגה המקדימה של תוצאות החיפוש רק חלק מהתוצאות קיבלו הדגשה. אותה תוצאה, בפתיחה בחלון מלא, כן הודגשה.

**השורש:** שני מסלולים באותה פונקציה ב-`tantivy_search_results.dart`. פתיחה בחלון מלא מעבירה שישה פרמטרים — `searchOptions`, `alternativeWords`, `spacingValues`, `searchMode`, `searchDistance`, `matchPolicy` — דרך `InBookSearchRouting.resolveForReadingTab`. התצוגה המקדימה העבירה רק `searchText`, ו-`BookPreviewPanel` בנה `TextBookTab` בלי השאר, למרות שהטאב כבר מכיל את כל השדות.

לכן שאילתה ליטרלית הודגשה בשתי התצוגות, ואילו תוצאה שהתאימה רק דרך קידומת, מילה חלופית או מרחק בין מילים הודגשה בחלון המלא בלבד. זה גם מסביר את "חלק מודגשות וחלק לא" בתוך אותו חיפוש.

**התיקון:** התצוגה המקדימה מקבלת את אותה קונפיגורציה, מחושבת דרך אותו `resolveForReadingTab`. בניית הטאב חולצה ל-`buildPreviewTextTab` כדי שאפשר יהיה לנעול אותה בטסט.

## מה אומת ומה לא

השרשרת אומתה חוליה-חוליה בקריאת קוד:
`BookPreviewPanel` → `buildPreviewTextTab` → `TextBookTab` → `TextBookInitial.named` → `TextBookBloc` (`initial.searchOptions` → state) → `CombinedView` → `RenderSettings` → הדגשה. `isPreviewMode` אינו חוסם הדגשה (הוא משפיע על תפריט ההקשר ורוחב הטקסט בלבד).

הטסט מכסה את הצנרת — שהטאב נושא את הקונפיגורציה — ולא את הפיקסלים על המסך. אימתתי שהוא באמת שומר על משהו: בביטול זמני של התיקון מקרה הבקרה (שאילתה פשוטה) עבר, והמקרה המתקדם נכשל עם `Expected: {'אבל': {'prefixes': true}}` מול `Actual: {}`.

**תופעת לוואי מכוונת:** התנאי `searchText.isNotEmpty && searchMode != SearchMode.exact` ב-`text_book_bloc.dart` לא התקיים בתצוגה המקדימה עד היום, כי היא תמיד קיבלה `exact`. כעת חיפוש מתקדם מפעיל גם ממנה את הזנת תבנית ההדגשה במנוע. הקריאה `unawaited` ולפי ההערה בקוד היא פגיעת מטמון אחרי חיפוש טרי — וזו בדיוק ההתנהגות שכבר קיימת בפתיחה בחלון מלא.

**מחוץ להיקף:** התצוגה המקדימה של PDF אינה מקבלת טקסט להדגשה כלל, לא רק את הקונפיגורציה — `_buildPdfViewer` ו-`PdfViewerParams` לא מקבלים שום פרמטר חיפוש. חסר נפרד ורחב יותר; לא הרחבתי אליו את הדיף.

**הערה:** `test/search/search_scope_menu_search_actions_test.dart` נכשל גם על `dev` נקי בלי השינוי הזה (נבדק ב-`git stash`). לא קשור ל-PR.

## קישור לבעיה

Fixes #1147

## הצהרות התורם

- [x] אני מאשר שה-PR שלי עומד ב[תנאי התרומה המפורטים ב-README](https://github.com/Otzaria/otzaria/blob/dev/README.md#תנאי-תרומה-חובה-לקריאה)
- [ ] פיצ'ר חדש? — התייעצתי לפני כן (בפורום או ב-issue)
- [ ] שינוי UI? — צירפתי צילומי מסך לפני/אחרי בסוף התיאור
- [x] הרצתי `flutter analyze` על הקוד ואין שגיאות

## צילומי מסך

אין שינוי בפריסה או ברכיבים — ההבדל הוא אילו מילים נצבעות בתצוגה המקדימה. `flutter analyze` נקי, הטסט החדש עובר (3), ו-716 טסטים ב-`test/library/` ו-`test/search/` עוברים פרט לטסט שנכשל מראש שצוין למעלה.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
