### PR TITLE
תיקון שישה באגים פתוחים בקריאה, איתור והערות

### DIFF
--- a/lib/data/cache/acronym_cache_data.dart
+++ b/lib/data/cache/acronym_cache_data.dart
@@ -1,0 +1,59 @@
+import 'dart:typed_data';
+
+import 'package:otzaria/utils/text/text_manipulation.dart';
+
+/// התוצאה המוכנה של חימום כינויי הספרים ואינדקס הביגרמים שלהם.
+class AcronymCacheData {
+  final Map<int, List<String>> acronymsByBookId;
+  final Map<int, Int32List> bookIdsByBigram;
+  final int rowCount;
+
+  const AcronymCacheData({
+    required this.acronymsByBookId,
+    required this.bookIdsByBigram,
+    required this.rowCount,
+  });
+}
+
+/// מנרמל זוגות `(bookId, term)` ובונה מהם את שני מבני הקאש.
+AcronymCacheData buildAcronymCacheData(Iterable<(int, String)> rawPairs) {
+  final acronymsByBookId = <int, List<String>>{};
+  var rowCount = 0;
+  for (final (bookId, term) in rawPairs) {
+    rowCount++;
+    if (term.isEmpty) continue;
+    final normalized = normalizeForFindRefMatch(term);
+    if (normalized.isEmpty) continue;
+    acronymsByBookId.putIfAbsent(bookId, () => <String>[]).add(normalized);
+  }
+
+  final postings = <int, List<int>>{};
+  final bookIds = acronymsByBookId.keys.toList()..sort();
+  for (final bookId in bookIds) {
+    for (final term in acronymsByBookId[bookId]!) {
+      var previous = -1;
+      for (var i = 0; i < term.length; i++) {
+        final current = term.codeUnitAt(i);
+        if (previous >= 0) {
+          final key = (previous << 16) | current;
+          final list = postings[key];
+          if (list == null) {
+            postings[key] = <int>[bookId];
+          } else if (list.last != bookId) {
+            list.add(bookId);
+          }
+        }
+        previous = current;
+      }
+    }
+  }
+
+  return AcronymCacheData(
+    acronymsByBookId: acronymsByBookId,
+    bookIdsByBigram: {
+      for (final entry in postings.entries)
+        entry.key: Int32List.fromList(entry.value),
+    },
+    rowCount: rowCount,
+  );
+}

--- a/lib/data/cache/acronyms_cache.dart
+++ b/lib/data/cache/acronyms_cache.dart
@@ -1,7 +1,7 @@
-import 'dart:isolate';
-
 import 'package:flutter/foundation.dart';
+import 'package:otzaria/data/cache/acronym_cache_data.dart';
 import 'package:otzaria/data/data_providers/sqlite_data_provider.dart';
+import 'package:otzaria/find_ref/repository/find_ref_db_isolate.dart';
 import 'package:otzaria/utils/text/text_manipulation.dart';
 
 /// קבוצת-על ממוינת של מזהי ספרים שכינוי שלהם עלול להתאים לשאילתה.
@@ -121,40 +121,19 @@ class AcronymsCache {
     }
 
     try {
-      final db = await repository.database.database;
-      if (myGen != _generation) return; // הופסק על ידי clear()
-
-      final acrRows = db.select(
-        'SELECT bookId, term FROM book_acronym ORDER BY bookId',
-      );
-
-      // רק שליפת השורות חייבת לרוץ כאן (החיבור חי על ה-isolate הזה);
-      // הנורמליזציה ובניית האינדקס עוברות ל-isolate כדי לא להתחרות ב-UI.
-      final rawPairs = <(int, String)>[
-        for (final row in acrRows)
-          (row['bookId'] as int, (row['term'] as String?) ?? ''),
-      ];
-      final (local, bigrams) = await Isolate.run(() {
-        final result = <int, List<String>>{};
-        for (final (bookId, term) in rawPairs) {
-          if (term.isEmpty) continue;
-          final normalized = normalizeForFindRefMatch(term);
-          if (normalized.isEmpty) continue;
-          result.putIfAbsent(bookId, () => <String>[]).add(normalized);
-        }
-        return (result, _buildBigramIndex(result));
-      });
+      final data = await (await FindRefDbIsolate.instance())
+          .getBookAcronymCache();
 
       if (myGen != _generation) return;
       _acronymsByBookId
         ..clear()
-        ..addAll(local);
+        ..addAll(data.acronymsByBookId);
       _bookIdsByBigram
         ..clear()
-        ..addAll(bigrams);
+        ..addAll(data.bookIdsByBigram);
       _isLoaded = true;
       debugPrint(
-        '[AcronymsCache] Loaded ${acrRows.length} acronyms for ${_acronymsByBookId.length} books',
+        '[AcronymsCache] Loaded ${data.rowCount} acronyms for ${_acronymsByBookId.length} books',
       );
     } catch (e) {
       debugPrint('[AcronymsCache] Warmup failed: $e');
@@ -179,52 +158,19 @@ class AcronymsCache {
   /// האמיתית, כדי לבדוק את מסלול ההתאמה בלי DB.
   @visibleForTesting
   void setAcronymsForTesting(Map<int, List<String>> rawTermsByBookId) {
-    _acronymsByBookId.clear();
-    for (final entry in rawTermsByBookId.entries) {
-      final normalized = entry.value
-          .map(normalizeForFindRefMatch)
-          .where((t) => t.isNotEmpty)
-          .toList();
-      if (normalized.isNotEmpty) _acronymsByBookId[entry.key] = normalized;
-    }
+    final data = buildAcronymCacheData(
+      rawTermsByBookId.entries.expand(
+        (entry) => entry.value.map((term) => (entry.key, term)),
+      ),
+    );
+    _acronymsByBookId
+      ..clear()
+      ..addAll(data.acronymsByBookId);
     _bookIdsByBigram
       ..clear()
-      ..addAll(_buildBigramIndex(_acronymsByBookId));
+      ..addAll(data.bookIdsByBigram);
     _isLoaded = true;
   }
 }
 
 int _bigramKey(int first, int second) => (first << 16) | second;
-
-/// בונה את אינדקס הביגרמים מהמונחים המנורמלים. פונקציה top-level כדי שה-closure
-/// של ה-`Isolate.run` לא יוכל ללכוד את ה-singleton — שאינו sendable.
-///
-/// המזהים נצברים בסדר עולה כדי שכל רשימה תהיה ממוינת ([AcronymCandidateBooks]
-/// מסתמך על כך), ולכן די בהשוואה לאיבר האחרון לניכוי כפילויות.
-Map<int, Int32List> _buildBigramIndex(
-  Map<int, List<String>> acronymsByBookId,
-) {
-  final postings = <int, List<int>>{};
-  final bookIds = acronymsByBookId.keys.toList()..sort();
-  for (final bookId in bookIds) {
-    for (final term in acronymsByBookId[bookId]!) {
-      var previous = -1;
-      for (var i = 0; i < term.length; i++) {
-        final current = term.codeUnitAt(i);
-        if (previous >= 0) {
-          final list = postings[_bigramKey(previous, current)];
-          if (list == null) {
-            postings[_bigramKey(previous, current)] = <int>[bookId];
-          } else if (list.last != bookId) {
-            list.add(bookId);
-          }
-        }
-        previous = current;
-      }
-    }
-  }
-  return {
-    for (final entry in postings.entries)
-      entry.key: Int32List.fromList(entry.value),
-  };
-}

--- a/lib/find_ref/repository/find_ref_db_isolate.dart
+++ b/lib/find_ref/repository/find_ref_db_isolate.dart
@@ -3,6 +3,7 @@ import 'dart:isolate';
 
 import 'package:flutter/foundation.dart';
 import 'package:otzaria/core/error_log_file.dart';
+import 'package:otzaria/data/cache/acronym_cache_data.dart';
 import 'package:otzaria/data/constants/database_constants.dart';
 import 'package:otzaria/find_ref/repository/alt_toc_flat_entry.dart';
 import 'package:otzaria/migration/database/daos/database.dart';
@@ -245,6 +246,19 @@ class FindRefDbIsolate {
   Future<List<Map<String, dynamic>>> getAllLocalBooksSlim() async {
     final res = await _request('allLocalBooksSlim', const {});
     return _castRows(res);
+  }
+
+  /// שולף ומכין את קאש הכינויים כולו ב-worker, בלי לממש עשרות אלפי שורות
+  /// SQLite על ה-UI isolate.
+  Future<AcronymCacheData> getBookAcronymCache() async {
+    final raw = (await _request('bookAcronymCache', const {}) as Map)
+        .cast<String, Object?>();
+    return AcronymCacheData(
+      acronymsByBookId: (raw['acronymsByBookId'] as Map)
+          .cast<int, List<String>>(),
+      bookIdsByBigram: (raw['bookIdsByBigram'] as Map).cast<int, Int32List>(),
+      rowCount: raw['rowCount'] as int,
+    );
   }
 
   /// שורות ה-TOC של ספר מ-`seforim.db`. המיפוי ל-`TocEntry` נעשה בצד הקורא
@@ -539,6 +553,28 @@ void _workerMain(_Bootstrap bootstrap) {
           throw StateError('seforim.db unavailable for allLocalBooksSlim');
         }
         return repo.database.bookDao.selectAllLocalBooksSlim();
+      case 'bookAcronymCache':
+        final repo = await ensureRepo();
+        if (repo == null) {
+          throw StateError('seforim.db unavailable for bookAcronymCache');
+        }
+        final db = await repo.database.database;
+        final rows = db.select(
+          'SELECT bookId, term FROM book_acronym ORDER BY bookId',
+        );
+        final data = buildAcronymCacheData(
+          rows.map(
+            (row) => (
+              row['bookId'] as int,
+              (row['term'] as String?) ?? '',
+            ),
+          ),
+        );
+        return {
+          'acronymsByBookId': data.acronymsByBookId,
+          'bookIdsByBigram': data.bookIdsByBigram,
+          'rowCount': data.rowCount,
+        };
       case 'bookToc':
         final repo = await ensureRepo();
         if (repo == null) {

--- a/lib/navigation/view/main_window_screen.dart
+++ b/lib/navigation/view/main_window_screen.dart
@@ -3163,7 +3163,10 @@ class MainWindowScreenState extends State<MainWindowScreen>
             // וטאב תוסף פתוח נטען מאפס לדף הראשי שלו.
             _cachedReadingPage ??= KeepAlivePage(
               key: const ValueKey('page-reading'),
-              child: ReadingScreen(key: _readingScreenKey),
+              child: ReadingScreen(
+                key: _readingScreenKey,
+                onFindRefRequested: () => _handleFindRefOpen(context),
+              ),
             );
             _cachedSettingsPage ??= KeepAlivePage(
               key: const ValueKey('page-settings'),

--- a/lib/pdf_book/view/pdf_book_screen.dart
+++ b/lib/pdf_book/view/pdf_book_screen.dart
@@ -190,6 +190,45 @@ Offset pdfTopAnchoredCenter({
   required double zoom,
 }) => Offset(currentCenter.dx, anchorDocTop + viewSize.height / 2 / zoom);
 
+/// עוגן חד־פעמי לשימור קו הראש בעת שינוי רוחב קורא ה-PDF.
+@visibleForTesting
+class PdfPaneToggleAnchor {
+  double? _docTop;
+  Size? _viewSize;
+
+  /// מכין עוגן לשינוי רוחב אמיתי, או מנקה עוגן קודם כשהחלונית היא overlay.
+  void prepare({
+    required bool changesReaderWidth,
+    double? docTop,
+    Size? viewSize,
+  }) {
+    _docTop = null;
+    _viewSize = null;
+    if (!changesReaderWidth || docTop == null || viewSize == null) return;
+    _docTop = docTop;
+    _viewSize = viewSize;
+  }
+
+  /// צורך את העוגן פעם אחת ומחזיר אותו רק לשינוי הרוחב התואם.
+  double? consume({
+    required Size? oldViewSize,
+    required Size newViewSize,
+    required bool isBookView,
+  }) {
+    final docTop = _docTop;
+    final capturedViewSize = _viewSize;
+    _docTop = null;
+    _viewSize = null;
+    if (docTop == null ||
+        oldViewSize != capturedViewSize ||
+        isBookView ||
+        oldViewSize!.width == newViewSize.width) {
+      return null;
+    }
+    return docTop;
+  }
+}
+
 /// מחזיר את מדיניות שינוי גודל ה-PDF לפי מצב התצוגה.
 @visibleForTesting
 PdfViewerSizeDelegateProvider pdfSizeDelegateProviderForLayoutMode(
@@ -524,13 +563,9 @@ class _PdfBookScreenState extends State<PdfBookScreen>
   bool _readerFocusAndHideQueued = false;
   bool _bookHasCommentaryLinks = false;
 
-  /// נקודת המסמך שהייתה בראש התצוגה רגע לפני שרוחב הקורא השתנה
-  /// (פתיחת/סגירת חלונית הצד), לשחזור אחריו.
-  double? _paneToggleAnchorDocTop;
-
-  /// גודל התצוגה שבו נלקח העוגן — מונע החלת עוגן ישן
-  /// על שינוי גודל אחר (במסך צר החלונית overlay והרוחב לא משתנה).
-  Size? _paneToggleAnchorViewSize;
+  final PdfPaneToggleAnchor _paneToggleAnchor = PdfPaneToggleAnchor();
+  bool _leftPaneUsesPushLayout = false;
+  bool _rightPaneUsesPushLayout = false;
 
   /// מצב יד — גרירת עכבר גוללת את הדף במקום לסמן טקסט (issue #916).
   bool _isHandMode = false;
@@ -690,41 +725,59 @@ class _PdfBookScreenState extends State<PdfBookScreen>
     if (current is PdfBookLoaded && current.showLeftPane == show) {
       return;
     }
-    _captureViewportTopAnchor();
+    _prepareViewportTopAnchor(
+      changesReaderWidth: _leftPaneUsesPushLayout,
+    );
     _bloc.add(pdf_events.ToggleLeftPane(show));
+  }
+
+  void _setRightPaneVisibility(bool show, {int? initialTabIndex}) {
+    final current = _bloc.state;
+    if (current is PdfBookLoaded && current.showRightPane == show) {
+      return;
+    }
+    _prepareViewportTopAnchor(
+      changesReaderWidth: _rightPaneUsesPushLayout,
+    );
+    _bloc.add(
+      pdf_events.ToggleRightPane(
+        show: show,
+        initialTabIndex: initialTabIndex,
+      ),
+    );
   }
 
   /// שומר את קו הראש של התצוגה לפני שינוי רוחב הקורא. מדיניות השינוי-גודל
   /// של pdfrx מעגנת את המרכז, ובזום שגדל התוצאה שנוּוט אליה נדחקת מהמסך.
-  void _captureViewportTopAnchor() {
-    final controller = widget.tab.pdfViewerController;
-    if (!controller.isReady || controller.layout.pageLayouts.isEmpty) {
-      _paneToggleAnchorDocTop = null;
-      _paneToggleAnchorViewSize = null;
+  void _prepareViewportTopAnchor({required bool changesReaderWidth}) {
+    if (!changesReaderWidth) {
+      _paneToggleAnchor.prepare(changesReaderWidth: false);
       return;
     }
-    _paneToggleAnchorDocTop = controller.visibleRect.top;
-    _paneToggleAnchorViewSize = controller.viewSize;
+    final controller = widget.tab.pdfViewerController;
+    if (!controller.isReady || controller.layout.pageLayouts.isEmpty) {
+      _paneToggleAnchor.prepare(changesReaderWidth: false);
+      return;
+    }
+    _paneToggleAnchor.prepare(
+      changesReaderWidth: true,
+      docTop: controller.visibleRect.top,
+      viewSize: controller.viewSize,
+    );
   }
 
-  /// מחזיר את קו הראש שנשמר ב-[_captureViewportTopAnchor], בזום שכבר נקבע
+  /// מחזיר את קו הראש שנשמר ב-[_prepareViewportTopAnchor], בזום שכבר נקבע
   /// על ידי מדיניות שינוי-הגודל (issue #1023).
   void _restoreViewportTopAnchor(
     PdfViewerController controller,
     Size? oldViewSize,
   ) {
-    final anchorDocTop = _paneToggleAnchorDocTop;
-    final anchorViewSize = _paneToggleAnchorViewSize;
-    _paneToggleAnchorDocTop = null;
-    _paneToggleAnchorViewSize = null;
-    // בתצוגת ספר העמוד ממורכז ומנורמל על ידי normalizeMatrix — אין שם
-    // גלילה חופשית לשמר.
-    if (anchorDocTop == null ||
-        oldViewSize != anchorViewSize ||
-        _isBookViewModeActive() ||
-        oldViewSize!.width == controller.viewSize.width) {
-      return;
-    }
+    final anchorDocTop = _paneToggleAnchor.consume(
+      oldViewSize: oldViewSize,
+      newViewSize: controller.viewSize,
+      isBookView: _isBookViewModeActive(),
+    );
+    if (anchorDocTop == null) return;
     // pdfrx מזהיר לא לשנות את המטריצה בתוך ה-callback — הוא נקרא תוך כדי build.
     Future.microtask(() {
       if (!mounted || !controller.isReady) return;
@@ -1035,7 +1088,7 @@ class _PdfBookScreenState extends State<PdfBookScreen>
       if (current is! PdfBookLoaded) return;
       final isOnCommentary = _currentRightPaneTabIndex == _kCommentaryTabIndex;
       if (current.showRightPane && isOnCommentary) {
-        _bloc.add(const pdf_events.ToggleRightPane(show: false));
+        _setRightPaneVisibility(false);
       } else {
         // בדומה ל-_openCommentaryPane: רישום interaction של TourCubit לפני
         // הפתיחה, כדי שטור/אונבורדינג ידע שהמשתמש השתמש במפרשים.
@@ -1044,7 +1097,7 @@ class _PdfBookScreenState extends State<PdfBookScreen>
           _rightPaneInitialTabIndex = _kCommentaryTabIndex;
           _currentRightPaneTabIndex = _kCommentaryTabIndex;
         });
-        _bloc.add(const pdf_events.ToggleRightPane(show: true));
+        _setRightPaneVisibility(true);
       }
     };
     widget.tab.toggleCommentatorsPaneNotifier.addListener(
@@ -1242,7 +1295,7 @@ class _PdfBookScreenState extends State<PdfBookScreen>
       _rightPaneInitialTabIndex = _kCommentaryTabIndex;
       _currentRightPaneTabIndex = _kCommentaryTabIndex;
     });
-    _bloc.add(const pdf_events.ToggleRightPane(show: true));
+    _setRightPaneVisibility(true);
   }
 
   void _openLinksPane() {
@@ -1250,7 +1303,7 @@ class _PdfBookScreenState extends State<PdfBookScreen>
       _rightPaneInitialTabIndex = _kLinksTabIndex;
       _currentRightPaneTabIndex = _kLinksTabIndex;
     });
-    _bloc.add(const pdf_events.ToggleRightPane(show: true));
+    _setRightPaneVisibility(true);
   }
 
   // פותחת את חלונית ההערות האישיות.
@@ -1266,7 +1319,7 @@ class _PdfBookScreenState extends State<PdfBookScreen>
     if (!isOpen) {
       _bloc.add(const pdf_events.UpdateRightPaneWidth(_kRightPaneNarrowWidth));
     }
-    _bloc.add(const pdf_events.ToggleRightPane(show: true));
+    _setRightPaneVisibility(true);
   }
 
   void _maybeRegisterPdfCommentaryOpportunity() {
@@ -3608,7 +3661,7 @@ class _PdfBookScreenState extends State<PdfBookScreen>
       return;
     }
     _didAutoOpenCommentary = true;
-    _bloc.add(const pdf_events.ToggleRightPane(show: true, initialTabIndex: 0));
+    _setRightPaneVisibility(true, initialTabIndex: 0);
     // פתיחה אוטומטית נחשבת כ"שימוש במפרשים" — מדכאת את טיפ "כדאי לפתוח מפרשים".
     _recordCommentaryOpenedIfNeeded();
   }
@@ -4339,6 +4392,9 @@ class _PdfBookScreenState extends State<PdfBookScreen>
                     minPaneWidth: 200,
                     maxPaneWidth: 600,
                     autoHandleResponsiveVisibility: false,
+                    onLayoutModeChanged: (usesPushLayout) {
+                      _leftPaneUsesPushLayout = usesPushLayout;
+                    },
                     onPaneWidthChanged: (nextWidth) {
                       _bloc.add(pdf_events.UpdateSidebarWidth(nextWidth));
                     },
@@ -4356,13 +4412,14 @@ class _PdfBookScreenState extends State<PdfBookScreen>
                       alignment: AlignmentDirectional.centerStart,
                       paneWidth: rightPaneWidth,
                       minMainContentWidth: 200,
-                      onClose: () => _bloc.add(
-                        const pdf_events.ToggleRightPane(show: false),
-                      ),
+                      onClose: () => _setRightPaneVisibility(false),
                       isResizable: true,
                       minPaneWidth: 250,
                       maxPaneWidth: 600,
                       autoHandleResponsiveVisibility: false,
+                      onLayoutModeChanged: (usesPushLayout) {
+                        _rightPaneUsesPushLayout = usesPushLayout;
+                      },
                       onPaneWidthChanged: (nextWidth) {
                         _bloc.add(pdf_events.UpdateRightPaneWidth(nextWidth));
                       },
@@ -4734,7 +4791,7 @@ class _PdfBookScreenState extends State<PdfBookScreen>
           openPreparedTab(context, tab, insertAdjacent: true),
       fontSize: settingsState.commentatorsFontSize,
       onClose: () {
-        _bloc.add(const pdf_events.ToggleRightPane(show: false));
+        _setRightPaneVisibility(false);
       },
       initialTabIndex: _rightPaneInitialTabIndex,
       onTabChanged: (index) {

--- a/lib/pdf_book/view/pdf_commentary_panel.dart
+++ b/lib/pdf_book/view/pdf_commentary_panel.dart
@@ -1057,7 +1057,6 @@ class PdfCommentaryPanelState extends State<PdfCommentaryPanel>
         Expanded(
           child: TabBarView(
             controller: _tabController,
-            physics: const NeverScrollableScrollPhysics(),
             children: [
               // מפתחות חייבים להישאר קבועים: מפתח תלוי-עמוד הורס את שלושת
               // התתי-עצים בכל דפדוף ומאפס את מטמוני התוכן שלהם.

--- a/lib/personal_notes/view/personal_notes_screen.dart
+++ b/lib/personal_notes/view/personal_notes_screen.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
@@ -75,6 +76,9 @@ class _PersonalNotesManagerScreenState
   String? _booksError;
   final Map<String, PersonalNotesState> _bookStates = {};
   final Map<String, bool> _expansionState = {};
+  int _notesLoadGeneration = 0;
+  StreamSubscription<PersonalNotesState>? _notesLoadSubscription;
+  Completer<void>? _notesLoadCompleter;
   // קאש ל-TOC לכל ספר, לחישוב כתובת המיקום של ההערות. נטען עצלן פעם אחת.
   final Map<String, Future<List<TocEntry>?>> _tocFutureByBook = {};
   bool _isNavigationVisible = true;
@@ -135,13 +139,54 @@ class _PersonalNotesManagerScreenState
   }
 
   void _scheduleNotesLoad(List<BookNotesInfo> books) {
+    final generation = ++_notesLoadGeneration;
+    _cancelPendingNotesLoad();
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!mounted) return;
-      final bloc = context.read<PersonalNotesBloc>();
-      for (final book in books) {
-        bloc.add(LoadPersonalNotes(book.bookId));
-      }
+      if (!mounted || generation != _notesLoadGeneration) return;
+      unawaited(_loadNotesSequence(books, generation));
     });
+  }
+
+  void _cancelPendingNotesLoad() {
+    final subscription = _notesLoadSubscription;
+    final completer = _notesLoadCompleter;
+    _notesLoadSubscription = null;
+    _notesLoadCompleter = null;
+    if (completer != null && !completer.isCompleted) completer.complete();
+    if (subscription != null) unawaited(subscription.cancel());
+  }
+
+  Future<void> _loadNotesSequence(
+    List<BookNotesInfo> books,
+    int generation,
+  ) async {
+    if (!mounted || generation != _notesLoadGeneration) return;
+    final bloc = context.read<PersonalNotesBloc>();
+    for (final book in books) {
+      if (generation != _notesLoadGeneration) return;
+      final completer = Completer<void>();
+      void completeLoad() {
+        if (!completer.isCompleted) completer.complete();
+      }
+
+      final subscription = bloc.stream.listen(
+        (state) {
+          if (state.bookId == book.bookId && !state.isLoading) completeLoad();
+        },
+        onError: (_, _) => completeLoad(),
+        onDone: completeLoad,
+      );
+      _notesLoadSubscription = subscription;
+      _notesLoadCompleter = completer;
+      bloc.add(LoadPersonalNotes(book.bookId));
+      await completer.future;
+      if (identical(_notesLoadSubscription, subscription)) {
+        _notesLoadSubscription = null;
+        _notesLoadCompleter = null;
+      }
+      unawaited(subscription.cancel());
+      if (!mounted || generation != _notesLoadGeneration) return;
+    }
   }
 
   void _onFilterChanged(String? filter) {
@@ -244,6 +289,8 @@ class _PersonalNotesManagerScreenState
 
   @override
   void dispose() {
+    _notesLoadGeneration++;
+    _cancelPendingNotesLoad();
     _searchController.dispose();
     _searchFocusNode.dispose();
     _windowFocusNode.dispose();
@@ -297,7 +344,7 @@ class _PersonalNotesManagerScreenState
         child: BlocListener<PersonalNotesBloc, PersonalNotesState>(
           listener: (context, state) {
             // Store the state for each book and trigger rebuild
-            if (state.bookId != null) {
+            if (state.bookId != null && !state.isLoading) {
               setState(() {
                 _bookStates[state.bookId!] = state;
               });

--- a/lib/tabs/reading_screen.dart
+++ b/lib/tabs/reading_screen.dart
@@ -47,7 +47,10 @@ import 'package:otzaria/widgets/widgets_exports.dart';
 import 'package:otzaria/tour/tour_target_keys.dart';
 
 class ReadingScreen extends StatefulWidget {
-  const ReadingScreen({super.key});
+  const ReadingScreen({super.key, this.onFindRefRequested});
+
+  /// פותח את חלונית איתור הספר דרך מעטפת החלון הראשי.
+  final VoidCallback? onFindRefRequested;
 
   /// עקיפה לבדיקות של זיהוי פלטפורמת מגע (physics ו-onPageChanged של מובייל).
   @visibleForTesting
@@ -403,11 +406,7 @@ class _ReadingScreenState extends State<ReadingScreen>
                         ActionButton.neutral(
                           text: 'איתור ספר',
                           icon: FluentIcons.search_24_regular,
-                          onPressed: () {
-                            context.read<NavigationBloc>().add(
-                              const NavigateToScreen(Screen.find),
-                            );
-                          },
+                          onPressed: widget.onFindRefRequested,
                         ),
                       ],
                     )

--- a/lib/text_book/utils/commentators_context_menu.dart
+++ b/lib/text_book/utils/commentators_context_menu.dart
@@ -1,8 +1,12 @@
+import 'dart:async';
+
 import 'package:fluentui_system_icons/fluentui_system_icons.dart';
 import 'package:flutter/foundation.dart';
+import 'package:otzaria/models/books.dart';
 import 'package:otzaria/models/link_types.dart';
 import 'package:otzaria/models/links.dart';
 import 'package:otzaria/text_book/models/commentator_group.dart';
+import 'package:otzaria/text_book/text_book_repository.dart';
 import 'package:otzaria/text_book/utils/inline_notes_utils.dart'
     as inline_notes;
 import 'package:otzaria/utils/text/text_manipulation.dart'
@@ -12,16 +16,72 @@ import 'package:otzaria/widgets/misc/app_menu_exports.dart';
 /// כותרת תת-התפריט "מפרשים" בתפריט ההקשר של גוף הספר.
 const String kParagraphCommentatorsMenuLabel = 'מפרשים על פסקה זו';
 
-/// המפרשים מתוך [availableCommentators] שיש להם תוכן על הפסקה [paragraphIndex]
-/// (0-based): קישור-מפרש ב-[linksByLine] (ממופתח 1-based), או הערות inline
-/// בשורה עבור המפרש הוירטואלי [kNotesCommentatorTitle]. הסדר נשמר.
+/// מטמון את מפרשי הפסקה שנטענו בשאילת טווח.
+///
+/// [changes] מאפשר לתת־התפריט הפתוח להתעדכן כשהשאילתה מסתיימת.
+class ParagraphCommentatorsCache {
+  final Map<(Object, int), List<String>> _values = {};
+  final Set<(Object, int)> _pending = {};
+  final StreamController<Object?> _changes = StreamController.broadcast();
+
+  Stream<Object?> get changes => _changes.stream;
+
+  List<String>? value(TextBook book, int paragraphIndex) =>
+      _values[_key(book, paragraphIndex)];
+
+  bool isLoading(TextBook book, int paragraphIndex) =>
+      _pending.contains(_key(book, paragraphIndex));
+
+  Future<void> prefetch({
+    required TextBookRepository repository,
+    required TextBook book,
+    required int paragraphIndex,
+  }) async {
+    final key = _key(book, paragraphIndex);
+    if (_values.containsKey(key) || !_pending.add(key)) return;
+    try {
+      final links = await repository.getBookLinksInRange(
+        book,
+        startIndex: paragraphIndex,
+        endIndex: paragraphIndex,
+        targetBookTitles: null,
+      );
+      _values[key] = {
+        for (final link in links)
+          if (LinkTypes.isDependentTextLink(link.connectionType))
+            getTitleFromPath(link.path2),
+      }.toList();
+    } finally {
+      _pending.remove(key);
+      if (!_changes.isClosed) _changes.add(key);
+    }
+  }
+
+  (Object, int) _key(TextBook book, int paragraphIndex) => (
+    (
+      book.id,
+      book.title,
+      book.categoryId,
+      book.fileType,
+      book.versionTitle,
+    ),
+    paragraphIndex,
+  );
+
+  void dispose() => _changes.close();
+}
+
+/// המפרשים מתוך [availableCommentators] שיש להם תוכן על הפסקה [paragraphIndex].
+/// [queriedCommentators] מגיע משאילתת הטווח; [linksByLine] מצרף קישורים
+/// מקומיים, לרבות ספרי משתמש. הערות inline מצרפות את [kNotesCommentatorTitle].
 List<String> paragraphCommentators({
   required List<String> availableCommentators,
   required List<String> content,
   required int paragraphIndex,
   required Map<int, List<Link>> linksByLine,
+  List<String>? queriedCommentators,
 }) {
-  final onParagraph = <String>{};
+  final onParagraph = queriedCommentators?.toSet() ?? <String>{};
   for (final link in linksByLine[paragraphIndex + 1] ?? const <Link>[]) {
     if (!LinkTypes.isDependentTextLink(link.connectionType)) continue;
     onParagraph.add(getTitleFromPath(link.path2));

--- a/lib/text_book/view/combined_view/combined_book_screen.dart
+++ b/lib/text_book/view/combined_view/combined_book_screen.dart
@@ -1179,7 +1179,9 @@ class _CombinedViewState extends State<CombinedView> {
       ];
     }
 
-    _prefetchParagraphCommentators(state, paragraphIndex);
+    if (state.availableCommentators.isNotEmpty) {
+      _prefetchParagraphCommentators(state, paragraphIndex);
+    }
 
     final paragraphLinks = buildCombinedViewContextMenuLinksForParagraph(
       linksByLine: state.linksByLine,

--- a/lib/text_book/view/combined_view/combined_book_screen.dart
+++ b/lib/text_book/view/combined_view/combined_book_screen.dart
@@ -274,6 +274,8 @@ typedef _CommentaryScrollTarget = ({
 
 class _CombinedViewState extends State<CombinedView> {
   bool _anchorHandledCurrentTap = false;
+  final ParagraphCommentatorsCache _paragraphCommentatorsCache =
+      ParagraphCommentatorsCache();
 
   final ValueNotifier<_CommentaryScrollTarget?> _anchorScrollTargetNotifier =
       ValueNotifier<_CommentaryScrollTarget?>(null);
@@ -939,6 +941,7 @@ class _CombinedViewState extends State<CombinedView> {
     _selectionManager.removeListener(_onSelectionModeChanged);
     _selectionManager.dispose();
     _siblingController.dispose();
+    _paragraphCommentatorsCache.dispose();
     super.dispose();
   }
 
@@ -1176,6 +1179,8 @@ class _CombinedViewState extends State<CombinedView> {
       ];
     }
 
+    _prefetchParagraphCommentators(state, paragraphIndex);
+
     final paragraphLinks = buildCombinedViewContextMenuLinksForParagraph(
       linksByLine: state.linksByLine,
       paragraphIndex: paragraphIndex,
@@ -1193,34 +1198,46 @@ class _CombinedViewState extends State<CombinedView> {
       isCommentatorsTabActive: isCommentatorsTabActive,
     );
 
-    final commentatorChildren = buildCommentatorsContextMenuChildren(
-      activeCommentators: state.activeCommentators,
-      availableCommentators: paragraphCommentators(
-        availableCommentators: state.availableCommentators,
-        content: state.content,
-        paragraphIndex: paragraphIndex,
-        linksByLine: state.linksByLine,
-      ),
-      commentatorGroups: state.commentatorGroups,
-      linksLoading: state.linksLoading,
-      onOpenPane: shouldShowOpenPaneEntry
-          ? () {
-              _selectParagraphForContextMenu(paragraphIndex);
-              _openCommentatorsPane(isAdding: true);
-            }
-          : null,
-      onSelectMultiple: shouldShowSelectEntry
-          ? () {
-              _selectParagraphForContextMenu(paragraphIndex);
-              widget.onOpenCommentatorsPaneWithFilter!();
-            }
-          : null,
-      onCommentatorsChanged: (commentators, {required isAdding}) {
-        _selectParagraphForContextMenu(paragraphIndex);
-        context.read<TextBookBloc>().add(UpdateCommentators(commentators));
-        _openCommentatorsPane(isAdding: isAdding);
-      },
-    );
+    List<AppContextMenuEntry> buildCommentatorChildren() {
+      final isLoading = _paragraphCommentatorsCache.isLoading(
+        state.book,
+        paragraphIndex,
+      );
+      return buildCommentatorsContextMenuChildren(
+        activeCommentators: state.activeCommentators,
+        availableCommentators: paragraphCommentators(
+          availableCommentators: state.availableCommentators,
+          content: state.content,
+          paragraphIndex: paragraphIndex,
+          linksByLine: state.linksByLine,
+          queriedCommentators: isLoading
+              ? const <String>[]
+              : _paragraphCommentatorsCache.value(
+                  state.book,
+                  paragraphIndex,
+                ),
+        ),
+        commentatorGroups: state.commentatorGroups,
+        linksLoading: state.linksLoading || isLoading,
+        onOpenPane: shouldShowOpenPaneEntry
+            ? () {
+                _selectParagraphForContextMenu(paragraphIndex);
+                _openCommentatorsPane(isAdding: true);
+              }
+            : null,
+        onSelectMultiple: shouldShowSelectEntry
+            ? () {
+                _selectParagraphForContextMenu(paragraphIndex);
+                widget.onOpenCommentatorsPaneWithFilter!();
+              }
+            : null,
+        onCommentatorsChanged: (commentators, {required isAdding}) {
+          _selectParagraphForContextMenu(paragraphIndex);
+          context.read<TextBookBloc>().add(UpdateCommentators(commentators));
+          _openCommentatorsPane(isAdding: isAdding);
+        },
+      );
+    }
 
     final showOpenLinksPaneEntry = shouldShowOpenLinksPaneEntry(
       hasLinks: paragraphLinks.isNotEmpty,
@@ -1314,7 +1331,8 @@ class _CombinedViewState extends State<CombinedView> {
         label: kParagraphCommentatorsMenuLabel,
         icon: OtzariaIcons.book_24_regular,
         enabled: state.availableCommentators.isNotEmpty,
-        children: commentatorChildren,
+        childrenBuilder: buildCommentatorChildren,
+        childrenRefreshStream: _paragraphCommentatorsCache.changes,
       ),
       AppContextMenuEntry(
         label: 'קישורים',
@@ -1487,6 +1505,25 @@ class _CombinedViewState extends State<CombinedView> {
         ];
       }(),
     ];
+  }
+
+  void _prefetchParagraphCommentators(
+    TextBookLoaded state,
+    int paragraphIndex,
+  ) {
+    unawaited(
+      _paragraphCommentatorsCache
+          .prefetch(
+            repository: context.read<TextBookBloc>().repository,
+            book: state.book,
+            paragraphIndex: paragraphIndex,
+          )
+          .onError((error, stackTrace) {
+            debugPrint(
+              'שגיאה בטעינת מפרשי הפסקה: $error\n$stackTrace',
+            );
+          }),
+    );
   }
 
   /// פריטי תוסף להקשר `reader-highlight` — לחיצה ימנית על טקסט מודגש

--- a/lib/text_book/view/page_shape/simple_text_viewer.dart
+++ b/lib/text_book/view/page_shape/simple_text_viewer.dart
@@ -1714,7 +1714,7 @@ class _SimpleTextViewerState extends State<SimpleTextViewer> {
     Offset tapPosition,
     String? capturedText,
   ) {
-    if (widget.isMainText) {
+    if (widget.isMainText && state.availableCommentators.isNotEmpty) {
       _prefetchParagraphCommentators(state, index);
     }
     List<AppContextMenuEntry> commentatorItems = [];

--- a/lib/text_book/view/page_shape/simple_text_viewer.dart
+++ b/lib/text_book/view/page_shape/simple_text_viewer.dart
@@ -482,6 +482,8 @@ class _SimpleTextViewerState extends State<SimpleTextViewer> {
   int? _pendingDisplayModeRestoreLineIndex;
   final DictionaryLookupRepository _dictionaryLookupRepository =
       DictionaryLookupRepository.instance;
+  final ParagraphCommentatorsCache _paragraphCommentatorsCache =
+      ParagraphCommentatorsCache();
   List<Link>? _anchorStyleSourceLinks;
   Map<String, int> _anchorStyleCache = const {};
   Timer? _previewHoverTimer;
@@ -1072,6 +1074,7 @@ class _SimpleTextViewerState extends State<SimpleTextViewer> {
     _selectionFocusNode.dispose();
     _keyboardFocusNode?.dispose();
     _siblingController?.dispose();
+    _paragraphCommentatorsCache.dispose();
     super.dispose();
   }
 
@@ -1711,6 +1714,9 @@ class _SimpleTextViewerState extends State<SimpleTextViewer> {
     Offset tapPosition,
     String? capturedText,
   ) {
+    if (widget.isMainText) {
+      _prefetchParagraphCommentators(state, index);
+    }
     List<AppContextMenuEntry> commentatorItems = [];
     if (!widget.isMainText && widget.bookTitle != null) {
       commentatorItems = _buildCommentatorSwitchMenu(state);
@@ -1853,6 +1859,7 @@ class _SimpleTextViewerState extends State<SimpleTextViewer> {
           icon: OtzariaIcons.book_24_regular,
           enabled: state.availableCommentators.isNotEmpty,
           childrenBuilder: () => _buildCommentatorsMenuItems(state, index),
+          childrenRefreshStream: _paragraphCommentatorsCache.changes,
         ),
       );
       entries.add(
@@ -2169,6 +2176,10 @@ class _SimpleTextViewerState extends State<SimpleTextViewer> {
     TextBookLoaded state,
     int index,
   ) {
+    final isLoading = _paragraphCommentatorsCache.isLoading(
+      state.book,
+      index,
+    );
     final showOpenPane = shouldShowOpenCommentatorsPaneEntry(
       hasSelectedCommentators: state.activeCommentators.isNotEmpty,
       showCommentaryAsExpansionTiles: false,
@@ -2194,9 +2205,12 @@ class _SimpleTextViewerState extends State<SimpleTextViewer> {
         content: widget.content,
         paragraphIndex: index,
         linksByLine: state.linksByLine,
+        queriedCommentators: isLoading
+            ? const <String>[]
+            : _paragraphCommentatorsCache.value(state.book, index),
       ),
       commentatorGroups: state.commentatorGroups,
-      linksLoading: state.linksLoading,
+      linksLoading: state.linksLoading || isLoading,
       onOpenPane: showOpenPane && widget.onOpenCommentatorsPane != null
           ? () {
               selectClickedLine();
@@ -2214,6 +2228,22 @@ class _SimpleTextViewerState extends State<SimpleTextViewer> {
         context.read<TextBookBloc>().add(UpdateCommentators(commentators));
         if (isAdding) widget.onOpenCommentatorsPane?.call();
       },
+    );
+  }
+
+  void _prefetchParagraphCommentators(TextBookLoaded state, int index) {
+    unawaited(
+      _paragraphCommentatorsCache
+          .prefetch(
+            repository: context.read<TextBookBloc>().repository,
+            book: state.book,
+            paragraphIndex: index,
+          )
+          .onError((error, stackTrace) {
+            debugPrint(
+              'שגיאה בטעינת מפרשי הפסקה: $error\n$stackTrace',
+            );
+          }),
     );
   }
 

--- a/test/core/startup_watchdog_test.dart
+++ b/test/core/startup_watchdog_test.dart
@@ -5,7 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   final source = File(
     'windows/runner/startup_watchdog.cpp',
-  ).readAsStringSync();
+  ).readAsStringSync().replaceAll('\r\n', '\n');
   final mainSource = File('windows/runner/main.cpp').readAsStringSync();
   final windowSource = File(
     'windows/runner/flutter_window.cpp',

--- a/test/find_ref/acronyms_cache_isolate_warmup_test.dart
+++ b/test/find_ref/acronyms_cache_isolate_warmup_test.dart
@@ -1,0 +1,104 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:flutter_settings_screens/flutter_settings_screens.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/data/cache/acronyms_cache.dart';
+import 'package:otzaria/data/data_providers/sqlite_data_provider.dart';
+import 'package:otzaria/find_ref/repository/find_ref_db_isolate.dart';
+import 'package:otzaria/migration/database/daos/database.dart';
+import 'package:otzaria/settings/engine/settings_repository.dart';
+import 'package:path/path.dart' as path;
+
+import '../test_helpers/memory_cache_provider.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory tempDir;
+  FindRefDbIsolate? worker;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('otzaria_acronym_worker');
+    await Settings.init(cacheProvider: MemoryCacheProvider());
+    AcronymsCache.instance.clear();
+  });
+
+  tearDown(() async {
+    AcronymsCache.instance.clear();
+    worker?.disposeForTesting();
+    await SqliteDataProvider.instance.dispose();
+    await tempDir.delete(recursive: true);
+  });
+
+  test(
+    'חימום ראשון על DB גדול אינו חוסם את ה-event loop ושומר התאמות',
+    () async {
+      final dbPath = path.join(tempDir.path, 'seforim.db');
+      final database = MyDatabase.withPath(dbPath);
+      final db = await database.database;
+      db.execute(
+        "INSERT INTO category (id, title, level) VALUES (7, 'תנך', 0)",
+      );
+      db.execute("INSERT INTO source (id, name) VALUES (1, 'אוצריא')");
+      db.execute(
+        "INSERT INTO book (id, categoryId, sourceId, title, orderIndex, "
+        "filePath, fileType) VALUES "
+        "(1, 7, 1, 'ספר גדול', 1, '/b/large.txt', 'txt'), "
+        "(2, 7, 1, 'משנה תורה', 2, '/b/rambam.txt', 'txt')",
+      );
+      db.execute('''
+        WITH digits(d) AS (
+          VALUES (0), (1), (2), (3), (4), (5), (6), (7), (8), (9)
+        ), numbers(n) AS (
+          SELECT a.d + b.d * 10 + c.d * 100 + d.d * 1000 + e.d * 10000
+          FROM digits a, digits b, digits c, digits d, digits e
+        )
+        INSERT INTO book_acronym (bookId, term)
+        SELECT 1, 'כינוי ' || printf('%05d', n)
+        FROM numbers
+        WHERE n < 60000
+      ''');
+      db.execute(
+        "INSERT INTO book_acronym (bookId, term) VALUES "
+        "(2, 'רמב\"ם'), (2, 'משנה תורה')",
+      );
+      database.close();
+
+      await Settings.setValue<String>(
+        SettingsRepository.keyDbEffectivePath,
+        dbPath,
+      );
+      await SqliteDataProvider.instance.initialize();
+      worker = await FindRefDbIsolate.instance();
+
+      var eventLoopTicks = 0;
+      final timer = Timer.periodic(
+        const Duration(milliseconds: 1),
+        (_) => eventLoopTicks++,
+      );
+      try {
+        await AcronymsCache.instance.warmUp().timeout(
+          const Duration(seconds: 30),
+        );
+      } finally {
+        timer.cancel();
+      }
+
+      expect(eventLoopTicks, greaterThan(5));
+      expect(AcronymsCache.instance.isLoaded, isTrue);
+      expect(
+        AcronymsCache.instance.getAcronymsForBook(1),
+        hasLength(60000),
+      );
+      expect(
+        AcronymsCache.instance.getAcronymsForBook(2),
+        unorderedEquals(['רמבם', 'משנה תורה']),
+      );
+      final candidates = AcronymsCache.instance.candidatesFor('רמבם')!;
+      expect(candidates.length, 1);
+      expect(candidates.contains(2), isTrue);
+    },
+    timeout: const Timeout(Duration(minutes: 1)),
+  );
+}

--- a/test/pdf_book/pdf_commentary_panel_test.dart
+++ b/test/pdf_book/pdf_commentary_panel_test.dart
@@ -104,6 +104,7 @@ PdfCommentaryPanel _panel(
   PdfBookTab tab, {
   bool linksLoading = false,
   int? initialTabIndex,
+  ValueChanged<int>? onTabChanged,
 }) => PdfCommentaryPanel(
   tab: tab,
   linksCount: tab.links.length,
@@ -111,6 +112,7 @@ PdfCommentaryPanel _panel(
   openBookCallback: (_) {},
   fontSize: 16.0,
   initialTabIndex: initialTabIndex,
+  onTabChanged: onTabChanged,
 );
 
 // ─── tests ───────────────────────────────────────────────────────────────────
@@ -120,6 +122,34 @@ void main() {
     WidgetsFlutterBinding.ensureInitialized();
     await Settings.init(cacheProvider: MemorySettingsCache());
     await text_utils.splitByEra(const []);
+  });
+
+  testWidgets('swipe אופקי מעביר מלשונית קישורים ללשונית מפרשים', (
+    tester,
+  ) async {
+    final tab = _tab(currentLine: 10);
+    addTearDown(tab.dispose);
+    final changedIndices = <int>[];
+
+    await tester.pumpWidget(
+      _wrap(
+        _panel(
+          tab,
+          initialTabIndex: 1,
+          onTabChanged: changedIndices.add,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('לא נמצאו קישורים לדף זה'), findsOneWidget);
+
+    await tester.drag(find.byType(TabBarView), const Offset(500, 0));
+    await tester.pumpAndSettle();
+
+    expect(changedIndices, [0]);
+    expect(find.text('לא נמצאו מפרשים לקטע הנבחר'), findsOneWidget);
+    expect(find.text('לא נמצאו קישורים לדף זה'), findsNothing);
   });
 
   // ── לשונית קישורים ──────────────────────────────────────────────────────

--- a/test/pdf_book/pdf_viewer_resize_test.dart
+++ b/test/pdf_book/pdf_viewer_resize_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:otzaria/pdf_book/view/pdf_book_screen.dart';
 import 'package:otzaria/widgets/layout/adaptive_side_pane.dart';
+import 'package:otzaria/widgets/navigation/nav_side_panel.dart';
 import 'package:otzaria/settings/services/per_book_settings_service.dart'
     show PdfLayoutMode;
 import 'package:pdfrx/pdfrx.dart';
@@ -244,7 +245,7 @@ void main() {
     );
   });
 
-  testWidgets('closing a wide side pane keeps the reading position', (
+  testWidgets('closing a wide right pane keeps the reading position', (
     tester,
   ) async {
     await tester.binding.setSurfaceSize(const Size(1400, 800));
@@ -255,16 +256,18 @@ void main() {
     final controller = PdfViewerController();
     var showRightPane = true;
     late ValueChanged<bool> setShowRightPane;
-
-    double? anchorDocTop;
-    Size? anchorViewSize;
+    var usesPushLayout = false;
+    final anchor = PdfPaneToggleAnchor();
 
     await tester.pumpWidget(
       StatefulBuilder(
         builder: (context, setState) {
           setShowRightPane = (value) {
-            anchorDocTop = controller.visibleRect.top;
-            anchorViewSize = controller.viewSize;
+            anchor.prepare(
+              changesReaderWidth: usesPushLayout,
+              docTop: controller.visibleRect.top,
+              viewSize: controller.viewSize,
+            );
             setState(() => showRightPane = value);
           };
           return MaterialApp(
@@ -281,6 +284,7 @@ void main() {
                   minPaneWidth: 180,
                   onClose: () => setShowRightPane(false),
                   minMainContentWidth: 500,
+                  onLayoutModeChanged: (value) => usesPushLayout = value,
                   mainContent: PdfViewer(
                     PdfDocumentRefDirect(document),
                     controller: controller,
@@ -297,21 +301,18 @@ void main() {
                           ),
                       // אותה חוליה שבמסך ה-PDF (issue #1023).
                       onViewSizeChanged: (viewSize, oldViewSize, c) {
-                        final top = anchorDocTop;
-                        final size = anchorViewSize;
-                        anchorDocTop = null;
-                        anchorViewSize = null;
-                        if (top == null ||
-                            oldViewSize != size ||
-                            oldViewSize!.width == c.viewSize.width) {
-                          return;
-                        }
+                        final anchorDocTop = anchor.consume(
+                          oldViewSize: oldViewSize,
+                          newViewSize: c.viewSize,
+                          isBookView: false,
+                        );
+                        if (anchorDocTop == null) return;
                         Future.microtask(() {
                           if (!c.isReady) return;
                           c.goTo(
                             c.calcMatrixFor(
                               pdfTopAnchoredCenter(
-                                anchorDocTop: top,
+                                anchorDocTop: anchorDocTop,
                                 currentCenter: c.centerPosition,
                                 viewSize: c.viewSize,
                                 zoom: c.currentZoom,
@@ -361,5 +362,106 @@ void main() {
 
     await tester.pumpWidget(const SizedBox.shrink());
     await tester.pump(const Duration(milliseconds: 200));
+  });
+
+  test('wide pane captures and restores the viewport anchor', () {
+    final anchor = PdfPaneToggleAnchor();
+    anchor.prepare(
+      changesReaderWidth: true,
+      docTop: 500,
+      viewSize: const Size(600, 800),
+    );
+
+    expect(
+      anchor.consume(
+        oldViewSize: const Size(600, 800),
+        newViewSize: const Size(900, 800),
+        isBookView: false,
+      ),
+      500,
+    );
+  });
+
+  test('overlay toggle clears an old anchor before scrolling and resize', () {
+    final anchor = PdfPaneToggleAnchor();
+    anchor.prepare(
+      changesReaderWidth: true,
+      docTop: 500,
+      viewSize: const Size(600, 800),
+    );
+
+    // פתיחת overlay אינה משנה את רוחב הקורא ולכן מבטלת את העוגן הממתין.
+    anchor.prepare(
+      changesReaderWidth: false,
+      docTop: 900,
+      viewSize: const Size(600, 800),
+    );
+
+    expect(
+      anchor.consume(
+        oldViewSize: const Size(600, 800),
+        newViewSize: const Size(900, 800),
+        isBookView: false,
+      ),
+      isNull,
+    );
+  });
+
+  testWidgets('narrow left pane reports overlay and clears an old anchor', (
+    tester,
+  ) async {
+    await tester.binding.setSurfaceSize(const Size(450, 800));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+
+    var showLeftPane = true;
+    var usesPushLayout = true;
+    late ValueChanged<bool> setShowLeftPane;
+    final anchor = PdfPaneToggleAnchor()
+      ..prepare(
+        changesReaderWidth: true,
+        docTop: 500,
+        viewSize: const Size(450, 800),
+      );
+
+    await tester.pumpWidget(
+      StatefulBuilder(
+        builder: (context, setState) {
+          setShowLeftPane = (value) {
+            anchor.prepare(changesReaderWidth: usesPushLayout);
+            setState(() => showLeftPane = value);
+          };
+          return MaterialApp(
+            home: Directionality(
+              textDirection: TextDirection.rtl,
+              child: NavSidePanel(
+                isOpen: showLeftPane,
+                alignment: AlignmentDirectional.centerEnd,
+                paneContent: const SizedBox.shrink(),
+                paneWidth: 300,
+                minMainContentWidth: 200,
+                onClose: () => setShowLeftPane(false),
+                autoHandleResponsiveVisibility: false,
+                onLayoutModeChanged: (value) => usesPushLayout = value,
+                mainContent: const SizedBox.expand(),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+    await tester.pump();
+
+    expect(usesPushLayout, isFalse);
+    setShowLeftPane(false);
+    await tester.pump();
+
+    expect(
+      anchor.consume(
+        oldViewSize: const Size(450, 800),
+        newViewSize: const Size(800, 800),
+        isBookView: false,
+      ),
+      isNull,
+    );
   });
 }

--- a/test/personal_notes/personal_notes_screen_test.dart
+++ b/test/personal_notes/personal_notes_screen_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -9,6 +11,7 @@ import 'package:otzaria/library/bloc/library_event.dart';
 import 'package:otzaria/library/bloc/library_state.dart';
 import 'package:otzaria/library/models/library.dart';
 import 'package:otzaria/personal_notes/bloc/personal_notes_bloc.dart';
+import 'package:otzaria/personal_notes/bloc/personal_notes_state.dart';
 import 'package:otzaria/personal_notes/models/personal_note.dart';
 import 'package:otzaria/personal_notes/repository/personal_notes_repository.dart';
 import 'package:otzaria/personal_notes/storage/personal_notes_database.dart';
@@ -39,6 +42,137 @@ class FakePersonalNotesRepository extends PersonalNotesRepository {
   }) async {
     return notesByBookId[bookId] ?? const [];
   }
+}
+
+class DelayedPersonalNotesRepository extends PersonalNotesRepository {
+  DelayedPersonalNotesRepository({required this.books});
+
+  final List<BookNotesInfo> books;
+  final Map<String, Completer<List<PersonalNote>>> requests = {};
+
+  @override
+  Future<List<BookNotesInfo>> listBooksWithNotes() async => books;
+
+  @override
+  Future<List<PersonalNote>> loadNotes(
+    String bookId, {
+    int? categoryId,
+  }) {
+    return requests.putIfAbsent(bookId, Completer.new).future;
+  }
+}
+
+class RefreshingDelayedPersonalNotesRepository extends PersonalNotesRepository {
+  RefreshingDelayedPersonalNotesRepository({required this.bookLists});
+
+  final List<List<BookNotesInfo>> bookLists;
+  final Map<String, List<Completer<List<PersonalNote>>>> requests = {};
+  int _listCall = 0;
+
+  @override
+  Future<List<BookNotesInfo>> listBooksWithNotes() async {
+    final index = _listCall < bookLists.length
+        ? _listCall
+        : bookLists.length - 1;
+    _listCall++;
+    return bookLists[index];
+  }
+
+  @override
+  Future<List<PersonalNote>> loadNotes(
+    String bookId, {
+    int? categoryId,
+  }) {
+    final request = Completer<List<PersonalNote>>();
+    requests.putIfAbsent(bookId, () => []).add(request);
+    return request.future;
+  }
+}
+
+class TrackingPersonalNotesBloc extends PersonalNotesBloc {
+  TrackingPersonalNotesBloc({required super.repository});
+
+  int activeStreamSubscriptions = 0;
+  int canceledStreamSubscriptions = 0;
+
+  @override
+  Stream<PersonalNotesState> get stream => _TrackingStream(
+    super.stream,
+    onListen: () => activeStreamSubscriptions++,
+    onCancel: () {
+      activeStreamSubscriptions--;
+      canceledStreamSubscriptions++;
+    },
+  );
+}
+
+class _TrackingStream<T> extends Stream<T> {
+  _TrackingStream(
+    this.source, {
+    required this.onListen,
+    required this.onCancel,
+  });
+
+  final Stream<T> source;
+  final void Function() onListen;
+  final void Function() onCancel;
+
+  @override
+  StreamSubscription<T> listen(
+    void Function(T event)? onData, {
+    Function? onError,
+    void Function()? onDone,
+    bool? cancelOnError,
+  }) {
+    onListen();
+    return _TrackingSubscription(
+      source.listen(
+        onData,
+        onError: onError,
+        onDone: onDone,
+        cancelOnError: cancelOnError,
+      ),
+      onCancel,
+    );
+  }
+}
+
+class _TrackingSubscription<T> implements StreamSubscription<T> {
+  _TrackingSubscription(this.source, this.onCancel);
+
+  final StreamSubscription<T> source;
+  final void Function() onCancel;
+  bool _canceled = false;
+
+  @override
+  Future<void> cancel() {
+    if (!_canceled) {
+      _canceled = true;
+      onCancel();
+    }
+    return source.cancel();
+  }
+
+  @override
+  void onData(void Function(T data)? handleData) => source.onData(handleData);
+
+  @override
+  void onError(Function? handleError) => source.onError(handleError);
+
+  @override
+  void onDone(void Function()? handleDone) => source.onDone(handleDone);
+
+  @override
+  void pause([Future<void>? resumeSignal]) => source.pause(resumeSignal);
+
+  @override
+  void resume() => source.resume();
+
+  @override
+  bool get isPaused => source.isPaused;
+
+  @override
+  Future<E> asFuture<E>([E? futureValue]) => source.asFuture(futureValue);
 }
 
 void main() {
@@ -112,6 +246,233 @@ void main() {
     expect(find.text('ספר בדיקה'), findsOneWidget);
     expect(find.text('כותרת הערה'), findsOneWidget);
     expect(find.text('תוכן הערה ראשונית'), findsOneWidget);
+  });
+
+  testWidgets('טוען שני ספרים בסדר ומציג כל הערה תחת ספרה', (tester) async {
+    PersonalNote note(String id, String bookId, String content) => PersonalNote(
+      id: id,
+      bookId: bookId,
+      lineNumber: 1,
+      displayTitle: 'כותרת $bookId',
+      lastKnownLineNumber: null,
+      status: PersonalNoteStatus.located,
+      content: content,
+      contentPlain: content,
+      contentFormat: PersonalNoteContentFormat.plain,
+      createdAt: DateTime(2025, 1, 1),
+      updatedAt: DateTime(2025, 1, 2),
+    );
+
+    final repository = DelayedPersonalNotesRepository(
+      books: [
+        BookNotesInfo(
+          bookId: 'ספר א',
+          noteCount: 1,
+          lastUpdated: DateTime(2025, 1, 2),
+        ),
+        BookNotesInfo(
+          bookId: 'ספר ב',
+          noteCount: 1,
+          lastUpdated: DateTime(2025, 1, 2),
+        ),
+      ],
+    );
+    final personalNotesBloc = PersonalNotesBloc(repository: repository);
+    final settingsBloc = SettingsBloc(repository: SettingsRepository());
+    final libraryBloc = MockLibraryBloc();
+    final libraryState = LibraryState(
+      library: Library(categories: []),
+      isLoading: false,
+      currentCategory: null,
+    );
+
+    whenListen(
+      libraryBloc,
+      const Stream<LibraryState>.empty(),
+      initialState: libraryState,
+    );
+    addTearDown(personalNotesBloc.close);
+    addTearDown(settingsBloc.close);
+
+    await tester.pumpWidget(
+      MultiBlocProvider(
+        providers: [
+          BlocProvider<SettingsBloc>.value(value: settingsBloc),
+          BlocProvider<LibraryBloc>.value(value: libraryBloc),
+          BlocProvider<PersonalNotesBloc>.value(value: personalNotesBloc),
+        ],
+        child: MaterialApp(
+          navigatorKey: navigatorKey,
+          home: Scaffold(
+            body: PersonalNotesManagerScreen(repository: repository),
+          ),
+        ),
+      ),
+    );
+
+    await tester.pump();
+    await tester.pump();
+    expect(repository.requests.keys, contains('ספר א'));
+    expect(repository.requests.keys, isNot(contains('ספר ב')));
+
+    repository.requests['ספר א']!.complete([
+      note('note-a', 'ספר א', 'תוכן א ייחודי'),
+    ]);
+    for (var i = 0; i < 10 && repository.requests['ספר ב'] == null; i++) {
+      await tester.pump(const Duration(milliseconds: 1));
+    }
+    expect(repository.requests.keys, contains('ספר ב'));
+
+    repository.requests['ספר ב']!.complete([
+      note('note-b', 'ספר ב', 'תוכן ב ייחודי'),
+    ]);
+    await tester.pumpAndSettle();
+
+    expect(find.text('תוכן א ייחודי'), findsOneWidget);
+    expect(find.text('תוכן ב ייחודי'), findsOneWidget);
+
+    final firstBook = tester.getTopLeft(find.text('ספר א')).dy;
+    final firstNote = tester.getTopLeft(find.text('תוכן א ייחודי')).dy;
+    final secondBook = tester.getTopLeft(find.text('ספר ב')).dy;
+    final secondNote = tester.getTopLeft(find.text('תוכן ב ייחודי')).dy;
+    expect(firstBook, lessThan(firstNote));
+    expect(firstNote, lessThan(secondBook));
+    expect(secondBook, lessThan(secondNote));
+  });
+
+  testWidgets('רענון מבטל מאזין תקוע ומתחיל רצף חדש', (
+    tester,
+  ) async {
+    BookNotesInfo book(String id) => BookNotesInfo(
+      bookId: id,
+      noteCount: 0,
+      lastUpdated: DateTime(2025, 1, 2),
+    );
+
+    final repository = RefreshingDelayedPersonalNotesRepository(
+      bookLists: [
+        [book('ספר א'), book('ספר ב')],
+        [book('ספר ג')],
+      ],
+    );
+    final personalNotesBloc = TrackingPersonalNotesBloc(
+      repository: repository,
+    );
+    final settingsBloc = SettingsBloc(repository: SettingsRepository());
+    final libraryBloc = MockLibraryBloc();
+    whenListen(
+      libraryBloc,
+      const Stream<LibraryState>.empty(),
+      initialState: LibraryState(
+        library: Library(categories: []),
+        isLoading: false,
+        currentCategory: null,
+      ),
+    );
+    addTearDown(personalNotesBloc.close);
+    addTearDown(settingsBloc.close);
+    addTearDown(() {
+      for (final requests in repository.requests.values) {
+        for (final request in requests) {
+          if (!request.isCompleted) request.complete(const []);
+        }
+      }
+    });
+
+    await tester.pumpWidget(
+      MultiBlocProvider(
+        providers: [
+          BlocProvider<SettingsBloc>.value(value: settingsBloc),
+          BlocProvider<LibraryBloc>.value(value: libraryBloc),
+          BlocProvider<PersonalNotesBloc>.value(value: personalNotesBloc),
+        ],
+        child: MaterialApp(
+          navigatorKey: navigatorKey,
+          home: Scaffold(
+            body: PersonalNotesManagerScreen(repository: repository),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+    expect(repository.requests['ספר א'], hasLength(1));
+    final cancellationsBeforeRefresh =
+        personalNotesBloc.canceledStreamSubscriptions;
+
+    await tester.tap(find.byTooltip('רענן'));
+    await tester.pump();
+    await tester.pump();
+    for (var i = 0; i < 10 && repository.requests['ספר ג'] == null; i++) {
+      await tester.pump(const Duration(milliseconds: 1));
+    }
+
+    expect(repository.requests['ספר ב'], isNull);
+    expect(repository.requests['ספר ג'], hasLength(1));
+    expect(
+      personalNotesBloc.canceledStreamSubscriptions,
+      greaterThan(cancellationsBeforeRefresh),
+    );
+    repository.requests['ספר א']!.single.complete(const []);
+    repository.requests['ספר ג']!.single.complete(const []);
+  });
+
+  testWidgets('dispose מבטל מאזין לטעינה שנתקעה', (tester) async {
+    final repository = DelayedPersonalNotesRepository(
+      books: [
+        BookNotesInfo(
+          bookId: 'ספר תקוע',
+          noteCount: 0,
+          lastUpdated: DateTime(2025, 1, 2),
+        ),
+      ],
+    );
+    final personalNotesBloc = TrackingPersonalNotesBloc(
+      repository: repository,
+    );
+    final settingsBloc = SettingsBloc(repository: SettingsRepository());
+    final libraryBloc = MockLibraryBloc();
+    whenListen(
+      libraryBloc,
+      const Stream<LibraryState>.empty(),
+      initialState: LibraryState(
+        library: Library(categories: []),
+        isLoading: false,
+        currentCategory: null,
+      ),
+    );
+    addTearDown(personalNotesBloc.close);
+    addTearDown(settingsBloc.close);
+    addTearDown(() {
+      final request = repository.requests['ספר תקוע'];
+      if (request != null && !request.isCompleted) request.complete(const []);
+    });
+
+    await tester.pumpWidget(
+      MultiBlocProvider(
+        providers: [
+          BlocProvider<SettingsBloc>.value(value: settingsBloc),
+          BlocProvider<LibraryBloc>.value(value: libraryBloc),
+          BlocProvider<PersonalNotesBloc>.value(value: personalNotesBloc),
+        ],
+        child: MaterialApp(
+          navigatorKey: navigatorKey,
+          home: Scaffold(
+            body: PersonalNotesManagerScreen(repository: repository),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+    expect(repository.requests['ספר תקוע'], isNotNull);
+    expect(personalNotesBloc.activeStreamSubscriptions, greaterThan(0));
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump();
+
+    expect(personalNotesBloc.activeStreamSubscriptions, 0);
+    repository.requests['ספר תקוע']!.complete(const []);
   });
 
   group('noteWithinDateRange - סינון לפי טווח תאריכים', () {

--- a/test/tabs/reading_screen_regression_test.dart
+++ b/test/tabs/reading_screen_regression_test.dart
@@ -619,6 +619,26 @@ void main() {
       }
     });
   });
+
+  testWidgets('כפתור איתור במסך ריק פותח את חלונית האיתור', (tester) async {
+    var findRequests = 0;
+    final tabsBloc = _FakeTabsBloc(TabsState.initial());
+    addTearDown(tabsBloc.close);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: BlocProvider<TabsBloc>.value(
+          value: tabsBloc,
+          child: ReadingScreen(onFindRefRequested: () => findRequests++),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('איתור ספר'));
+    await tester.pump();
+
+    expect(findRequests, 1);
+  });
 }
 
 class _FakeSettingsBloc extends Bloc<SettingsEvent, SettingsState>

--- a/test/text_book/utils/commentators_context_menu_test.dart
+++ b/test/text_book/utils/commentators_context_menu_test.dart
@@ -1,10 +1,30 @@
+import 'dart:io';
+
+import 'package:flutter_settings_screens/flutter_settings_screens.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/core/app_paths.dart';
+import 'package:otzaria/data/data_providers/file_system_data_provider.dart';
+import 'package:otzaria/data/data_providers/user_books_database_holder.dart';
+import 'package:otzaria/models/books.dart';
 import 'package:otzaria/models/links.dart';
+import 'package:otzaria/settings/settings_exports.dart';
 import 'package:otzaria/text_book/models/commentator_group.dart';
+import 'package:otzaria/text_book/text_book_repository.dart';
 import 'package:otzaria/text_book/utils/commentators_context_menu.dart';
+import 'package:otzaria/user_content_import/models/user_import_models.dart';
+import 'package:otzaria/user_content_import/repository/user_content_repository.dart';
 import 'package:otzaria/widgets/misc/app_menu_exports.dart';
+import 'package:path/path.dart' as path;
+
+import '../../test_helpers/memory_cache_provider.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    await Settings.init(cacheProvider: MemoryCacheProvider());
+  });
+
   const groups = [
     CommentatorGroup(title: 'ראשונים', commentators: ['רש"י', 'רמב"ן']),
     CommentatorGroup(title: 'אחרונים', commentators: ['מלבי"ם']),
@@ -226,6 +246,25 @@ void main() {
       expect(result, ['רמב"ן', 'מלבי"ם']);
     });
 
+    test('שאילת הטווח מציגה גם מפרש שאינו פעיל בתפריט', () {
+      final onParagraph = paragraphCommentators(
+        availableCommentators: const ['רש"י', 'רמב"ן'],
+        content: const ['פסקה'],
+        paragraphIndex: 0,
+        linksByLine: {
+          1: [commentaryLink(1, 'רש"י')],
+        },
+        queriedCommentators: const ['רש"י', 'רמב"ן'],
+      );
+      final entries = build(
+        active: const ['רש"י'],
+        availableCommentators: onParagraph,
+      );
+
+      expect(entryNamed(entries, 'רש"י').isSelected, isTrue);
+      expect(entryNamed(entries, 'רמב"ן').isSelected, isFalse);
+    });
+
     test('"הערות" נכלל רק כשיש הערות inline בפסקה', () {
       const available = ['רש"י', kNotesCommentatorTitle];
       const content = [
@@ -250,6 +289,57 @@ void main() {
         ),
         [kNotesCommentatorTitle],
       );
+    });
+  });
+
+  group('ParagraphCommentatorsCache — קישורי משתמש', () {
+    late Directory tempDir;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp(
+        'otzaria-paragraph-commentators-',
+      );
+      await UserBooksDatabaseHolder.instance.close();
+      AppPaths.debugOverrideDataRootPath(tempDir.path);
+      await Settings.setValue<String>(
+        SettingsRepository.keyDatabasesPath,
+        path.join(tempDir.path, 'databases'),
+      );
+    });
+
+    tearDown(() async {
+      await UserBooksDatabaseHolder.instance.close();
+      await Settings.setValue<String>(SettingsRepository.keyDatabasesPath, '');
+      AppPaths.debugOverrideDataRootPath(null);
+      if (await tempDir.exists()) await tempDir.delete(recursive: true);
+    });
+
+    test('שאילת הטווח כוללת מפרש משתמש שאינו פעיל', () async {
+      final userBooksRepository =
+          await UserBooksDatabaseHolder.instance.repository;
+      await UserContentRepository(userBooksRepository.database).upsertUserLink(
+        const UserLinkRecord(
+          sourceTitle: 'ספר בסיס',
+          sourceIsUserBook: false,
+          sourceLineIndex: 0,
+          targetTitle: 'מפרש אישי',
+          targetIsUserBook: true,
+          targetLineIndex: 0,
+          connectionType: 'COMMENTARY',
+        ),
+      );
+      final cache = ParagraphCommentatorsCache();
+      addTearDown(cache.dispose);
+      final repository = TextBookRepository(fileSystem: FileSystemData());
+      final book = TextBook(title: 'ספר בסיס');
+
+      await cache.prefetch(
+        repository: repository,
+        book: book,
+        paragraphIndex: 0,
+      );
+
+      expect(cache.value(book, 0), ['מפרש אישי']);
     });
   });
 

--- a/test/text_book/view/combined_view/combined_book_screen_test.dart
+++ b/test/text_book/view/combined_view/combined_book_screen_test.dart
@@ -16,6 +16,7 @@ import 'package:otzaria/text_book/bloc/text_book_bloc.dart';
 import 'package:otzaria/text_book/bloc/text_book_event.dart';
 import 'package:otzaria/text_book/bloc/text_book_state.dart';
 import 'package:otzaria/text_book/models/commentator_group.dart';
+import 'package:otzaria/text_book/text_book_repository.dart';
 import 'package:otzaria/text_book/utils/commentators_context_menu.dart';
 import 'package:otzaria/text_book/view/combined_view/combined_book_screen.dart';
 import 'package:otzaria/text_book/view/selection/enhanced_gesture_detector.dart';
@@ -1024,11 +1025,19 @@ TextBookLoaded _loadedState() {
 
 class _ClosedTextBookBloc extends Bloc<TextBookEvent, TextBookState>
     implements TextBookBloc {
-  _ClosedTextBookBloc(super.initialState) {
+  _ClosedTextBookBloc(super.initialState)
+    : repository = _TestTextBookRepository(
+        initialState is TextBookLoaded
+            ? initialState.availableCommentators
+            : const [],
+      ) {
     on<TextBookEvent>((event, emit) {});
   }
 
   bool addWasCalled = false;
+
+  @override
+  final TextBookRepository repository;
 
   @override
   bool get isClosed => true;
@@ -1045,11 +1054,45 @@ class _ClosedTextBookBloc extends Bloc<TextBookEvent, TextBookState>
 
 class _RecordingTextBookBloc extends Bloc<TextBookEvent, TextBookState>
     implements TextBookBloc {
-  _RecordingTextBookBloc(super.initialState) {
+  _RecordingTextBookBloc(super.initialState)
+    : repository = _TestTextBookRepository(
+        initialState is TextBookLoaded
+            ? initialState.availableCommentators
+            : const [],
+      ) {
     on<TextBookEvent>((event, emit) => received.add(event));
   }
 
   final List<TextBookEvent> received = [];
+
+  @override
+  final TextBookRepository repository;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _TestTextBookRepository implements TextBookRepository {
+  _TestTextBookRepository(this.commentators);
+
+  final List<String> commentators;
+
+  @override
+  Future<List<Link>> getBookLinksInRange(
+    TextBook book, {
+    required int startIndex,
+    required int endIndex,
+    Iterable<String>? targetBookTitles,
+  }) async => [
+    for (final title in commentators)
+      Link(
+        heRef: '',
+        index1: startIndex + 1,
+        path2: title,
+        index2: 1,
+        connectionType: 'commentary',
+      ),
+  ];
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);

--- a/test/text_book/view/page_shape/simple_text_viewer_context_menu_test.dart
+++ b/test/text_book/view/page_shape/simple_text_viewer_context_menu_test.dart
@@ -16,6 +16,7 @@ import 'package:otzaria/text_book/bloc/text_book_bloc.dart';
 import 'package:otzaria/text_book/bloc/text_book_event.dart';
 import 'package:otzaria/text_book/bloc/text_book_state.dart';
 import 'package:otzaria/text_book/models/commentator_group.dart';
+import 'package:otzaria/text_book/text_book_repository.dart';
 import 'package:otzaria/text_book/view/page_shape/simple_text_viewer.dart';
 import 'package:otzaria/text_book/view/tabbed_commentary_panel.dart';
 import 'package:otzaria/widgets/misc/app_context_menu.dart';
@@ -176,6 +177,44 @@ void main() {
       expect(find.text('פתח את חלונית המפרשים'), findsNothing);
       expect(find.text('בחר מפרשים מרובים'), findsNothing);
       expect(find.text('הצג את כל המפרשים על פסקה זו'), findsOneWidget);
+    });
+
+    testWidgets('לחיצה ארוכה מתחילה טעינת מפרשי הפסקה', (tester) async {
+      final bloc = _RecordingTextBookBloc(
+        _loadedState(
+          availableCommentators: const ['רש"י', 'רמב"ן'],
+          activeCommentators: const ['רש"י'],
+          commentatorGroups: const [
+            CommentatorGroup(
+              title: 'ראשונים',
+              commentators: ['רש"י', 'רמב"ן'],
+            ),
+          ],
+          linksByLine: _commentaryLinks(const ['רש"י']),
+        ),
+      );
+      addTearDown(bloc.close);
+      final repository = bloc.repository as _TestTextBookRepository;
+
+      await pumpViewer(
+        tester,
+        textBookBloc: bloc,
+        viewer: SimpleTextViewer(
+          content: const ['שורה א'],
+          fontSize: 18,
+          openBookCallback: (_) {},
+          isMainText: true,
+        ),
+      );
+
+      expect(repository.requestedRanges, isEmpty);
+      await tester.longPress(find.byType(AppContextMenuRegion).first);
+      await tester.pumpAndSettle();
+
+      expect(repository.requestedRanges, [(startIndex: 0, endIndex: 0)]);
+      await tester.tap(find.text('מפרשים על פסקה זו'));
+      await tester.pumpAndSettle();
+      expect(find.text('רמב"ן'), findsOneWidget);
     });
 
     testWidgets('בחירת מפרש מסנכרנת את הקטע לשורה שנלחצה בכפתור הימני', (
@@ -461,11 +500,49 @@ TextBookLoaded _loadedState({
 
 class _RecordingTextBookBloc extends Bloc<TextBookEvent, TextBookState>
     implements TextBookBloc {
-  _RecordingTextBookBloc(super.initialState) {
+  _RecordingTextBookBloc(super.initialState)
+    : repository = _TestTextBookRepository(
+        initialState is TextBookLoaded
+            ? initialState.availableCommentators
+            : const [],
+      ) {
     on<TextBookEvent>((event, emit) => received.add(event));
   }
 
   final List<TextBookEvent> received = [];
+
+  @override
+  final TextBookRepository repository;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _TestTextBookRepository implements TextBookRepository {
+  _TestTextBookRepository(this.commentators);
+
+  final List<String> commentators;
+  final List<({int startIndex, int endIndex})> requestedRanges = [];
+
+  @override
+  Future<List<Link>> getBookLinksInRange(
+    TextBook book, {
+    required int startIndex,
+    required int endIndex,
+    Iterable<String>? targetBookTitles,
+  }) async {
+    requestedRanges.add((startIndex: startIndex, endIndex: endIndex));
+    return [
+      for (final title in commentators)
+        Link(
+          heRef: '',
+          index1: startIndex + 1,
+          path2: title,
+          index2: 1,
+          connectionType: 'commentary',
+        ),
+    ];
+  }
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);


### PR DESCRIPTION
## מה השתנה

- #1222 — חימום מטמון ראשי־התיבות עובר כולו ל־FindRefDbIsolate, כולל שליפת SQLite, נרמול ובניית אינדקס.
- #1212 — פתיחה וסגירה של חלוניות PDF שומרות את קו הראש רק בפריסת push, בלי עוגן ישן במצב overlay.
- #1194 — תפריט מפרשי הפסקה נטען מטווח הקישורים המלא, כולל מפרשי משתמש שאינם פעילים, ועובד גם בלחיצה ארוכה.
- #1186 — כפתור איתור ספר במסך הקריאה הריק מחובר למסלול פתיחת האיתור האמיתי.
- #1155 — מחוות החלקה אופקית מחליפה לשוניות בחלונית מפרשי PDF.
- #1131 — טעינת הערות למספר ספרים סדרתית וברת־ביטול, בלי שיוך מצב ישן לספר חדש ובלי מאזינים תלויים ברענון או dispose.

## מניעת חפיפות

נבדקו PRs פתוחים, ממוזגים וסגורים, ענפים, worktrees ומשימות Codex מקבילות. ה־PR אינו נוגע ב־#1213/#1214/#1192 או ב־library_update, שמטופלים כעת ב־PRs ומשימות אחרות.

## בדיקות

- flutter analyze — נקי.
- 689 בדיקות רלוונטיות עברו: FindRef, הערות אישיות, PDF, מסך הקריאה ותפריטי מפרשים.
- dart format ו־git diff --check — נקיים.

Fixes #1222
Fixes #1212
Fixes #1194
Fixes #1186
Fixes #1155
Fixes #1131