### PR TITLE
עדכון ספרייה: ניסיון חוזר אוטומטי אחרי קטיעת רשת והודעת כשל קצרה בעברית (issue #1244)

### DIFF
--- a/lib/core/messages/library_messages.dart
+++ b/lib/core/messages/library_messages.dart
@@ -93,6 +93,9 @@ abstract class LibraryMessages {
   static const String updateDiskSpaceError =
       'אין מספיק מקום פנוי בדיסק לעדכון הספרייה';
 
+  static const String updateNetworkInterrupted =
+      'החיבור לרשת נקטע במהלך ההורדה';
+
   static const String deltaApplyFailed = 'החלת עדכון הדלתא נכשלה';
 
   static const String deltaResultMismatch =

--- a/lib/library_update/bloc/library_update_bloc.dart
+++ b/lib/library_update/bloc/library_update_bloc.dart
@@ -254,7 +254,7 @@ class LibraryUpdateBloc extends Bloc<LibraryUpdateEvent, LibraryUpdateState> {
       return LibraryUpdateState(
         status: LibraryUpdateStatus.error,
         message: message,
-        errorMessage: error.toString(),
+        errorMessage: _errorDetail(error),
         isCheckFailure: true,
       );
     }
@@ -357,7 +357,7 @@ class LibraryUpdateBloc extends Bloc<LibraryUpdateEvent, LibraryUpdateState> {
           hasUpdate: partial?.hasDatabaseChanges ?? false,
           changedBookIds: partial?.changedBookIds ?? const {},
           requiresFullIndexRefresh: requiresFullIndexRefresh,
-          errorMessage: applyError.toString(),
+          errorMessage: _errorDetail(applyError),
         ),
       );
     } finally {
@@ -437,7 +437,7 @@ class LibraryUpdateBloc extends Bloc<LibraryUpdateEvent, LibraryUpdateState> {
           requiresFullIndexRefresh:
               dbReplaced || state.requiresFullIndexRefresh,
           plan: dbReplaced ? plan : null,
-          errorMessage: e.toString(),
+          errorMessage: _errorDetail(e),
         ),
       );
     } finally {
@@ -659,7 +659,16 @@ class LibraryUpdateBloc extends Bloc<LibraryUpdateEvent, LibraryUpdateState> {
     return ltrIsolate('${(bytes / (1 << 10)).toStringAsFixed(0)}KB');
   }
 
-  // ה-UI מציג שגיאת עדכון גנרית בלבד; שומרים את הפרטים ל-errors.txt לאבחון.
+  /// פרט הכשל לחיווי. חריגות ה-updater נושאות הודעה עברית; קטיעת רשת גולמית
+  /// ממופה לטקסט קצר. הפרטים המלאים נרשמים ל-errors.txt ב-[_logUpdateError].
+  String _errorDetail(Object error) {
+    if (error is PatchDownloadException) return error.message;
+    if (PatchDownloader.isTransientNetworkError(error)) {
+      return LibraryMessages.updateNetworkInterrupted;
+    }
+    return error.toString();
+  }
+
   void _logUpdateError(String stage, Object e, StackTrace st) {
     debugPrint('[LibraryUpdate] ERROR in $stage: $e\n$st');
     try {

--- a/test/library_update/library_update_bloc_test.dart
+++ b/test/library_update/library_update_bloc_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -76,6 +77,24 @@ class _DiskFullOnFullDownloadService extends _FakeService {
     throw const LibraryUpdateDiskSpaceException(
       'אין מספיק מקום פנוי בכונן: נדרש ~7.5GB, פנוי 2.0GB',
     );
+  }
+}
+
+/// הורדה מלאה שנופלת על קטיעת רשת — [error] הוא החריגה שתיזרק.
+class _NetworkFailingFullDownloadService extends _FakeService {
+  _NetworkFailingFullDownloadService(super.plan, this.error);
+
+  final Object error;
+
+  @override
+  Future<void> applyFullDownload(
+    LibraryUpdatePlan plan, {
+    LibraryUpdateProgressCallback? onProgress,
+    FullDbReplacedCallback? onDbReplaced,
+    bool Function()? isCancelled,
+  }) async {
+    fullCalled = true;
+    throw error;
   }
 }
 
@@ -1022,6 +1041,67 @@ void main() {
               LibraryMessages.updateDiskSpaceError,
             )
             .having((s) => s.errorMessage, 'errorMessage', contains('7.5GB')),
+      ],
+    );
+
+    blocTest<LibraryUpdateBloc, LibraryUpdateState>(
+      'קטיעת רשת בהורדה מלאה → פרט הכשל הוא ההודעה העברית של ה-updater',
+      build: () => _bloc(
+        _NetworkFailingFullDownloadService(
+          fullPlan,
+          const PatchNetworkException(
+            SocketException('Connection closed before full header'),
+          ),
+        ),
+      ),
+      seed: () => LibraryUpdateState(
+        status: LibraryUpdateStatus.needsFullConfirmation,
+        plan: fullPlan,
+      ),
+      act: (b) => b.add(const ConfirmFullDownload()),
+      expect: () => [
+        isA<LibraryUpdateState>().having(
+          (s) => s.status,
+          'status',
+          LibraryUpdateStatus.downloading,
+        ),
+        isA<LibraryUpdateState>()
+            .having((s) => s.status, 'status', LibraryUpdateStatus.error)
+            .having((s) => s.message, 'message', 'שגיאה בהורדה המלאה')
+            .having(
+              (s) => s.errorMessage,
+              'errorMessage',
+              'החיבור לרשת נקטע במהלך ההורדה',
+            ),
+      ],
+    );
+
+    blocTest<LibraryUpdateBloc, LibraryUpdateState>(
+      'SocketException גולמית בהורדה מלאה → טקסט עברי קצר, לא toString',
+      build: () => _bloc(
+        _NetworkFailingFullDownloadService(
+          fullPlan,
+          const SocketException('Connection reset by peer'),
+        ),
+      ),
+      seed: () => LibraryUpdateState(
+        status: LibraryUpdateStatus.needsFullConfirmation,
+        plan: fullPlan,
+      ),
+      act: (b) => b.add(const ConfirmFullDownload()),
+      expect: () => [
+        isA<LibraryUpdateState>().having(
+          (s) => s.status,
+          'status',
+          LibraryUpdateStatus.downloading,
+        ),
+        isA<LibraryUpdateState>()
+            .having((s) => s.status, 'status', LibraryUpdateStatus.error)
+            .having(
+              (s) => s.errorMessage,
+              'errorMessage',
+              LibraryMessages.updateNetworkInterrupted,
+            ),
       ],
     );
 


### PR DESCRIPTION
סוגר את #1244.

## ⚠️ תלות — למזג קודם את Otzaria/otzaria_library_updater#12
ה-PR הזה משתמש ב-`PatchNetworkException` וב-`PatchDownloader.isTransientNetworkError`, שנוספו בחבילת העדכונים 0.6.0. ה-`pubspec.yaml` ב-dev מצביע ל-`ref: main` של החבילה, ולכן **אחרי** מיזוג PR #12 שם ה-PR הזה נבנה כמו שהוא. **לפני** המיזוג `flutter pub get` יצליח אבל ה-analyze ייכשל על סמלים חסרים. סדר המיזוג: קודם updater#12, אחר כך זה.

## הבעיה
מעבר רשת באמצע הורדת עדכון ספרייה הפיל את ההורדה מיד, והחיווי הציג את `toString` הגולמי של `SocketException` באנגלית. המוריד תמך ב-resume, אבל רק דרך לחיצה ידנית על "ניסיון חוזר".

## השינוי
- **בחבילה (PR Otzaria/otzaria_library_updater#12):** קטיעת רשת חולפת מנוסה שוב אוטומטית (2s, 5s, 15s) עם המשך מהבייט האחרון דרך `Range`/`If-Range`. כשגם זה נכשל נזרקת `PatchNetworkException` עם הודעה עברית קצרה.
- **כאן:** ה-BLoC מציג כפרט הכשל את ההודעה של חריגות ה-updater (`PatchDownloadException.message`) במקום `toString`, וממפה קטיעת רשת גולמית ל-`LibraryMessages.updateNetworkInterrupted`. במקום `SocketException: Connection closed before full header was received...` המשתמש יראה "שגיאה בהורדה המלאה / החיבור לרשת נקטע במהלך ההורדה".

## בדיקות
שתי בדיקות BLoC חדשות (חריגת ה-updater + `SocketException` גולמית). `flutter analyze` נקי; `flutter test test/library_update/` — 150 עוברות.