### PR TITLE
עדכון ספרייה: אימות חלקי לפי טבלאות ובדיקת שאר הספרייה אחרי ה-commit

### DIFF
--- a/lib/core/messages/library_messages.dart
+++ b/lib/core/messages/library_messages.dart
@@ -94,6 +94,9 @@ abstract class LibraryMessages {
   static const String localLibraryContentMismatch =
       'תוכן הספרייה המקומית שונה מהצפוי';
 
+  static const String libraryContentDriftAfterUpdate =
+      'העדכון הוחל, אך תוכן הספרייה המקומית סוטה מהגרסה הרשמית';
+
   static String fullLibraryDownloadRequired(String reason, String size) =>
       '$reason — נדרשת הורדה מלאה ($size)';
 }

--- a/lib/library_update/bloc/library_update_bloc.dart
+++ b/lib/library_update/bloc/library_update_bloc.dart
@@ -279,27 +279,27 @@ class LibraryUpdateBloc extends Bloc<LibraryUpdateEvent, LibraryUpdateState> {
       // ביטול לפני apply — לא שגיאה; _onCancel כבר העביר ל-idle.
     } catch (e, st) {
       if (_isStale(opId)) return;
-      _logUpdateError('applyDeltaPlan', e, st);
-      final partial = e is PartiallyAppliedLibraryDeltaException
-          ? e.appliedResult
-          : null;
+      final drift = e is LibraryDeltaContentDriftException ? e : null;
+      // סטייה אחרי commit כבר נרשמה ל-errors.txt על ידי הריפוזיטורי.
+      if (drift == null) _logUpdateError('applyDeltaPlan', e, st);
+      final partial = switch (e) {
+        PartiallyAppliedLibraryDeltaException(:final appliedResult) =>
+          appliedResult,
+        LibraryDeltaContentDriftException(:final appliedResult) =>
+          appliedResult,
+        _ => null,
+      };
       final applyError = e is PartiallyAppliedLibraryDeltaException
           ? e.cause
           : e;
-      // כל כשל apply (אי-התאמת hash, גרסה/סכמה לא תואמת, patch פגום) הופך
-      // את מסלול הדלתא ללא בטוח; הורדה מלאה עוקפת אותו. בלי זה, כשל שאינו
-      // אי-התאמת תוכן — למשל patch בסכמה חדשה מהנתמכת — משאיר את המשתמש
-      // בלולאת שגיאה ללא מוצא עד עדכון אפליקציה.
-      if (applyError is PatchApplyException) {
-        final String mismatchReason;
-        if (!applyError.isContentMismatch) {
-          mismatchReason = LibraryMessages.deltaApplyFailed;
-        } else if (applyError.hashMismatchStage ==
-            PatchHashMismatchStage.toContentHash) {
-          mismatchReason = LibraryMessages.deltaResultMismatch;
-        } else {
-          mismatchReason = LibraryMessages.localLibraryContentMismatch;
-        }
+      // כל כשל apply (וגם סטייה שהתגלתה אחרי commit) מנותב להורדה מלאה — אחרת
+      // כשל שאינו אי-התאמת תוכן משאיר את המשתמש בלולאת שגיאה עד עדכון אפליקציה.
+      final mismatchReason = drift != null
+          ? LibraryMessages.libraryContentDriftAfterUpdate
+          : applyError is PatchApplyException
+          ? _applyMismatchReason(applyError)
+          : null;
+      if (mismatchReason != null) {
         final fallback = plan.toFullDownloadFallback(
           reason: mismatchReason,
         );
@@ -334,6 +334,13 @@ class LibraryUpdateBloc extends Bloc<LibraryUpdateEvent, LibraryUpdateState> {
     } finally {
       _deltaWriteStarted = false;
     }
+  }
+
+  String _applyMismatchReason(PatchApplyException error) {
+    if (!error.isContentMismatch) return LibraryMessages.deltaApplyFailed;
+    return error.hashMismatchStage == PatchHashMismatchStage.toContentHash
+        ? LibraryMessages.deltaResultMismatch
+        : LibraryMessages.localLibraryContentMismatch;
   }
 
   Future<void> _onConfirmFull(
@@ -568,6 +575,7 @@ class LibraryUpdateBloc extends Bloc<LibraryUpdateEvent, LibraryUpdateState> {
     'upserts' => 'מוסיף ומעדכן רשומות',
     'deletes' => 'מסיר רשומות שהוסרו',
     'verifyToHash' => 'מאמת את הספרייה המעודכנת',
+    'verifyDeferred' => 'בודק את שאר הספרייה (ניתן להמשיך לקרוא)',
     'commit' => 'שומר שינויים',
     _ => 'מחיל עדכון',
   };

--- a/lib/library_update/bloc/library_update_bloc.dart
+++ b/lib/library_update/bloc/library_update_bloc.dart
@@ -292,6 +292,8 @@ class LibraryUpdateBloc extends Bloc<LibraryUpdateEvent, LibraryUpdateState> {
       final applyError = e is PartiallyAppliedLibraryDeltaException
           ? e.cause
           : e;
+      final requiresFullIndexRefresh =
+          drift != null || (partial?.requiresFullIndexRefresh ?? false);
       // כל כשל apply (וגם סטייה שהתגלתה אחרי commit) מנותב להורדה מלאה — אחרת
       // כשל שאינו אי-התאמת תוכן משאיר את המשתמש בלולאת שגיאה עד עדכון אפליקציה.
       final mismatchReason = drift != null
@@ -314,8 +316,7 @@ class LibraryUpdateBloc extends Bloc<LibraryUpdateEvent, LibraryUpdateState> {
               plan: fallback,
               hasUpdate: partial?.hasDatabaseChanges ?? false,
               changedBookIds: partial?.changedBookIds ?? const {},
-              requiresFullIndexRefresh:
-                  partial?.requiresFullIndexRefresh ?? false,
+              requiresFullIndexRefresh: requiresFullIndexRefresh,
             ),
           );
           return;
@@ -327,7 +328,7 @@ class LibraryUpdateBloc extends Bloc<LibraryUpdateEvent, LibraryUpdateState> {
           message: 'שגיאה בהחלת העדכון',
           hasUpdate: partial?.hasDatabaseChanges ?? false,
           changedBookIds: partial?.changedBookIds ?? const {},
-          requiresFullIndexRefresh: partial?.requiresFullIndexRefresh ?? false,
+          requiresFullIndexRefresh: requiresFullIndexRefresh,
           errorMessage: applyError.toString(),
         ),
       );

--- a/lib/library_update/repository/library_update_repository.dart
+++ b/lib/library_update/repository/library_update_repository.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 import 'dart:isolate';
 
@@ -93,6 +94,22 @@ class LibraryDeltaApplyResult {
             requiresFullIndexRefresh || step.hasChangesOutsideBooksTouched,
         appliedSteps: appliedSteps + 1,
       );
+}
+
+/// העדכון הוחל בהצלחה, אך בבדיקה שאחרי ה-commit נמצאו טבלאות שאף צעד לא נגע
+/// בהן ותוכנן סוטה מהצפוי — הספרייה המקומית אינה זהה לגרסה הרשמית.
+class LibraryDeltaContentDriftException implements Exception {
+  final List<String> driftedTables;
+  final LibraryDeltaApplyResult appliedResult;
+
+  const LibraryDeltaContentDriftException({
+    required this.driftedTables,
+    required this.appliedResult,
+  });
+
+  @override
+  String toString() =>
+      'LibraryDeltaContentDriftException(${driftedTables.join(', ')})';
 }
 
 /// כשל אחרי שלפחות צעד דלתא אחד כבר הושלם ונכתב ל-DB.
@@ -222,6 +239,17 @@ class LibraryUpdateRepository implements LibraryUpdateService {
     var verifyTotalHint = _readIntQuietly(hintFile);
     var lastVerifyDone = 0;
 
+    // רמז בתים לכל טבלה — נדרש כשהמניפסט מאפשר אימות חלקי, שאז ה-total הוא
+    // סכום הטבלאות המאומתות בלבד ולא גודל הקובץ.
+    final tableBytesFile = File(
+      p.join(cacheDir.path, 'verify_table_bytes.json'),
+    );
+    var verifyTableBytes = _readTableBytesQuietly(tableBytesFile);
+
+    // הטבלאות שאף צעד לא אימת — מועמדות לבדיקת סטייה אחרי סיום השרשרת.
+    Set<String>? deferredIntersection;
+    DeltaManifest? lastAppliedManifest;
+
     var result = const LibraryDeltaApplyResult();
     final steps = plan.deltaSteps;
     try {
@@ -271,6 +299,7 @@ class LibraryUpdateRepository implements LibraryUpdateService {
             patchPath: patchPath,
             step: step,
             verifyTotalBytesHint: verifyTotalHint,
+            verifyTableBytesHint: verifyTableBytes,
             onStage: (stage) => onProgress?.call(
               LibraryUpdateProgress(
                 phase: LibraryUpdatePhase.applying,
@@ -295,6 +324,20 @@ class LibraryUpdateRepository implements LibraryUpdateService {
             },
           );
           result = result.addStep(stepResult);
+          lastAppliedManifest = step.manifest;
+          final deferred = stepResult.deferredTables.toSet();
+          final previousDeferred = deferredIntersection;
+          deferredIntersection = previousDeferred == null
+              ? deferred
+              : previousDeferred.intersection(deferred);
+          if (stepResult.verifyTableBytes.isNotEmpty) {
+            final mergedTableBytes = {
+              ...?verifyTableBytes,
+              ...stepResult.verifyTableBytes,
+            };
+            verifyTableBytes = mergedTableBytes;
+            _writeTableBytesQuietly(tableBytesFile, mergedTableBytes);
+          }
           // הדיווח האחרון מ-compute הוא הסך המדויק — total לריצות הבאות.
           if (lastVerifyDone > 0) {
             verifyTotalHint = lastVerifyDone;
@@ -335,10 +378,79 @@ class LibraryUpdateRepository implements LibraryUpdateService {
     );
     await refreshService.refreshAfterDbUpdate();
 
+    // אחרי שחיבור ה-RO נפתח מחדש והריענון הסתיים — מעבר קריאה
+    // בלבד, בלי תור פעולות, כך שניתן להמשיך לקרוא בזמן הבדיקה.
+    final drifted = await _verifyDeferredTables(
+      dbPath: dbPath,
+      manifest: lastAppliedManifest,
+      deferred: deferredIntersection,
+      tableBytesHint: verifyTableBytes,
+      onProgress: onProgress,
+    );
+
+    if (drifted.isNotEmpty) {
+      try {
+        ErrorLogFile.append(
+          title: 'Library Update: content drift in untouched tables',
+          error: 'tables: ${drifted.join(', ')}',
+        );
+      } catch (_) {}
+      throw LibraryDeltaContentDriftException(
+        driftedTables: drifted,
+        appliedResult: result,
+      );
+    }
+
     onProgress?.call(
       const LibraryUpdateProgress(phase: LibraryUpdatePhase.done),
     );
     return result;
+  }
+
+  /// בודק את הטבלאות שאף צעד לא נגע בהן מול ה-hash של הצעד האחרון, ומחזיר
+  /// את אלה שסטו. כשל בבדיקה עצמה אינו הופך עדכון תקין לשגיאה.
+  Future<List<String>> _verifyDeferredTables({
+    required String dbPath,
+    required DeltaManifest? manifest,
+    required Set<String>? deferred,
+    required Map<String, int>? tableBytesHint,
+    LibraryUpdateProgressCallback? onProgress,
+  }) async {
+    final expected = manifest?.toTableContentHashes;
+    if (manifest == null || expected == null) return const [];
+    if (deferred == null || deferred.isEmpty) return const [];
+    onProgress?.call(
+      const LibraryUpdateProgress(
+        phase: LibraryUpdatePhase.applying,
+        stage: 'verifyDeferred',
+      ),
+    );
+    try {
+      return await _verifyTablesInIsolateWithProgress(
+        dbPath: dbPath,
+        schemaVersion: manifest.toSchemaVersion,
+        expected: expected,
+        tables: deferred.toList(),
+        tableBytesHint: tableBytesHint,
+        onVerifyProgress: (done, total) => onProgress?.call(
+          LibraryUpdateProgress(
+            phase: LibraryUpdatePhase.applying,
+            stage: 'verifyDeferred',
+            applyProgress: total > 0 ? (done / total).clamp(0.0, 1.0) : null,
+          ),
+        ),
+      );
+    } catch (error, stackTrace) {
+      debugPrint('Deferred table verification failed: $error\n$stackTrace');
+      try {
+        ErrorLogFile.append(
+          title: 'Library Update: deferred verification failed',
+          error: error,
+          stackTrace: stackTrace,
+        );
+      } catch (_) {}
+      return const [];
+    }
   }
 
   /// מבצע הורדה מלאה: מוריד את `seforim.db.zst`, מחלץ בזרימה ליד ה-DB,
@@ -593,6 +705,7 @@ class LibraryUpdateRepository implements LibraryUpdateService {
     required String patchPath,
     required PatchEdge step,
     int? verifyTotalBytesHint,
+    Map<String, int>? verifyTableBytesHint,
     void Function(String stage)? onStage,
     void Function(int done, int total)? onVerifyProgress,
   }) {
@@ -621,6 +734,7 @@ class LibraryUpdateRepository implements LibraryUpdateService {
           patchPath: patchPath,
           manifest: step.manifest,
           verifyTotalBytesHint: verifyTotalBytesHint,
+          verifyTableBytesHint: verifyTableBytesHint,
           onStage: onStage,
           onVerifyProgress: onVerifyProgress,
         );
@@ -687,6 +801,7 @@ class LibraryUpdateRepository implements LibraryUpdateService {
     required String patchPath,
     required DeltaManifest manifest,
     int? verifyTotalBytesHint,
+    Map<String, int>? verifyTableBytesHint,
     void Function(String stage)? onStage,
     void Function(int done, int total)? onVerifyProgress,
   }) async {
@@ -705,6 +820,7 @@ class LibraryUpdateRepository implements LibraryUpdateService {
         patchPath: patchPath,
         manifest: manifest,
         verifyTotalBytesHint: verifyTotalBytesHint,
+        verifyTableBytesHint: verifyTableBytesHint,
         sendPort: port.sendPort,
       );
     } finally {
@@ -722,6 +838,7 @@ class LibraryUpdateRepository implements LibraryUpdateService {
     required DeltaManifest manifest,
     required SendPort sendPort,
     int? verifyTotalBytesHint,
+    Map<String, int>? verifyTableBytesHint,
   }) {
     return Isolate.run(
       () => const PatchApplier().apply(
@@ -729,6 +846,7 @@ class LibraryUpdateRepository implements LibraryUpdateService {
         patchPath: patchPath,
         manifest: manifest,
         verifyTotalBytesHint: verifyTotalBytesHint,
+        verifyTableBytesHint: verifyTableBytesHint,
         // verifyFromHash=false: verifyToHash אחרי ה-apply הוא הערובה האמיתית —
         // אם המקור שונה, ה-toHash ייכשל וה-transaction יתגלגל אחורה. הבדיקה
         // המקדימה רק כפילה קריאה של כל ה-DB (5.5GB) לחינם.
@@ -738,6 +856,55 @@ class LibraryUpdateRepository implements LibraryUpdateService {
         checkForeignKeys: false,
         onStage: (stage) => sendPort.send(stage),
         onVerifyProgress: (done, total) => sendPort.send((done, total)),
+      ),
+    );
+  }
+
+  // כמו [_applyPatchInIsolate]: ה-callback נשאר ב-caller, ל-isolate נכנסים
+  // ערכים sendable בלבד.
+  static Future<List<String>> _verifyTablesInIsolateWithProgress({
+    required String dbPath,
+    required int schemaVersion,
+    required Map<String, String> expected,
+    required List<String> tables,
+    Map<String, int>? tableBytesHint,
+    void Function(int done, int total)? onVerifyProgress,
+  }) async {
+    final port = ReceivePort();
+    final sub = port.listen((msg) {
+      if (msg is (int, int)) onVerifyProgress?.call(msg.$1, msg.$2);
+    });
+    try {
+      return await _runVerifyTablesIsolate(
+        dbPath: dbPath,
+        schemaVersion: schemaVersion,
+        expected: expected,
+        tables: tables,
+        tableBytesHint: tableBytesHint,
+        sendPort: port.sendPort,
+      );
+    } finally {
+      await sub.cancel();
+      port.close();
+    }
+  }
+
+  static Future<List<String>> _runVerifyTablesIsolate({
+    required String dbPath,
+    required int schemaVersion,
+    required Map<String, String> expected,
+    required List<String> tables,
+    required SendPort sendPort,
+    Map<String, int>? tableBytesHint,
+  }) {
+    return Isolate.run(
+      () => const PatchApplier().verifyTableHashes(
+        dbPath: dbPath,
+        schemaVersion: schemaVersion,
+        expected: expected,
+        tables: tables,
+        tableBytesHint: tableBytesHint,
+        onProgress: (done, total) => sendPort.send((done, total)),
       ),
     );
   }
@@ -771,6 +938,28 @@ class LibraryUpdateRepository implements LibraryUpdateService {
     try {
       file.parent.createSync(recursive: true);
       file.writeAsStringSync('$value');
+    } catch (_) {}
+  }
+
+  static Map<String, int>? _readTableBytesQuietly(File file) {
+    try {
+      if (!file.existsSync()) return null;
+      final decoded = jsonDecode(file.readAsStringSync());
+      if (decoded is! Map) return null;
+      final result = <String, int>{};
+      decoded.forEach((key, value) {
+        if (key is String && value is int && value > 0) result[key] = value;
+      });
+      return result.isEmpty ? null : result;
+    } catch (_) {
+      return null;
+    }
+  }
+
+  static void _writeTableBytesQuietly(File file, Map<String, int> value) {
+    try {
+      file.parent.createSync(recursive: true);
+      file.writeAsStringSync(jsonEncode(value));
     } catch (_) {}
   }
 }

--- a/lib/library_update/repository/library_update_repository.dart
+++ b/lib/library_update/repository/library_update_repository.dart
@@ -847,12 +847,16 @@ class LibraryUpdateRepository implements LibraryUpdateService {
         manifest: manifest,
         verifyTotalBytesHint: verifyTotalBytesHint,
         verifyTableBytesHint: verifyTableBytesHint,
+        // האימות החלקי הוא opt-in ב-updater: הריפוזיטורי משלים אותו במעבר
+        // read-only על deferredTables אחרי ה-commit (ראו _verifyDeferredTables).
+        enablePartialTableVerification: true,
         // verifyFromHash=false: verifyToHash אחרי ה-apply הוא הערובה האמיתית —
         // אם המקור שונה, ה-toHash ייכשל וה-transaction יתגלגל אחורה. הבדיקה
         // המקדימה רק כפילה קריאה של כל ה-DB (5.5GB) לחינם.
         verifyFromHash: false,
-        // checkForeignKeys=false: verifyToHash מאמת את כל 28 הטבלאות (וכל ה-FK
-        // שביניהן) מול ה-DB התקין, אז התאמת hash כבר שוללת הפרות FK — חוסך ~60ש.
+        // checkForeignKeys=false: התאמת ה-hash של הטבלאות שנגעו בהן ל-DB
+        // הקנוני שוללת הפרות שה-patch יצר; הטבלאות האחרות נבדקות במעבר
+        // deferred שאחרי ה-commit. כך נמנעת סריקת FK מלאה נוספת.
         checkForeignKeys: false,
         onStage: (stage) => sendPort.send(stage),
         onVerifyProgress: (done, total) => sendPort.send((done, total)),

--- a/lib/library_update/repository/library_update_repository.dart
+++ b/lib/library_update/repository/library_update_repository.dart
@@ -338,8 +338,8 @@ class LibraryUpdateRepository implements LibraryUpdateService {
             verifyTableBytes = mergedTableBytes;
             _writeTableBytesQuietly(tableBytesFile, mergedTableBytes);
           }
-          // הדיווח האחרון מ-compute הוא הסך המדויק — total לריצות הבאות.
-          if (lastVerifyDone > 0) {
+          // באימות מלא הדיווח האחרון הוא ה-total המדויק לריצה הבאה.
+          if (lastVerifyDone > 0 && deferred.isEmpty) {
             verifyTotalHint = lastVerifyDone;
             _writeIntQuietly(hintFile, lastVerifyDone);
           }
@@ -363,6 +363,14 @@ class LibraryUpdateRepository implements LibraryUpdateService {
         // הכשל המקורית; ה-BLoC עדיין יוכל להציע fallback ולרענן אחרי ההחלטה.
         refreshError = error;
       }
+      final drifted = await _verifyDeferredTables(
+        dbPath: dbPath,
+        manifest: lastAppliedManifest,
+        deferred: deferredIntersection,
+        tableBytesHint: verifyTableBytes,
+        onProgress: onProgress,
+      );
+      _throwIfContentDrifted(drifted, result);
       Error.throwWithStackTrace(
         PartiallyAppliedLibraryDeltaException(
           cause: error,
@@ -388,23 +396,29 @@ class LibraryUpdateRepository implements LibraryUpdateService {
       onProgress: onProgress,
     );
 
-    if (drifted.isNotEmpty) {
-      try {
-        ErrorLogFile.append(
-          title: 'Library Update: content drift in untouched tables',
-          error: 'tables: ${drifted.join(', ')}',
-        );
-      } catch (_) {}
-      throw LibraryDeltaContentDriftException(
-        driftedTables: drifted,
-        appliedResult: result,
-      );
-    }
+    _throwIfContentDrifted(drifted, result);
 
     onProgress?.call(
       const LibraryUpdateProgress(phase: LibraryUpdatePhase.done),
     );
     return result;
+  }
+
+  void _throwIfContentDrifted(
+    List<String> drifted,
+    LibraryDeltaApplyResult result,
+  ) {
+    if (drifted.isEmpty) return;
+    try {
+      ErrorLogFile.append(
+        title: 'Library Update: content drift in untouched tables',
+        error: 'tables: ${drifted.join(', ')}',
+      );
+    } catch (_) {}
+    throw LibraryDeltaContentDriftException(
+      driftedTables: drifted,
+      appliedResult: result,
+    );
   }
 
   /// בודק את הטבלאות שאף צעד לא נגע בהן מול ה-hash של הצעד האחרון, ומחזיר

--- a/test/library_update/library_update_bloc_test.dart
+++ b/test/library_update/library_update_bloc_test.dart
@@ -1565,6 +1565,49 @@ void main() {
     );
 
     blocTest<LibraryUpdateBloc, LibraryUpdateState>(
+      'סטייה בטבלאות שלא נגעו בהן אחרי commit → fallback עם שינויי הצעדים',
+      build: () => _bloc(
+        _FakeService(
+          deltaWithFallbackPlan,
+          applyError: const LibraryDeltaContentDriftException(
+            driftedTables: ['author', 'topic'],
+            appliedResult: LibraryDeltaApplyResult(
+              changedBookIds: {3, 9},
+              requiresFullIndexRefresh: true,
+              appliedSteps: 1,
+            ),
+          ),
+        ),
+      ),
+      act: (b) => b.add(const StartLibraryUpdate()),
+      expect: () => [
+        isA<LibraryUpdateState>().having(
+          (s) => s.status,
+          'status',
+          LibraryUpdateStatus.checking,
+        ),
+        isA<LibraryUpdateState>()
+            .having(
+              (s) => s.status,
+              'status',
+              LibraryUpdateStatus.needsFullConfirmation,
+            )
+            .having(
+              (s) => s.message,
+              'message',
+              contains(LibraryMessages.libraryContentDriftAfterUpdate),
+            )
+            .having((s) => s.hasUpdate, 'hasUpdate', true)
+            .having((s) => s.changedBookIds, 'changedBookIds', const {3, 9})
+            .having(
+              (s) => s.requiresFullIndexRefresh,
+              'requiresFullIndexRefresh',
+              true,
+            ),
+      ],
+    );
+
+    blocTest<LibraryUpdateBloc, LibraryUpdateState>(
       'סטיית תוכן בלי DB מלא בתוכנית → error',
       build: () => _bloc(
         _FakeService(

--- a/test/library_update/library_update_bloc_test.dart
+++ b/test/library_update/library_update_bloc_test.dart
@@ -1573,7 +1573,6 @@ void main() {
             driftedTables: ['author', 'topic'],
             appliedResult: LibraryDeltaApplyResult(
               changedBookIds: {3, 9},
-              requiresFullIndexRefresh: true,
               appliedSteps: 1,
             ),
           ),

--- a/test/library_update/library_update_repository_test.dart
+++ b/test/library_update/library_update_repository_test.dart
@@ -665,6 +665,264 @@ void main() {
   );
 
   test(
+    'מניפסט עם hash לכל טבלה: אימות חלקי, שלב verifyDeferred, בלי סטייה',
+    () async {
+      final dbPath = p.join(tmp.path, DatabaseConstants.databaseFileName);
+      _writeSchema4SourceDb(dbPath, version: 1, sourceName: 'old');
+      final expectedPath = p.join(tmp.path, 'expected.db');
+      _writeSchema4SourceDb(expectedPath, version: 2, sourceName: 'new');
+      final patchPath = p.join(tmp.path, 'patch-1-2.db');
+      _writeSourcePatch(
+        patchPath,
+        fromVersion: 1,
+        toVersion: 2,
+        sourceName: 'new',
+      );
+      final repository = LibraryUpdateRepository(
+        discovery: _unusedDiscovery(),
+        downloader: _PatchMapDownloader({'patch-1-2.db': patchPath}),
+        refreshService: _NoopRefreshService(),
+        dbPathProvider: () => dbPath,
+        dataRootProvider: () async => tmp.path,
+        nowTimestamp: () => '2026-09-07T00:00:00Z',
+      );
+      final stages = <String>[];
+
+      final result = await repository.applyDeltaPlan(
+        _schema4DeltaPlan([
+          _schema4Edge(
+            fromVersion: 1,
+            toVersion: 2,
+            patchName: 'patch-1-2.db',
+            toHash: _logicalHash(expectedPath),
+            fromTableHashes: _tableHashes(dbPath),
+            toTableHashes: _tableHashes(expectedPath),
+          ),
+        ]),
+        onProgress: (progress) {
+          final stage = progress.stage;
+          if (stage != null) stages.add(stage);
+        },
+      );
+
+      expect(result.appliedSteps, 1);
+      expect(stages, contains('verifyDeferred'));
+      expect(_readSourceName(dbPath), 'new');
+      // רמז הבתים לכל טבלה נשמר לריצה הבאה.
+      final hintFile = File(
+        p.join(tmp.path, 'library_update_cache', 'verify_table_bytes.json'),
+      );
+      expect(hintFile.existsSync(), isTrue);
+      expect(
+        (jsonDecode(hintFile.readAsStringSync()) as Map).keys,
+        contains('source'),
+      );
+    },
+    timeout: const Timeout(Duration(seconds: 60)),
+  );
+
+  test(
+    'סטייה בטבלה שאף צעד לא נגע בה מדווחת אחרי ה-commit ונרשמת ל-errors.txt',
+    () async {
+      final dbPath = p.join(tmp.path, DatabaseConstants.databaseFileName);
+      final pristinePath = p.join(tmp.path, 'pristine.db');
+      final expectedPath = p.join(tmp.path, 'expected.db');
+      // ה-manifest נבנה מ-DB תקין; המקומי זהה לו פרט ל-author שסטה.
+      _writeSchema4SourceDb(
+        pristinePath,
+        version: 1,
+        sourceName: 'old',
+        authorName: 'תקין',
+      );
+      _writeSchema4SourceDb(
+        expectedPath,
+        version: 2,
+        sourceName: 'new',
+        authorName: 'תקין',
+      );
+      _writeSchema4SourceDb(
+        dbPath,
+        version: 1,
+        sourceName: 'old',
+        authorName: 'סוטה',
+      );
+      final patchPath = p.join(tmp.path, 'patch-1-2.db');
+      _writeSourcePatch(
+        patchPath,
+        fromVersion: 1,
+        toVersion: 2,
+        sourceName: 'new',
+      );
+      AppPaths.debugOverrideDataRootPath(tmp.path);
+      final refresh = _NoopRefreshService();
+      final repository = LibraryUpdateRepository(
+        discovery: _unusedDiscovery(),
+        downloader: _PatchMapDownloader({'patch-1-2.db': patchPath}),
+        refreshService: refresh,
+        dbPathProvider: () => dbPath,
+        dataRootProvider: () async => tmp.path,
+        nowTimestamp: () => '2026-09-07T00:00:00Z',
+      );
+
+      try {
+        await expectLater(
+          repository.applyDeltaPlan(
+            _schema4DeltaPlan([
+              _schema4Edge(
+                fromVersion: 1,
+                toVersion: 2,
+                patchName: 'patch-1-2.db',
+                toHash: _logicalHash(expectedPath),
+                fromTableHashes: _tableHashes(pristinePath),
+                toTableHashes: _tableHashes(expectedPath),
+              ),
+            ]),
+          ),
+          throwsA(
+            isA<LibraryDeltaContentDriftException>()
+                .having(
+                  (e) => e.driftedTables,
+                  'driftedTables',
+                  contains('author'),
+                )
+                .having((e) => e.appliedResult.appliedSteps, 'appliedSteps', 1),
+          ),
+        );
+
+        // העדכון עצמו הוחל ורוענן — הסטייה אינה rollback.
+        expect(_readSourceName(dbPath), 'new');
+        expect(refresh.called, isTrue);
+        expect(
+          ErrorLogFile.resolveFile().readAsStringSync(),
+          contains('Library Update: content drift in untouched tables'),
+        );
+      } finally {
+        AppPaths.debugOverrideDataRootPath(null);
+      }
+    },
+    timeout: const Timeout(Duration(seconds: 60)),
+  );
+
+  test(
+    'שרשרת שבה צעד אחד בלי hash לכל טבלה: אין שלב verifyDeferred',
+    () async {
+      final dbPath = p.join(tmp.path, DatabaseConstants.databaseFileName);
+      _writeSchema4SourceDb(dbPath, version: 1, sourceName: 'old');
+      final expected2 = p.join(tmp.path, 'expected2.db');
+      _writeSchema4SourceDb(expected2, version: 2, sourceName: 'new');
+      final expected3 = p.join(tmp.path, 'expected3.db');
+      _writeSchema4SourceDb(expected3, version: 3, sourceName: 'newer');
+      final firstPatch = p.join(tmp.path, 'patch-1-2.db');
+      final secondPatch = p.join(tmp.path, 'patch-2-3.db');
+      _writeSourcePatch(
+        firstPatch,
+        fromVersion: 1,
+        toVersion: 2,
+        sourceName: 'new',
+      );
+      _writeSourcePatch(
+        secondPatch,
+        fromVersion: 2,
+        toVersion: 3,
+        sourceName: 'newer',
+      );
+      final repository = LibraryUpdateRepository(
+        discovery: _unusedDiscovery(),
+        downloader: _PatchMapDownloader({
+          'patch-1-2.db': firstPatch,
+          'patch-2-3.db': secondPatch,
+        }),
+        refreshService: _NoopRefreshService(),
+        dbPathProvider: () => dbPath,
+        dataRootProvider: () async => tmp.path,
+        nowTimestamp: () => '2026-09-07T00:00:00Z',
+      );
+      final stages = <String>[];
+
+      final result = await repository.applyDeltaPlan(
+        _schema4DeltaPlan([
+          _schema4Edge(
+            fromVersion: 1,
+            toVersion: 2,
+            patchName: 'patch-1-2.db',
+            toHash: _logicalHash(expected2),
+            fromTableHashes: _tableHashes(dbPath),
+            toTableHashes: _tableHashes(expected2),
+          ),
+          _schema4Edge(
+            fromVersion: 2,
+            toVersion: 3,
+            patchName: 'patch-2-3.db',
+            toHash: _logicalHash(expected3),
+          ),
+        ]),
+        onProgress: (progress) {
+          final stage = progress.stage;
+          if (stage != null) stages.add(stage);
+        },
+      );
+
+      // הצעד הישן אימת את כל ה-DB, ולכן אין טבלה שנותרה לא-מאומתת.
+      expect(result.appliedSteps, 2);
+      expect(_readSourceName(dbPath), 'newer');
+      expect(stages, isNot(contains('verifyDeferred')));
+    },
+    timeout: const Timeout(Duration(seconds: 60)),
+  );
+
+  test(
+    'מניפסט בלי hash לכל טבלה: אימות DB מלא, בלי שלב verifyDeferred',
+    () async {
+      final dbPath = p.join(tmp.path, DatabaseConstants.databaseFileName);
+      _writeSchema4SourceDb(dbPath, version: 1, sourceName: 'old');
+      final expectedPath = p.join(tmp.path, 'expected.db');
+      _writeSchema4SourceDb(expectedPath, version: 2, sourceName: 'new');
+      final patchPath = p.join(tmp.path, 'patch-1-2.db');
+      _writeSourcePatch(
+        patchPath,
+        fromVersion: 1,
+        toVersion: 2,
+        sourceName: 'new',
+      );
+      final repository = LibraryUpdateRepository(
+        discovery: _unusedDiscovery(),
+        downloader: _PatchMapDownloader({'patch-1-2.db': patchPath}),
+        refreshService: _NoopRefreshService(),
+        dbPathProvider: () => dbPath,
+        dataRootProvider: () async => tmp.path,
+        nowTimestamp: () => '2026-09-07T00:00:00Z',
+      );
+      final stages = <String>[];
+
+      final result = await repository.applyDeltaPlan(
+        _schema4DeltaPlan([
+          _schema4Edge(
+            fromVersion: 1,
+            toVersion: 2,
+            patchName: 'patch-1-2.db',
+            toHash: _logicalHash(expectedPath),
+          ),
+        ]),
+        onProgress: (progress) {
+          final stage = progress.stage;
+          if (stage != null) stages.add(stage);
+        },
+      );
+
+      expect(result.appliedSteps, 1);
+      expect(stages, contains('verifyToHash'));
+      expect(stages, isNot(contains('verifyDeferred')));
+      expect(
+        File(
+          p.join(tmp.path, 'library_update_cache', 'verify_table_bytes.json'),
+        ).existsSync(),
+        isFalse,
+      );
+    },
+    timeout: const Timeout(Duration(seconds: 60)),
+  );
+
+  test(
     'קורא RO ממשיך לקרוא בזמן כתיבת WAL (הנחת היסוד של עדכון ללא חסימה)',
     () async {
       final dbPath = p.join(tmp.path, DatabaseConstants.databaseFileName);
@@ -907,6 +1165,21 @@ class _PatchMapDownloader extends PatchDownloader {
   }) async => patchPaths[patchFile.file]!;
 }
 
+/// ה-hash לכל טבלה בסדר של סכמה 4 — הבסיס למפות שבמניפסט.
+Map<String, String> _tableHashes(String dbPath, {int schemaVersion = 4}) {
+  final db = sqlite3.sqlite3.open(dbPath, mode: sqlite3.OpenMode.readOnly);
+  try {
+    return const LogicalContentHasher()
+        .computeReport(
+          db,
+          tableOrder: hashTableOrderForSchemaVersion(schemaVersion),
+        )
+        .tableHashes;
+  } finally {
+    db.close();
+  }
+}
+
 String _logicalHash(String dbPath) {
   final db = sqlite3.sqlite3.open(dbPath, mode: sqlite3.OpenMode.readOnly);
   try {
@@ -920,6 +1193,7 @@ void _writeSchema4SourceDb(
   String dbPath, {
   required int version,
   required String sourceName,
+  String? authorName,
 }) {
   final db = sqlite3.sqlite3.open(dbPath);
   try {
@@ -931,6 +1205,10 @@ void _writeSchema4SourceDb(
     );
     db.execute('CREATE TABLE source (id INTEGER PRIMARY KEY, name TEXT)');
     db.execute('INSERT INTO source VALUES (1, ?)', [sourceName]);
+    if (authorName != null) {
+      db.execute('CREATE TABLE author (id INTEGER PRIMARY KEY, name TEXT)');
+      db.execute('INSERT INTO author VALUES (1, ?)', [authorName]);
+    }
     db.execute('PRAGMA journal_mode=DELETE');
   } finally {
     db.close();
@@ -976,6 +1254,8 @@ PatchEdge _schema4Edge({
   required int toVersion,
   required String patchName,
   required String toHash,
+  Map<String, String>? fromTableHashes,
+  Map<String, String>? toTableHashes,
 }) {
   final manifest = DeltaManifest.fromJson({
     'fromVersion': fromVersion,
@@ -985,6 +1265,8 @@ PatchEdge _schema4Edge({
     'patchFormatVersion': 4,
     'fromContentHash': 'unused',
     'toContentHash': toHash,
+    'fromTableContentHashes': ?fromTableHashes,
+    'toTableContentHashes': ?toTableHashes,
     'patchFiles': [
       {
         'file': patchName,

--- a/test/library_update/library_update_repository_test.dart
+++ b/test/library_update/library_update_repository_test.dart
@@ -717,6 +717,12 @@ void main() {
         (jsonDecode(hintFile.readAsStringSync()) as Map).keys,
         contains('source'),
       );
+      expect(
+        File(
+          p.join(tmp.path, 'library_update_cache', 'verify_total_bytes.txt'),
+        ).existsSync(),
+        isFalse,
+      );
     },
     timeout: const Timeout(Duration(seconds: 60)),
   );
@@ -866,6 +872,92 @@ void main() {
       expect(result.appliedSteps, 2);
       expect(_readSourceName(dbPath), 'newer');
       expect(stages, isNot(contains('verifyDeferred')));
+    },
+    timeout: const Timeout(Duration(seconds: 60)),
+  );
+
+  test(
+    'כשל בצעד מאוחר עדיין מדווח סטייה בטבלה שנדחתה בצעד שהושלם',
+    () async {
+      final dbPath = p.join(tmp.path, DatabaseConstants.databaseFileName);
+      final pristinePath = p.join(tmp.path, 'pristine.db');
+      final expectedPath = p.join(tmp.path, 'expected.db');
+      _writeSchema4SourceDb(
+        pristinePath,
+        version: 1,
+        sourceName: 'old',
+        authorName: 'תקין',
+      );
+      _writeSchema4SourceDb(
+        expectedPath,
+        version: 2,
+        sourceName: 'new',
+        authorName: 'תקין',
+      );
+      _writeSchema4SourceDb(
+        dbPath,
+        version: 1,
+        sourceName: 'old',
+        authorName: 'סוטה',
+      );
+      final firstPatch = p.join(tmp.path, 'patch-1-2.db');
+      final invalidPatch = p.join(tmp.path, 'patch-2-3.db');
+      _writeSourcePatch(
+        firstPatch,
+        fromVersion: 1,
+        toVersion: 2,
+        sourceName: 'new',
+      );
+      _writeSourcePatch(
+        invalidPatch,
+        fromVersion: 2,
+        toVersion: 3,
+        sourceName: 'newer',
+        patchFormatVersion: 99,
+      );
+      final repository = LibraryUpdateRepository(
+        discovery: _unusedDiscovery(),
+        downloader: _PatchMapDownloader({
+          'patch-1-2.db': firstPatch,
+          'patch-2-3.db': invalidPatch,
+        }),
+        refreshService: _NoopRefreshService(),
+        dbPathProvider: () => dbPath,
+        dataRootProvider: () async => tmp.path,
+        nowTimestamp: () => '2026-09-08T00:00:00Z',
+      );
+
+      await expectLater(
+        repository.applyDeltaPlan(
+          _schema4DeltaPlan([
+            _schema4Edge(
+              fromVersion: 1,
+              toVersion: 2,
+              patchName: 'patch-1-2.db',
+              toHash: _logicalHash(expectedPath),
+              fromTableHashes: _tableHashes(pristinePath),
+              toTableHashes: _tableHashes(expectedPath),
+            ),
+            _schema4Edge(
+              fromVersion: 2,
+              toVersion: 3,
+              patchName: 'patch-2-3.db',
+              toHash: 'unused',
+            ),
+          ]),
+        ),
+        throwsA(
+          isA<LibraryDeltaContentDriftException>()
+              .having(
+                (e) => e.driftedTables,
+                'driftedTables',
+                contains('author'),
+              )
+              .having((e) => e.appliedResult.appliedSteps, 'appliedSteps', 1),
+        ),
+      );
+      expect(const LocalDbVersionReader().read(dbPath).dbVersion, 2);
+      expect(_readSourceName(dbPath), 'new');
     },
     timeout: const Timeout(Duration(seconds: 60)),
   );


### PR DESCRIPTION
## מה השינוי
שלב "מאמת את הספרייה המעודכנת" בעדכון דלתא מתקצר מדקות לשניות: כשהמניפסט נושא hash לכל טבלה, ה-updater מאמת בתוך ה-transaction רק את הטבלאות שה-patch יכול היה לשנות. הטבלאות שאף צעד בשרשרת לא נגע בהן נבדקות **אחרי** שהשרשרת נשמרה וחיבור ה-RO נפתח מחדש — מעבר קריאה-בלבד ב-isolate, בלי תור פעולות ובלי `closeForExternalWrite`, בשלב חדש `verifyDeferred` שמוצג כ"בודק את שאר הספרייה (ניתן להמשיך לקרוא)".

- `LibraryUpdateRepository.applyDeltaPlan` — מעביר `verifyTableBytesHint` לכל צעד, שומר את הבתים לכל טבלה ב-`library_update_cache/verify_table_bytes.json`, אוסף את חיתוך `deferredTables` של כל הצעדים, ואחרי `refreshAfterDbUpdate` מריץ `verifyTableHashes` על החיתוך מול `toTableContentHashes` של הצעד האחרון.
- סטייה שמתגלית אחרי ה-commit **אינה** rollback (העדכון תקין לטבלאות שנגע בהן): נרשמת ל-`errors.txt` (`Library Update: content drift in untouched tables`), וזורקת `LibraryDeltaContentDriftException` עם תוצאת ה-apply. ה-bloc מנתב ל-`needsFullConfirmation` עם `LibraryMessages.libraryContentDriftAfterUpdate`, ושומר `changedBookIds`/`requiresFullIndexRefresh` כך שהאינדוקס לא אובד.
- כשל של הבדיקה המושהית עצמה נרשם ל-`errors.txt` ואינו הופך עדכון תקין לשגיאה.
- מניפסט בלי מפות — התנהגות זהה לקודם: אין שלב חדש, אין קובץ חדש, אותם progress ואותן חריגות.

## PRים מקושרים (מענפים נפרדים) — סדר מיזוג
1. Otzaria/SeforimLibrary#27 — המפיק כותב את המפות למניפסט.
2. Otzaria/otzaria_library_updater#10 — הלקוח (0.4.0) עם האימות החלקי ו-`verifyTableHashes`.
3. PR זה — **למזג רק אחרי שניהם**: התלות ב-`pubspec.yaml` היא `ref: main` של ה-updater, וה-API החדש (`verifyTableBytesHint`, `deferredTables`, `verifyTableHashes`) קיים רק שם. פותח מקומית דרך `pubspec_overrides.yaml` (לא בקומיט).

הענף כולל גם את c891d0ad4 ("עדכון ספרייה: רישום נסיגה מ-WAL ל-errors.txt") שהיה על בסיס ה-worktree וטרם ב-`dev`.

## איך נבדק
- `test/library_update/library_update_repository_test.dart`: מניפסט עם מפות → אימות חלקי, שלב `verifyDeferred`, קובץ הרמז נשמר; סטייה בטבלה שלא נגעו בה → חריגה אחרי ה-commit, ה-DB מעודכן, refresh נקרא, נרשם ל-`errors.txt`; שרשרת שבה צעד אחד בלי מפות → אין `verifyDeferred`; מניפסט בלי מפות → אימות מלא בלבד ואין קובץ.
- `test/library_update/library_update_bloc_test.dart`: סטייה → `needsFullConfirmation` עם ההודעה החדשה ו-`changedBookIds` שמורים.
- `flutter analyze` נקי; `flutter test test/library_update/` — 115/115.
