### PR TITLE
תוספים: קיצורי מקלדת ו-APIים של גופנים (issue #1206)

### DIFF
--- a/lib/plugins/services/plugin_shortcut_registry.dart
+++ b/lib/plugins/services/plugin_shortcut_registry.dart
@@ -125,5 +125,5 @@ class PluginShortcutException implements Exception {
   const PluginShortcutException(this.code, this.message);
 
   @override
-  String toString() => 'error.$code: $message';
+  String toString() => '$code: $message';
 }

--- a/test/plugins/services/plugin_shortcut_registry_test.dart
+++ b/test/plugins/services/plugin_shortcut_registry_test.dart
@@ -165,5 +165,14 @@ void main() {
     test('find returns null for unknown plugin or id', () {
       expect(registry.find('nope', 's'), isNull);
     });
+
+    test('חריגת קיצור שומרת על קוד השגיאה של ה-RPC', () {
+      const error = PluginShortcutException(
+        'error.invalid_params',
+        'invalid shortcut',
+      );
+
+      expect(error.toString(), 'error.invalid_params: invalid shortcut');
+    });
   });
 }


### PR DESCRIPTION
## מה זה מתקן

issue #1206 דיווח על שני APIים של תוספים. אחרי אבחון מלא התברר שהתמונה מורכבת מהדיווח:

**הקיצור לפקד בסרגל — התלונה עצמה לא הייתה באג.** המדווח היה חסר את ההרשאה `navigation.write`, שדרושה ל-`plugin.openSelf`. הגשר החזיר לו `permission_denied: Missing permission: navigation.write`, אבל `Otzaria.call` נפתר עם `{success:false, error}` ואינו זורק — ותוסף שאינו בודק `.success` לא רואה כלום. הוא פתר את זה בעצמו והודיע שהקיצור עובד.

**הגופנים — כן באג, ונמדד.** `fonts.resolveFamilies` החזירה `{css:'', resolved:[]}` בלי שגיאה על כל קלט שאינו במבנה המדויק `{name, substitutes:[…]}`. הדרך הטבעית לבקש גופן, `{name:'David'}`, החזירה ריק. אובייקט ריק הוא truthy ב-JS, ולכן הבדיקה "אם לא חזר כלום קח את הגופן הידני" לא הופעלה, וייצוא ה-PDF יצא בגופן ברירת המחדל.

ומעבר לדיווח, נמצאו פערים אמיתיים במסלול הקיצורים.

## הקומיטים

| קומיט | מה |
|---|---|
| `84e9b3ee8` | `openPlugin` לקיצור מקלדת |
| `77ed2d687` | `fonts.resolveFamilies` מפסיקה להיכשל בשקט |
| `e0d955a3d` | `toolbarItemId` — קיצור מפעיל פקד בסרגל העיון |
| `904a85f7e` | ביעור הכשלים השקטים שנותרו במסלול הקיצורים |
| `c5638ff33` | `fonts.getBytes` — הבייטים של הגופן |
| `11fb6c6c8` | הצלבה בין `getBytes` ל-`queryLocalFonts` בתיעוד |

## תיקוני באגים

* **`PluginShortcutException.toString()` הכפילה את הקידומת `error.`**, ולכן כל שגיאת אימות של קיצור עברה את `_codedErrorPattern` ככשל והגיעה לתוסף כ-`error.internal` במקום קוד השגיאה האמיתי.
* **קיצורי תוספים היו מתים לחלוטין בטאב מפוצל.** המטפל נשען על `TabsState.currentTab`, שבטאב מפוצל הוא `CombinedTab` ולא חלונית הקריאה. עבר ל-`readingPane`, כפי שגשר התוספים פותר את החלונית.
* **המטמון ב-`_loadFontFaceCss` לא נגע במסלול `resolveFamilies`** (`asFamily` לעולם לא היה `null`), ולכן כל קריאה קראה מחדש את קובץ ה-TTF וקידדה אותו ל-base64 על ה-UI isolate.
* **`contributes.startup.shortcuts` לא נבדק בוולידטור כלל** — קיצור פסול נארז, הותקן, ונעלם בשקט בזמן ריצה.
* **שני כשלים שקטים בשיגור**: פריט תפריט הקשר שאינו רשום, ופקד סרגל שאינו רשום או שאינו זמין בהקשר הנוכחי — שניהם חזרו ב-`return` בלי הודעה.

## תוספות API (0.9.98)

* **`fonts.getBytes`** — הבייטים של משפחה אחת עם המשקל, הפורמט האמיתי (מחתימת ה-sfnt, לא `truetype` על הכול כמו ב-CSS) ואורך הקובץ. זה מה שהמדווח ביקש. גופן משתנה ואוסף `ttc` מסומנים, כי ספריות PDF נכשלות עליהם בלי טיפול מיוחד. מטמון LRU של שתי משפחות, כי `base64Encode` רץ על ה-UI isolate.
* **`openPlugin` בקיצור** — מנווט לכרטיסיית התוסף מצד המארח. **לא תיקון באג** אלא עקביות עם פקדי הסרגל ותפריט ההקשר, ורווח של least privilege: התוסף אינו צריך יותר `navigation.write` — הרשאה שמאפשרת לו לנווט את המשתמש לכל מקום — רק כדי להביא את עצמו לקדמת הבמה.
* **`toolbarItemId` בקיצור** — מפעיל פקד בסרגל דרך אותה פונקציה שהלחיצה קוראת לה, כלומר אותו נושא ואותו payload מלא כולל `param` והקשר הקריאה. פקד מסוג `menu` נדחה: לחיצה עליו פותחת תפריט ואינה משגרת דבר.

## שינויים שוברים

הקיצור חייב מעכשיו **בדיוק אחת** משלוש הפעולות. צירוף היה דו-משמעי גם קודם — בספר טקסט `contextMenuItemId` ניצח וב-PDF הקיצור פשוט מת. `app.registerShortcut` שוחרר לפני שבוע בלבד (`0.9.97+769`).

האימות בוולידטור מפיק **אזהרה ולא שגיאה**, בכוונה: `contributes.startup.shortcuts` נתמך מ-0.9.96, ולכן חסימה הייתה מפילה עדכון של תוסף שנארז כשהכלל עוד לא היה קיים. בזמן ריצה אותה אי-חוקיות מפילה רק את הקיצור.

## בדיקות

`flutter analyze` נקי. 4,624 בדיקות עוברות ב-`test/plugins/`, `test/shortcuts/`, `test/text_book/`, `test/pdf_book/`, `test/theme/` ו-`test/settings/l10n/`. כל ענף חדש נבדק במוטציה — שינוי שמשבר את הקוד מפיל בדיקה. שש מוטציות ששרדו בסבב הראשון נסגרו.

**שימו לב:** 13 בדיקות ב-`test/search/` נופלות בענף הזה — וגם ב-`origin/dev` עצמו, בלי השינוי. אימתתי בהרצה נפרדת של `origin/dev` ב-detached HEAD: אותן 13 בדיקות בדיוק, אותם שמות. רגרסיה שקדמה ל-PR הזה ואינה קשורה אליו.

## מה נשאר לא מאומת

התיעוד **אינו** טוען שקיצור `command` עובד כשהפוקוס בתוך ה-WebView של תוסף. אוצריא מוסרת שם את המקלדת ל-WebView במכוון, ואירועי מקש אינם מגיעים ל-`HardwareKeyboard` של Flutter — אבל לא הרצתי את האפליקציה כדי לאמת. התיעוד מנוסח כך שהוא נכון בשני המקרים ומפנה את המפתח ל-`keydown` ב-JS.
