### PR TITLE
פס גלילה: המסילה נעלמה בקצה הרשימה כי maxScrollExtent מתאפס

### DIFF
--- a/lib/text_book/view/combined_view/combined_book_screen.dart
+++ b/lib/text_book/view/combined_view/combined_book_screen.dart
@@ -2011,6 +2011,8 @@ class _CombinedViewState extends State<CombinedView> {
                                   scrollController: widget.tab.scrollController,
                                   itemPositionsListener:
                                       widget.tab.positionsListener,
+                                  offsetController:
+                                      widget.tab.mainOffsetController,
                                   itemCount: state.readingSegments.isNotEmpty
                                       ? state.readingSegments.length
                                       : widget.data.length,

--- a/lib/text_book/view/page_shape/simple_text_viewer.dart
+++ b/lib/text_book/view/page_shape/simple_text_viewer.dart
@@ -2720,6 +2720,9 @@ class _SimpleTextViewerState extends State<SimpleTextViewer> {
                                 ? ScrollablePositionedListScrollbar(
                                     scrollController: _scrollController,
                                     itemPositionsListener: _positionsListener,
+                                    offsetController: widget.isMainText
+                                        ? state.scrollOffsetController
+                                        : widget.scrollOffsetController,
                                     itemCount: itemCount,
                                     labelForIndex: widget.labelForIndex,
                                     child: SmoothWheelScroll(

--- a/lib/widgets/feedback/scrollable_positioned_list_scrollbar.dart
+++ b/lib/widgets/feedback/scrollable_positioned_list_scrollbar.dart
@@ -293,8 +293,9 @@ class _ScrollablePositionedListScrollbarState
 
     setState(() {
       // maxScrollExtent משקף רק את החלון שמרונדר סביב העוגן, ולכן הוא מתאפס
-      // בקצה הרשימה והמסילה הייתה נעלמת. מדידת התוכן עצמו יציבה (issue #1169).
-      if (totalContent > 1.0 + precisionErrorTolerance) {
+      // בקצה הרשימה והמסילה הייתה נעלמת. מדידת התוכן עצמה יציבה (issue #1169).
+      final hasOffscreenItem = minIndex > 0 || maxIndex < widget.itemCount - 1;
+      if (hasOffscreenItem || totalContent > 1.0 + precisionErrorTolerance) {
         _canScroll = true;
       }
       // _maxScrollableIndex חייב להתעדכן גם תוך כדי גרירה: כשהמשתמש גורר

--- a/lib/widgets/feedback/scrollable_positioned_list_scrollbar.dart
+++ b/lib/widgets/feedback/scrollable_positioned_list_scrollbar.dart
@@ -292,6 +292,11 @@ class _ScrollablePositionedListScrollbarState
         : 0.0;
 
     setState(() {
+      // maxScrollExtent משקף רק את החלון שמרונדר סביב העוגן, ולכן הוא מתאפס
+      // בקצה הרשימה והמסילה הייתה נעלמת. מדידת התוכן עצמו יציבה (issue #1169).
+      if (totalContent > 1.0 + precisionErrorTolerance) {
+        _canScroll = true;
+      }
       // _maxScrollableIndex חייב להתעדכן גם תוך כדי גרירה: כשהמשתמש גורר
       // לתוך אזור עם פריטים גדולים יותר (לדוגמה — אזור שבו מפרש פתוח, או
       // כותרות עם הרבה תוכן) מספר הפריטים הגלויים יורד והאינדקס המקסימלי

--- a/test/text_book/view/reading_scrollbar_offset_controller_test.dart
+++ b/test/text_book/view/reading_scrollbar_offset_controller_test.dart
@@ -1,0 +1,38 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+/// גרירת פס הגלילה גוללת *בתוך* קטע גבוה מהמסך רק כשהסרגל מקבל
+/// `offsetController`; בלעדיו היא מסוגלת לקפוץ בין אינדקסים בלבד, ובספר
+/// שכולו קטע אחד אין לאן לקפוץ והגרירה אינה מזיזה דבר (issue #1169).
+///
+/// הרשימות בשני מסכי הקריאה כבר מחוברות ל-`ScrollOffsetController`, ולכן
+/// המבחן כאן הוא שגם הסרגל שעוטף אותן מקבל אותו.
+void main() {
+  const surfaces = {
+    'lib/text_book/view/combined_view/combined_book_screen.dart': 2,
+    'lib/text_book/view/page_shape/simple_text_viewer.dart': 1,
+  };
+
+  group('פס הגלילה במסכי הקריאה מקבל offsetController', () {
+    surfaces.forEach((path, expectedScrollbars) {
+      test(path.split('/').last, () {
+        final source = File(path).readAsStringSync();
+        final scrollbars = 'ScrollablePositionedListScrollbar('
+            .allMatches(source)
+            .length;
+
+        expect(
+          scrollbars,
+          expectedScrollbars,
+          reason: 'השתנה מספר הסרגלים בקובץ — יש לעדכן את הבדיקה',
+        );
+        expect(
+          'offsetController:'.allMatches(source).length,
+          greaterThanOrEqualTo(scrollbars),
+          reason: 'כל סרגל במסך קריאה חייב לקבל offsetController',
+        );
+      });
+    });
+  });
+}

--- a/test/widgets/scrollable_positioned_list_scrollbar_test.dart
+++ b/test/widgets/scrollable_positioned_list_scrollbar_test.dart
@@ -1644,4 +1644,43 @@ void main() {
       expect(track.center.dx, lessThan(scrollbar.center.dx));
     });
   });
+
+  testWidgets(
+    'גלילה לסוף ספר ארוך אינה מעלימה את המסילה (issue #1169)',
+    (tester) async {
+      final listener = ItemPositionsListener.create();
+      final controller = ItemScrollController();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: ScrollablePositionedListScrollbar(
+              scrollController: controller,
+              itemPositionsListener: listener,
+              itemCount: 200,
+              // ScrollablePositionedList מרנדר חלון סביב העוגן, ולכן בקצה
+              // הרשימה maxScrollExtent מתאפס אף שיש עוד 198 פריטים.
+              child: const _ScrollableStub(maxScrollExtent: 0),
+            ),
+          ),
+        ),
+      );
+
+      (listener.itemPositions as ValueNotifier<Iterable<ItemPosition>>).value =
+          const [
+            ItemPosition(index: 198, itemLeadingEdge: 0, itemTrailingEdge: 0.4),
+            ItemPosition(
+              index: 199,
+              itemLeadingEdge: 0.4,
+              itemTrailingEdge: 0.8,
+            ),
+          ];
+      await tester.pump();
+
+      expect(
+        find.byKey(ScrollablePositionedListScrollbar.thumbKey),
+        findsOneWidget,
+      );
+    },
+  );
 }

--- a/test/widgets/scrollable_positioned_list_scrollbar_test.dart
+++ b/test/widgets/scrollable_positioned_list_scrollbar_test.dart
@@ -40,6 +40,29 @@ class _GrowingItemState extends State<_GrowingItem> {
   Widget build(BuildContext context) => SizedBox(height: _height);
 }
 
+/// כמו [_RecordingItemScrollController], אך מדווח שהוא מחובר: הגלילה בתוך
+/// פריט נדחית ל-postFrameCallback שיוצא מוקדם כשאין רשימה אמיתית מאחוריו.
+class _AttachedRecordingItemScrollController
+    extends _RecordingItemScrollController {
+  @override
+  bool get isAttached => true;
+}
+
+/// מתעד קריאות גלילה בתוך פריט. הסרגל משתמש ב-offsetController כדי לגלול
+/// *בתוך* קטע גבוה מהמסך; בלעדיו הגרירה מסוגלת רק לקפוץ בין אינדקסים.
+class _RecordingOffsetController extends ScrollOffsetController {
+  final List<double> offsets = <double>[];
+
+  @override
+  Future<void> animateScroll({
+    required double offset,
+    required Duration duration,
+    Curve curve = Curves.linear,
+  }) async {
+    offsets.add(offset);
+  }
+}
+
 /// ילד שמדווח [ScrollMetricsNotification] בלי Scrollable אמיתי. הסרגל נשען על
 /// המטריקות כדי להחליט אם להציג את המסילה, והטסטים כאן מזינים את הפוזיציות
 /// בעצמם ולכן אין להם רשימה שתדווח אותן.
@@ -1683,4 +1706,90 @@ void main() {
       );
     },
   );
+
+  testWidgets(
+    'ספר בקטע יחיד: גרירה גוללת בתוך הקטע דרך offsetController (issue #1169)',
+    (tester) async {
+      final listener = ItemPositionsListener.create();
+      final controller = _AttachedRecordingItemScrollController();
+      final offsets = _RecordingOffsetController();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: ScrollablePositionedListScrollbar(
+              scrollController: controller,
+              itemPositionsListener: listener,
+              offsetController: offsets,
+              itemCount: 1,
+              child: const _ScrollableStub(),
+            ),
+          ),
+        ),
+      );
+
+      // קטע יחיד הגבוה פי כמה מהמסך: אין אינדקס אחר לקפוץ אליו, וכל
+      // הגלילה חייבת להתרחש בתוך אותו פריט.
+      (listener.itemPositions as ValueNotifier<Iterable<ItemPosition>>).value =
+          const [
+            ItemPosition(index: 0, itemLeadingEdge: 0, itemTrailingEdge: 5.0),
+          ];
+      await tester.pump();
+
+      final track = find.byType(GestureDetector);
+      final trackTopLeft = tester.getTopLeft(track);
+      final trackBottomRight = tester.getBottomRight(track);
+      final gesture = await tester.startGesture(
+        Offset(
+          (trackTopLeft.dx + trackBottomRight.dx) / 2,
+          trackBottomRight.dy - 5,
+        ),
+      );
+      await tester.pump();
+      await gesture.moveBy(const Offset(0, 30));
+      await tester.pump();
+      await gesture.up();
+      await tester.pumpAndSettle();
+
+      expect(
+        offsets.offsets.where((offset) => offset > 0),
+        isNotEmpty,
+        reason: 'בלי גלילה בתוך הפריט הגרירה בספר בעל קטע אחד אינה מזיזה דבר',
+      );
+    },
+  );
+
+  testWidgets('רשימה קצרה שרק פריט אחד ממנה נמדד — המסילה מוצגת', (
+    tester,
+  ) async {
+    final listener = ItemPositionsListener.create();
+    final controller = ItemScrollController();
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: ScrollablePositionedListScrollbar(
+            scrollController: controller,
+            itemPositionsListener: listener,
+            itemCount: 2,
+            child: const _ScrollableStub(maxScrollExtent: 0),
+          ),
+        ),
+      ),
+    );
+
+    // רק הפריט האחרון מרונדר: אומדן הגובה מגיע ל-0.8 בלבד, אבל הפריט שמעליו
+    // מחוץ למסך ומוכיח שיש לאן לגלול.
+    (listener.itemPositions as ValueNotifier<Iterable<ItemPosition>>).value =
+        const [
+          ItemPosition(index: 1, itemLeadingEdge: 0.4, itemTrailingEdge: 0.8),
+        ];
+    await tester.pump();
+
+    expect(
+      find.byKey(ScrollablePositionedListScrollbar.thumbKey),
+      findsOneWidget,
+      reason: 'פריט מחוץ לחלון הנראה = יש מה לגלול',
+    );
+  });
 }


### PR DESCRIPTION
# מה השינוי?

פס הגלילה נעלם או לא הגיב בכמה מצבים ולא חזר עד לפתיחה מחדש של הספר. הדיווח כלל תסמינים שנראו שונים; מתחתם שני שורשים נפרדים, ושניהם מטופלים כאן.

## שורש א׳ — הנראות נגזרה ממדד של החלון המרונדר

```dart
final canScroll = notification.metrics.maxScrollExtent > precisionErrorTolerance;
```

`ScrollablePositionedList` מרנדר חלון סביב העוגן, ולכן `maxScrollExtent` מתאר את החלון ולא את הרשימה. בקצה הרשימה אין תוכן קדימה, המדד מתאפס והמסילה מוסתרת — גם כשיש מאות פריטים מעל. הוספת מפרשים מגדילה את החלון והמדד חוזר; מסך גדול מרנדר יותר ולכן המדד לא מתאפס. זה מסביר גם את ההיעלמות בגרירה לסוף, גם את זו שבחלונית המפרשים, וגם את תלות גודל המסך.

התיקון נשען על שני סימנים במקום על המדד: פריט שנמצא מחוץ לחלון הנראה (`minIndex > 0 || maxIndex < itemCount - 1`) הוא הוכחה ישירה שיש לאן לגלול, ובנוסף מדידת התוכן עצמו (`avgItemHeight * itemCount`, ביחידות viewport). האומדן לבדו אינו מספיק: ברשימה קצרה עם פריטים בגבהים שונים ייתכן שרק פריט קצר נמדד והמכפלה נשארת מתחת ל-viewport.

הסתרה כשכל התוכן נראה נשמרת, והטסט הקיים שנועל אותה ממשיך לעבור.

## שורש ב׳ — מסכי הקריאה לא העבירו `offsetController` לסרגל

גרירת הסרגל גוללת *בתוך* קטע גבוה מהמסך רק דרך `offsetController`; בלעדיו `_jumpDuringDrag` נופל ל-`jumpTo(index:)` בלבד. בספר שכולו קטע אחד אין אינדקס אחר לקפוץ אליו, ולכן הגרירה לא הזיזה דבר — התסמין שדווח על 'אגדה בבני יעקב' (`otzaria://open/book/7288`).

הרשימות בשני מסכי הקריאה כבר מחוברות ל-`ScrollOffsetController`; רק הסרגל שעוטף אותן לא קיבל אותו. חלונית המפרשים, חלונית הקישורים וההערות האישיות כבר העבירו אותו — ולכן שם הגרירה עבדה, וזה חידד היכן הפער.

## בדיקות

- טסט שחזור לשורש א׳: 200 פריטים עם `maxScrollExtent: 0` (העוגן בקצה) — המסילה נשארת.
- טסט לרשימה קצרה שרק פריט אחד ממנה נמדד — המסילה מוצגת בזכות הפריט שמחוץ לחלון.
- טסט לשורש ב׳: קטע יחיד גבוה מהמסך — הגרירה מייצרת גלילה בתוך הפריט דרך `offsetController`.
- טסט שומר שנועל את שני אתרי הקריאה: כל סרגל במסך קריאה מקבל `offsetController` (אומת שנכשל בלי התיקון).
- כל הטסטים הקיימים בקובץ הסרגל עוברים, כולל זה שנועל את ההסתרה. `test/widgets/` + `test/text_book/` — 2,386 עוברים.

## מה לא נכלל

הדיווח כלל גם היעלמות שהמדווח לא הצליח לשחזר במדויק ותיאר בהקלטה. המנגנון של שורש א׳ מסביר אותה, אך היא לא נבדקה ישירות.

## קישור לבעיה

Fixes #1169

## הצהרות התורם

- [x] אני מאשר שה-PR שלי עומד ב[תנאי התרומה המפורטים ב-README](https://github.com/Otzaria/otzaria/blob/dev/README.md#תנאי-תרומה-חובה-לקריאה)
- [ ] פיצ'ר חדש? — התייעצתי לפני כן (בפורום או ב-issue)
- [ ] שינוי UI? — צירפתי צילומי מסך לפני/אחרי בסוף התיאור
- [x] הרצתי `flutter analyze` על הקוד ואין שגיאות

## צילומי מסך

השינוי הוא בתנאי הנראות של המסילה ובחיווט בקר הגלילה, בלי שינוי בעיצוב. ההבדל מודגם בטסטים: אותה רשימה ואותם נתונים, מסילה שנעלמה מול מסילה שנשארת; וקטע יחיד שהגרירה לא הזיזה מול כזה שנגלל.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
