### PR TITLE
תיקון בנייה: החזרת ההצמדה לממשקי חבילת העדכון שבשימוש

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -84,7 +84,7 @@ dependencies:
   seforim_library_updater:
     git:
       url: https://github.com/Otzaria/otzaria_library_updater
-      ref: main
+      ref: 30bf3ff8d6d278f8ba782161e231d219217a3f0a
   window_manager: ^0.5.2
   screen_retriever: ^0.2.2
   flutter_spinbox: ^0.13.1


### PR DESCRIPTION
## הבעיה ושחזור

בנייה נקייה של `dev` ב־5115298109bb712c26da9b00cfbfd18a61eeaf28 פותרת את `seforim_library_updater` מ־`main` לגרסה 0.4.0 (1c1e5bd24e00dd1a77e05741a1eb363543967f9e). הרצת `flutter pub get && flutter analyze` עם Flutter 3.47.2 מסתיימת ב־12 שגיאות: `heavyDeltaReason`, `isHeavyDelta`, `localDbSizeBytes`, `onApplyProgress` ו־`onVerifyProgress` אינם זמינים בחוזה שנבחר. גם בדיקות עדכון הספרייה אינן מתקמפלות.

## סיבת השורש והתיקון

51152981 החליף את ההצמדה ל־30bf3ff8d6d278f8ba782161e231d219217a3f0a בענף `main`, אף שהאפליקציה כבר צורכת את ממשקי 0.5.0 שב־Otzaria/otzaria_library_updater#11, שעדיין פתוח. השינוי מחזיר את ההצמדה הקודמת בלבד. הוא אינו מעתיק קוד של מחברי החבילה ואינו משנה את מימוש העדכון.

## בטיחות, סיכונים וחזרה לאחור

ה־SHA הקבוע מחזיר את התאימות לממשק שכבר נדרש בקוד ובבדיקות, ומונע שינוי תלות בין שתי בניות נקיות. אין שינוי בסכמה, בקובצי המשתמש, במנגנון השחזור או בפרוטוקול הרשת. התלות ב־PR של החבילה מפורשת; לאחר מיזוגו אפשר להצמיד ל־commit הממוזג. חזרה ל־`main` הנוכחי משחזרת את כשל הבנייה ולכן אינה rollback תקין עד שהממשקים יהיו זמינים בו.

## בדיקות

- לפני התיקון: `flutter analyze` — 12 שגיאות; בדיקות BLoC/repository של העדכון נכשלות בקומפילציה.
- אחרי התיקון: `flutter analyze` — ללא שגיאות או אזהרות.
- `flutter test test/library_update test/utils/file/zstd_stream_extractor_test.dart test/navigation/library_update_refresh_listener_predicate_test.dart --reporter expanded` — 152 עברו, 2 דולגו.
- בדיקות חבילת העדכון ב־30bf3ff8 — 200 עברו, 10 דולגו; ב־main — 188 עברו, 10 דולגו. דילוגים תלויים בקובצי fixture שאינם מצויים בסביבת הבדיקה.
- ניסוי נוסף עם `StreamingPatchDownloader` הקיים: הורדה משרת loopback, חילוץ zstd של 1 GiB שנדחס ללא גודל frame ידוע, אימות SHA256, שימוש חוזר וניקוי ארכיון — עבר עם `--old_gen_heap_size=128`. שיא RSS כולל VM/קומפיילר: 319,440 KiB (כ־312 MiB), לעומת פלט של 1,073,741,824 בתים. הנתונים סינתטיים; אין DB פרטי.
- סביבת הבדיקה: Ubuntu 26.04, GNOME 50.1/Wayland, Flutter 3.47.2, Dart 3.13.2 לאפליקציה; בדיקות החבילה הורצו ב־Dart 3.12.2.

## הקשר לאימות ההתקנה האמיתית

הבדיקה נערכה בעקבות עדכון מוצלח של Otzaria 0.9.97+99701. דוח הקבלה הקודם מתעד DB בגודל 7,789,461,504 בתים, `quick_check=ok`, אפס הפרות foreign key, מצב `DELETE`, ללא קובצי צד/שחזור/patch, ואינדקס בגודל 5,427,199,429 בתים שהגיע למנוחה. במהלך עבודה זו אומתו שוב hash ה־DB, גודלו, היעדר שאריות וגודל האינדקס. ההתקנה הפעילה לא שונתה.

תיקוני ההורדה והחילוץ הזורמים, SHA256, המשך הורדה, בדיקת מקום, החלה טרנזקציונית, החלפה אטומית ורענון runtime כבר קיימים ב־Otzaria. אין כאן הגשה חוזרת שלהם, ואין טענה שהבינארי הפעיל נבנה מה־SHA המוצמד ב־PR זה.
