### PR TITLE
PDF: שיפורי טעינה בטוחים ועדכון pdfrx ל-2.6.1

### DIFF
--- a/lib/find_ref/repository/reference_books_cache.dart
+++ b/lib/find_ref/repository/reference_books_cache.dart
@@ -12,6 +12,7 @@ import 'package:otzaria/data/data_providers/sqlite_data_provider.dart';
 import 'package:otzaria/migration/database/repository/seforim_repository.dart';
 import 'package:otzaria/migration/models/category.dart' as db_models;
 import 'package:otzaria/migration/models/pdf_outline_cache_entry.dart';
+import 'package:otzaria/pdf_book/utils/pdf_viewer_activity.dart';
 import 'package:otzaria/services/commentary_service.dart';
 import 'package:otzaria/utils/text/text_manipulation.dart';
 import 'package:pdfrx/pdfrx.dart';
@@ -489,6 +490,8 @@ class ReferenceBooksCache {
     if (paths.isEmpty) return;
 
     for (var i = 0; i < paths.length; i += maxConcurrent) {
+      // הקורא קודם — טאב שממתין לעמוד היעד לא יחכה בתור מאחורי ה-outline.
+      await PdfViewerActivity.instance.waitUntilIdle();
       if (gen != _generation) return;
       final end = (i + maxConcurrent < paths.length)
           ? i + maxConcurrent

--- a/lib/find_ref/repository/reference_books_cache.dart
+++ b/lib/find_ref/repository/reference_books_cache.dart
@@ -465,16 +465,17 @@ class ReferenceBooksCache {
 
   /// Pre-warms the PDF outline cache for all currently-known FS PDF books.
   ///
-  /// Runs in bounded batches of [maxConcurrent] files at a time to avoid
-  /// opening dozens of PdfDocument objects simultaneously (pdfrx serializes
-  /// work in a single background isolate, but each open file holds memory).
+  /// Runs in bounded batches of [maxConcurrent] files at a time. pdfrx
+  /// serializes all PDFium work through a single worker isolate, so a larger
+  /// batch only holds more documents in memory and lengthens that queue —
+  /// hence the default of 1.
   ///
   /// Idempotent and cheap to re-run: entries already cached are skipped
   /// automatically by [getPdfOutlineEntries]'s `putIfAbsent`.
   ///
   /// Respects [clear] via the generation counter — if the cache is cleared
   /// mid-run, the remaining batches are aborted.
-  Future<void> prewarmAllPdfOutlines({int maxConcurrent = 4}) async {
+  Future<void> prewarmAllPdfOutlines({int maxConcurrent = 1}) async {
     // ולידציה רצה גם ב-release: ערך לא חיובי יוצר לולאה אינסופית
     // (i += 0), עדיף להיכשל בקול מאשר להקפיא את ה-isolate.
     if (maxConcurrent <= 0) {

--- a/lib/indexing/repository/indexing_repository.dart
+++ b/lib/indexing/repository/indexing_repository.dart
@@ -16,6 +16,7 @@ import 'package:otzaria/indexing/utils/pdf_extraction_prefetcher.dart';
 import 'package:otzaria/indexing/models/catalogue_order_resolver.dart';
 import 'package:otzaria/indexing/models/indexing_run_result.dart';
 import 'package:otzaria/migration/database/repository/seforim_repository.dart';
+import 'package:otzaria/pdf_book/utils/pdf_viewer_activity.dart';
 import 'package:otzaria/library/models/library.dart';
 import 'package:otzaria/models/books.dart';
 import 'package:otzaria/search/book_facet.dart';
@@ -976,6 +977,8 @@ class IndexingRepository {
     final file = File(book.path);
     if (!await file.exists()) return empty;
 
+    // הקורא קודם — טאב שממתין לעמוד היעד לא יחכה בתור מאחורי האינדוקס.
+    await PdfViewerActivity.instance.waitUntilIdle();
     final document = await PdfDocument.openFile(
       book.path,
     ).timeout(const Duration(seconds: 60));
@@ -994,6 +997,7 @@ class IndexingRepository {
       final pageCount = document.pages.length;
       for (int i = 0; i < pageCount; i++) {
         if (!_tantivyDataProvider.isIndexing.value) return empty;
+        await PdfViewerActivity.instance.waitUntilIdle();
 
         final pageText = await document.pages[i].loadText().timeout(
           const Duration(seconds: 5),

--- a/lib/library/view/book_preview_panel.dart
+++ b/lib/library/view/book_preview_panel.dart
@@ -22,6 +22,8 @@ import 'package:pdfrx/pdfrx.dart';
 import 'package:otzaria/utils/file/page_converter.dart';
 import 'package:otzaria/utils/navigation/talmud_bavli_open_format.dart';
 import 'package:otzaria/widgets/dialogs/password_dialog.dart';
+import 'package:otzaria/pdf_book/view/pdf_book_screen.dart'
+    show kPdfImageCacheMinBytesPerPane;
 import 'package:otzaria/pdf_book/view/pdf_scrollbar.dart';
 import 'package:otzaria/widgets/widgets_exports.dart';
 
@@ -544,6 +546,9 @@ class _BookPreviewPanelState extends State<BookPreviewPanel> {
           controller: _pdfController!,
           params: PdfViewerParams(
             backgroundColor: Theme.of(context).colorScheme.surface,
+            // התצוגה המקדימה חיה לצד טאבי הקריאה — מקבלת את רצפת התקציב שלהם
+            // ולא את 100MB ברירת המחדל של pdfrx.
+            maxImageBytesCachedOnMemory: kPdfImageCacheMinBytesPerPane,
             zoomStepsDelegateProvider:
                 const PdfViewerZoomStepsDelegateProviderSmart(),
             sizeDelegateProvider: PdfViewerSizeDelegateProviderLegacy(

--- a/lib/pdf_book/utils/pdf_viewer_activity.dart
+++ b/lib/pdf_book/utils/pdf_viewer_activity.dart
@@ -1,0 +1,40 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+
+/// שער "הקורא קודם": סופר את טאבי ה-PDF שממתינים לייצוב עמוד היעד, כדי
+/// שעבודת רקע על PDF (outline, אינדוקס) תפנה את ה-worker היחיד של pdfrx.
+class PdfViewerActivity {
+  PdfViewerActivity._();
+
+  static final PdfViewerActivity instance = PdfViewerActivity._();
+
+  /// מספר ה-viewers שנמצאים כעת בטעינה.
+  final ValueNotifier<int> loadingCount = ValueNotifier<int>(0);
+
+  void begin() => loadingCount.value++;
+
+  void end() {
+    assert(loadingCount.value > 0, 'end() ללא begin() תואם');
+    if (loadingCount.value > 0) loadingCount.value--;
+  }
+
+  /// חוזר מיד כשאין viewer בטעינה; אחרת ממתין עד שכולם יסיימו או עד
+  /// [timeout] — כך עבודת הרקע לעולם אינה נחסמת לצמיתות.
+  Future<void> waitUntilIdle({
+    Duration timeout = const Duration(seconds: 5),
+  }) async {
+    if (loadingCount.value == 0) return;
+    final idle = Completer<void>();
+    void listener() {
+      if (loadingCount.value == 0 && !idle.isCompleted) idle.complete();
+    }
+
+    loadingCount.addListener(listener);
+    try {
+      await idle.future.timeout(timeout, onTimeout: () {});
+    } finally {
+      loadingCount.removeListener(listener);
+    }
+  }
+}

--- a/lib/pdf_book/view/pdf_book_screen.dart
+++ b/lib/pdf_book/view/pdf_book_screen.dart
@@ -3924,6 +3924,7 @@ class _PdfBookScreenState extends State<PdfBookScreen>
     textSearcher = null;
     _stableLayoutTimer?.cancel();
     _stableLayoutTimer = null;
+    _pageMetadataTimer?.cancel();
     if (_waitingForStableLayout) PdfViewerActivity.instance.end();
     pdfController.removeListener(_onPdfViewerControllerUpdate);
     _leftPaneTabController?.removeListener(_leftPaneTabControllerListener);
@@ -3962,6 +3963,10 @@ class _PdfBookScreenState extends State<PdfBookScreen>
   // מצב התצוגה האחרון שנצפה ב-BlocListener, לזיהוי מעבר בין מצבים.
   PdfLayoutMode? _lastObservedLayoutMode;
   int _lastComputedForPage = -1;
+
+  /// פתרון הכותרת, מספר השורה והקישורים ניגש ל-DB — נדחה עד שהגלילה נרגעת.
+  static const Duration _kPageMetadataDebounce = Duration(milliseconds: 150);
+  Timer? _pageMetadataTimer;
   int? _initialPageNumber; // שמירת מספר העמוד ההתחלתי
   bool _isJumping = false; // flag לציון שאנחנו בתהליך קפיצה
   bool _linksLoading = true; // true עד שטעינת הקישורים מסתיימת
@@ -4030,7 +4035,6 @@ class _PdfBookScreenState extends State<PdfBookScreen>
     // loading. Cheap & idempotent — guarded by `_lastPrerenderTriggeredSpread`.
     _schedulePrerenderForAdjacentSpreads();
 
-    final tourCubit = context.read<TourCubit>();
     final newZoom = widget.tab.pdfViewerController.value.zoom;
     widget.tab.savedZoom = newZoom;
 
@@ -4077,7 +4081,7 @@ class _PdfBookScreenState extends State<PdfBookScreen>
 
     if (newPage == widget.tab.pageNumber) return;
     widget.tab.pageNumber = newPage;
-    final token = _lastComputedForPage = newPage;
+    _lastComputedForPage = newPage;
 
     final immediateRange = _spreadPageRangeFor(newPage);
     widget.tab.currentTitle.value =
@@ -4085,30 +4089,36 @@ class _PdfBookScreenState extends State<PdfBookScreen>
         ? 'עמודים ${immediateRange.startPage}-${immediateRange.endPageExclusive - 1}'
         : 'עמוד $newPage';
 
-    final titles = await _resolveTitlesForPage(newPage);
-    if (!mounted) return;
-    if (token == _lastComputedForPage) {
-      widget.tab.currentTitle.value = titles.display;
+    _pageMetadataTimer?.cancel();
+    _pageMetadataTimer = Timer(
+      _kPageMetadataDebounce,
+      () => _resolvePageMetadata(newPage),
+    );
+  }
 
-      final resolved = await _resolveTextLineNumberForPage(
-        newPage,
-        resolvedTitle: titles.single,
-      );
-      if (!mounted) return;
-      widget.tab.currentTextLineNumber = resolved.start;
-      widget.tab.currentTextLineNumberEnd = resolved.end;
-      unawaited(_refreshLinksWindow());
-      _maybeRegisterPdfCommentaryOpportunity();
-      tourCubit.recordInteraction(
-        TourInteraction(
-          type: TourInteractionType.readerPositionChanged,
-          primaryValue: widget.tab.title,
-        ),
-      );
-      if (mounted) {
-        setState(() {});
-      }
-    }
+  Future<void> _resolvePageMetadata(int page) async {
+    if (!mounted) return;
+    final tourCubit = context.read<TourCubit>();
+    final titles = await _resolveTitlesForPage(page);
+    if (!mounted || page != _lastComputedForPage) return;
+    widget.tab.currentTitle.value = titles.display;
+
+    final resolved = await _resolveTextLineNumberForPage(
+      page,
+      resolvedTitle: titles.single,
+    );
+    if (!mounted || page != _lastComputedForPage) return;
+    widget.tab.currentTextLineNumber = resolved.start;
+    widget.tab.currentTextLineNumberEnd = resolved.end;
+    unawaited(_refreshLinksWindow());
+    _maybeRegisterPdfCommentaryOpportunity();
+    tourCubit.recordInteraction(
+      TourInteraction(
+        type: TourInteractionType.readerPositionChanged,
+        primaryValue: widget.tab.title,
+      ),
+    );
+    setState(() {});
   }
 
   @override

--- a/lib/pdf_book/view/pdf_book_screen.dart
+++ b/lib/pdf_book/view/pdf_book_screen.dart
@@ -3724,15 +3724,21 @@ class _PdfBookScreenState extends State<PdfBookScreen>
 
   void _onLayoutMaybeStable() {
     if (!mounted || !_waitingForStableLayout) return;
-    final controller = widget.tab.pdfViewerController;
-    if (!controller.isReady) {
-      _restartStableLayoutDebounce();
-      return;
-    }
     final startedAt = _stableLayoutStartedAt;
     final maxWaitReached =
         startedAt != null &&
         DateTime.now().difference(startedAt) >= _kStableLayoutMaxWait;
+    final controller = widget.tab.pdfViewerController;
+    if (!controller.isReady) {
+      // גם controller שלא נעשה ready מוגבל בזמן — אחרת ה-overlay ומונה
+      // PdfViewerActivity היו נשארים תקועים.
+      if (maxWaitReached) {
+        _completeStableLayoutTracking();
+      } else {
+        _restartStableLayoutDebounce();
+      }
+      return;
+    }
     if (!_isTargetPagePrefixLoaded() && !maxWaitReached) {
       _restartStableLayoutDebounce();
       return;
@@ -3922,10 +3928,8 @@ class _PdfBookScreenState extends State<PdfBookScreen>
     textSearcher?.removeListener(_onTextSearcherUpdated);
     textSearcher?.dispose();
     textSearcher = null;
-    _stableLayoutTimer?.cancel();
-    _stableLayoutTimer = null;
+    _cancelStableLayoutTracking();
     _pageMetadataTimer?.cancel();
-    if (_waitingForStableLayout) PdfViewerActivity.instance.end();
     pdfController.removeListener(_onPdfViewerControllerUpdate);
     _leftPaneTabController?.removeListener(_leftPaneTabControllerListener);
     widget.tab.showLeftPane.removeListener(_showLeftPaneListener);

--- a/lib/pdf_book/view/pdf_book_screen.dart
+++ b/lib/pdf_book/view/pdf_book_screen.dart
@@ -36,6 +36,7 @@ import 'package:otzaria/pdf_book/bloc/pdf_book_bloc.dart';
 import 'package:otzaria/pdf_book/bloc/pdf_book_event.dart' as pdf_events;
 import 'package:otzaria/pdf_book/bloc/pdf_book_state.dart';
 import 'package:otzaria/pdf_book/utils/pdf_spread_layout.dart';
+import 'package:otzaria/pdf_book/utils/pdf_viewer_activity.dart';
 import 'package:otzaria/pdf_book/utils/trackpad_axis_lock.dart';
 import 'package:otzaria/pdf_book/utils/trackpad_pan_recognizer.dart';
 import 'package:otzaria/widgets/misc/app_cursors.dart';
@@ -3708,6 +3709,7 @@ class _PdfBookScreenState extends State<PdfBookScreen>
     // יכול לירות לפני onViewerReady, ואיפוס היה מאבד את הסימון. הוא
     // מנוהל ריכוזית ב-_createDocumentRef.
     if (!_waitingForStableLayout) {
+      PdfViewerActivity.instance.begin();
       setState(() {
         _waitingForStableLayout = true;
       });
@@ -3776,6 +3778,7 @@ class _PdfBookScreenState extends State<PdfBookScreen>
     _stableLayoutTargetPage = null;
     _stableLayoutStartedAt = null;
     if (!_waitingForStableLayout) return;
+    PdfViewerActivity.instance.end();
     if (mounted) {
       setState(() {
         _waitingForStableLayout = false;
@@ -3793,6 +3796,7 @@ class _PdfBookScreenState extends State<PdfBookScreen>
     _stableLayoutStartedAt = null;
     _stableLayoutRetryCount = 0;
     _stableLayoutPrefixChecked = false;
+    if (_waitingForStableLayout) PdfViewerActivity.instance.end();
     _waitingForStableLayout = false;
     // לא מאפסים _documentFullyLoaded כאן — ראה הסבר ב-_beginStableLayoutTracking.
   }
@@ -3920,6 +3924,7 @@ class _PdfBookScreenState extends State<PdfBookScreen>
     textSearcher = null;
     _stableLayoutTimer?.cancel();
     _stableLayoutTimer = null;
+    if (_waitingForStableLayout) PdfViewerActivity.instance.end();
     pdfController.removeListener(_onPdfViewerControllerUpdate);
     _leftPaneTabController?.removeListener(_leftPaneTabControllerListener);
     widget.tab.showLeftPane.removeListener(_showLeftPaneListener);

--- a/lib/tools/calendar/helpers/daf_yomi_navigation.dart
+++ b/lib/tools/calendar/helpers/daf_yomi_navigation.dart
@@ -196,8 +196,15 @@ Future<PdfOutlineNode?> getDafYomiOutline(PdfBook book, String daf) async {
 }
 
 Future<List<PdfOutlineNode>> _loadOutlineFromFile(PdfBook book) async {
-  final document = await PdfDocument.openFile(book.path);
-  return document.loadOutline();
+  PdfDocument? document;
+  try {
+    document = await PdfDocument.openFile(book.path);
+    return await document.loadOutline();
+  } finally {
+    // המתנה לשחרור בפועל — ה-worker היחיד של pdfrx חייב להשתחרר מהמסמך
+    // לפני שהטאב שנפתח מיד אחר כך פותח את אותו PDF.
+    await document?.dispose();
+  }
 }
 
 /// פותח ספר PDF לפי שם וסימן

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,7 +42,7 @@ dependencies:
   hive_ce: ^2.19.3
   path_provider: ^2.1.6
   html: ^0.15.7
-  pdfrx: ^2.5.0
+  pdfrx: ^2.6.1
   url_launcher: ^6.3.2
   flutter_widget_from_html: ^0.17.3
   scrollable_positioned_list: ^0.3.8

--- a/test/find_ref/pdf_outline_prewarm_test.dart
+++ b/test/find_ref/pdf_outline_prewarm_test.dart
@@ -1,7 +1,7 @@
 // Tests for [ReferenceBooksCache.prewarmAllPdfOutlines].
 //
 // המנגנון: לאחר ש-warmUp מסיים, ה-cache מפעיל ברקע parse של ה-outline לכל
-// ה-FS PDFs ב-batches מוגבלות (ברירת מחדל 4). הטסטים בודקים את ההתנהגויות
+// ה-FS PDFs ב-batches מוגבלות (ברירת מחדל 1 — ה-worker של pdfrx יחיד). הטסטים בודקים את ההתנהגויות
 // הקריטיות: throttle בפועל, דילוג על ערכים שכבר בקאש, וביטול לאחר clear().
 
 import 'dart:async';

--- a/test/pdf_book/pdf_viewer_activity_test.dart
+++ b/test/pdf_book/pdf_viewer_activity_test.dart
@@ -1,0 +1,63 @@
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/pdf_book/utils/pdf_viewer_activity.dart';
+
+void main() {
+  final activity = PdfViewerActivity.instance;
+
+  tearDown(() {
+    while (activity.loadingCount.value > 0) {
+      activity.end();
+    }
+  });
+
+  group('PdfViewerActivity', () {
+    test('begin/end מאזנים את המונה', () {
+      activity.begin();
+      activity.begin();
+      expect(activity.loadingCount.value, 2);
+      activity.end();
+      expect(activity.loadingCount.value, 1);
+      activity.end();
+      expect(activity.loadingCount.value, 0);
+    });
+
+    test('waitUntilIdle חוזר מיד כשאין viewer בטעינה', () {
+      fakeAsync((async) {
+        var done = false;
+        activity.waitUntilIdle().then((_) => done = true);
+        async.flushMicrotasks();
+        expect(done, isTrue);
+      });
+    });
+
+    test('waitUntilIdle ממתין עד שהמונה יורד לאפס', () {
+      fakeAsync((async) {
+        activity.begin();
+        var done = false;
+        activity.waitUntilIdle().then((_) => done = true);
+        async.elapse(const Duration(seconds: 1));
+        expect(done, isFalse);
+        activity.end();
+        async.flushMicrotasks();
+        expect(done, isTrue);
+      });
+    });
+
+    test('waitUntilIdle משתחרר ב-timeout בלי לזרוק', () {
+      fakeAsync((async) {
+        activity.begin();
+        var done = false;
+        activity
+            .waitUntilIdle(timeout: const Duration(seconds: 2))
+            .then((_) => done = true);
+        async.elapse(const Duration(seconds: 1));
+        expect(done, isFalse);
+        async.elapse(const Duration(seconds: 1));
+        expect(done, isTrue);
+        expect(activity.loadingCount.value, 1);
+        activity.end();
+      });
+    });
+  });
+}


### PR DESCRIPTION
## סיכום

סדרת תיקונים קטנים ובטוחים בטעינת PDF, סביב הדרך שבה אוצריא משתמשת ב‑pdfrx. אין שינוי בממשק המשתמש ואין הגדרות חדשות.

## מה השתנה

- **דף יומי**: מסמך ה‑PDF שנפתח לצורך קריאת ה‑outline משוחרר תמיד (try/finally). עד עכשיו כל ניווט השאיר מסמך פתוח.
- **חימום outlines** (`prewarmAllPDFOutlines`): קובץ אחד בכל פעם במקום כולם במקביל. כל הקריאות ל‑pdfium עוברות דרך worker יחיד, כך שההקבלה רק חסמה את הרינדור של הטאב הפתוח.
- **תצוגה מקדימה בספרייה**: תקציב מטמון תמונות מוגבל (16MB) במקום ברירת המחדל הגדולה.
- **עבודת רקע מפנה את התור למציג**: מחלקה קטנה `PdfViewerActivity` סופרת מציגים שממתינים לעמוד היעד. חימום ה‑outlines והאינדוקס ממתינים עד שהמציג התייצב (עם תקרה של 5 שניות) לפני שהם שולחים עבודה ל‑worker.
- **גלילה**: פתרון הכותרת, השורה והקישורים מה‑DB לפי העמוד הנוכחי נדחה ב‑150 מ״ש עד שהגלילה נרגעת, במקום לרוץ על כל אירוע גלילה.
- **מעקב היציבות של הפריסה**: תקרת הזמן נבדקת גם כשה‑controller עוד לא ready, ו‑dispose מבטל את המעקב בצורה מסודרת.
- **pdfrx 2.6.1**: כולל שלושה תיקונים שנתרמו לספרייה עבור השימוש של אוצריא: פתיחה בעמוד גבוה מודדת מהעמוד היעד החוצה במקום מעמוד 1, הציור הראשון לא ממתין ללולאת פולינג, וקובץ פגום מגיע למסך השגיאה במקום לדיאלוג סיסמה חוזר.

## בדיקות

- `flutter analyze`: ללא ממצאים.
- `flutter test test/pdf_book test/settings`: כל הבדיקות עוברות, כולל בדיקות חדשות ל‑`PdfViewerActivity`. הכישלון היחיד הוא בדיקה קיימת ב‑`change_location_dialog_test` שנכשלת גם על `dev` (השוואת מקור עם `\n` בקובץ CRLF) ואינה קשורה.
- נבדק ידנית ב‑Windows: פתיחת מסכתות בעמוד גבוה, חיפוש, החלפת טאבים בזמן רינדור, ודף יומי.
