### PR TITLE
Linux: הכללת תיקוני WebView מהמאגר של Otzaria בבנייה

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -135,6 +135,12 @@ dependency_overrides:
       url: https://github.com/Otzaria/flutter_inappwebview
       ref: master
       path: flutter_inappwebview_macos
+  # תיקוני העברת התמונה בין WPE ל-Flutter נמצאים ב-fork, ולא ב-pub.dev.
+  flutter_inappwebview_linux:
+    git:
+      url: https://github.com/Otzaria/flutter_inappwebview
+      ref: master
+      path: flutter_inappwebview_linux
   # הגרסה שב-pub.dev קוראת ל-setStatusBarColor שהוצא משימוש ב-Android 15.
   flutter_inappwebview_android:
     git:

--- a/test/plugins/linux_webview_dependency_test.dart
+++ b/test/plugins/linux_webview_dependency_test.dart
@@ -1,0 +1,25 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('רכיב WebView של Linux נפתר מאותו checkout כמו ממשק הפלטפורמה', () {
+    final configFile = File('.dart_tool/package_config.json').absolute;
+    final config = jsonDecode(configFile.readAsStringSync()) as Map;
+    final packages = (config['packages'] as List).cast<Map>();
+
+    Uri checkoutOf(String name) {
+      final package = packages.singleWhere((entry) => entry['name'] == name);
+      return configFile.uri
+          .resolve(package['rootUri'] as String)
+          .resolve('../');
+    }
+
+    expect(
+      checkoutOf('flutter_inappwebview_linux'),
+      checkoutOf('flutter_inappwebview_platform_interface'),
+      reason: 'גרסת pub.dev חסרה את תיקוני WPE שבמאגר Otzaria',
+    );
+  });
+}


### PR DESCRIPTION
**התוצאה למשתמש שאומתה ב־Linux:** תוספי Otzaria המבוססים על WebView מוצגים בפועל במקום משטח שחור/ריק או תוכן בלתי נראה, האינטראקציה עם התוספים פועלת כרגיל, וקלט מגע בתוך ה־WebView המוטמע פועל כראוי. השילוב התפעולי של תוסף Linux מתוקן, גשר מגע ו־zero-copy fallback פעיל נבדק בהצלחה באפליקציה המותקנת האמיתית, Otzaria **0.9.97+99701**, על Ubuntu 26.04 / GNOME 50.1 / Wayland. הוחלף רק התוסף; האפליקציה, מנוע Flutter ו־WPE WebKit של 0.9.97 נשמרו.

זהו אימות הקבלה הקודם של הבינארי המקומי עם `FLUTTER_INAPPWEBVIEW_LINUX_DISABLE_ZERO_COPY=1`, כולל רינדור תוספים ואינטראקציית מגע. מקורו המדויק של אותו בינארי לא נשמר; Otzaria/flutter_inappwebview#21 מממש מחדש את אפשרות התאימות מעל המקור הנוכחי. אין כאן טענה ששני ענפי ה־PR החדשים נבנו יחד והותקנו מחדש לבדיקת GUI. בדיקות המקור של ה־PRs מפורטות בנפרד להלן.

ב־Linux, `flutter pub get` ב־`dev` בוחר את `flutter_inappwebview_linux` מ־pub.dev, בעוד יתר רכיבי WebView נפתרים מה־fork של Otzaria. כך שדרוג יכול להחמיץ את תיקוני WPE/EGL שכבר קיימים ב־fork ולהחזיר משטח תוסף שחור/ריק. התיקון מוסיף רק override תואם ל־Linux ובדיקת מקור תלות: שני קבצים, ‎+31 שורות. אין שינוי במעדכן הספרייה או ב־launcher.

**#1260 נסגר ללא מיזוג בהחלטת המתחזק; מצב תלות ה־updater מתקבל כמצב upstream מכוון. #1261 עצמאי מ־#1260.** בוצע fetch ו־rebase מול `dev` ‏`5115298109bb712c26da9b00cfbfd18a61eeaf28`; הענף כבר התבסס עליו. אין צורך במיזוג #1260 או בשינוי pin לצורך PR זה.

הפתרון מתחלק בין רכיבים משלימים: #1261 מחבר את בניית Linux למקור של Otzaria, וכך מקבל את תיקון EGL הקיים (`5c7a9b147aaa23090c9c85499f94a033e1d3b924`, ייבוא DMA-BUF בתצוגת EGL של Flutter) ואת גשר המגע הקיים (`sendTouchEvent` ומיפוי אירועי WPE). אלה חלקים מהפתרון העובד שיש לשמר ללא רגרסיה; הם אינם תיקונים חדשים המוגשים שוב כאן.

Otzaria/flutter_inappwebview#21 משלים את הפתרון עבור מערכות Linux מושפעות שבהן zero-copy עדיין אינו מציג את התוכן: בהן נדרש מסלול התאימות שהופעל באימות Otzaria 0.9.97. #1261 יכול להיכנס בנפרד כדי להביא את התיקונים שכבר upstream, אך אינו מוסיף בעצמו את ה־fallback של Otzaria/flutter_inappwebview#21. לקבלת מסלול התאימות המלא דרך המקור נדרשים גם Otzaria/flutter_inappwebview#21 בתוך גרסת התוסף הנפתרת וגם הגדרת `FLUTTER_INAPPWEBVIEW_LINUX_DISABLE_ZERO_COPY=1` לפני יצירת WebView והפעלה מחדש. אף אחד משני ה־PRs אינו מפעיל את המשתנה אוטומטית.

ההשוואה בוצעה ב־2026-09-09 בשני worktrees, ב־Ubuntu 26.04 / GNOME 50.1 / Wayland, עם Flutter 3.47.2 ו־Dart 3.13.2. **לא נעשה שימוש ב־pubspec_overrides.yaml או ב־pin חלופי ל־updater.** בשני העצים הוא נפתר מ־`main` ל־`1c1e5bd24e00dd1a77e05741a1eb363543967f9e` ‏(0.4.0). השוואת package_config אישרה שרק מקור חבילת Linux שונה: pub.dev ‏0.1.0-beta.1 לעומת fork ‏`d14e25826e8709900ec86a04224aa5df11ebc438`.

| בדיקה | dev | PR #1261 |
|---|---|---|
| `flutter analyze --no-pub` | 12 שגיאות updater | אותן 12 בדיוק; **0 חדשות** |
| בדיקות plugin משותפות | 198 עברו, 3 דולגו, 2 כשלי טעינה | תוצאות זהות בכל בדיקה |
| בדיקת מקור התלות החדשה | נכשלת כמצופה | עוברת |
| `flutter build linux --debug --no-pub` | 9 שגיאות קומפילציית updater | אותן 9 בדיוק; **0 חדשות** |
| בניית Linux עם entrypoint מינימלי של `InAppWebView` באותן תלויות | לא נבדקה | עברה קומפילציה וקישור |
| בדיקות WPE bundle paths ו־probe link של ה־fork | — | עברו |

פקודת הבדיקות המשותפות: `flutter test --no-pub test/plugins/view test/plugins/services/plugin_webview_focus_test.dart test/plugins/services/plugin_webview_permission_gate_test.dart --reporter json`. שני כשלי הטעינה הזהים הם `plugin_tab_webview_settings_test.dart` ו־`plugin_creation_failure_routing_test.dart`, עקב ממשקי updater חסרים. תוצאות הבדיקות והודעות analyze/build הושוו לאחר נרמול נתיבי worktree וסדר; אין הבדל. השגיאות מתייחסות ל־`isHeavyDelta`, `heavyDeltaReason`, `deltaUncompressedBytes`, `localDbSizeBytes`, `onVerifyProgress` ו־`onApplyProgress`. כשל analyze ב־CI הקיים הוא מאותה קבוצת שגיאות baseline; הוא אינו מסומן כאן כהצלחה.

לבנייה המקומית הוגדרו נתיבי include/link של SDK ה־WPE, לרבות `LIBRARY_PATH`, `PKG_CONFIG_PATH` ו־`-rpath-link`, וכן `CMAKE_POLICY_VERSION_MINIMUM=3.5`. ניסיון baseline ראשוני נכשל בזיהוי ספריות SDK; לאחר הוספת נתיב הספריות, אותה סביבה שימשה לשתי הבניות בטבלה. קיימות אזהרות bundling של SDK מקומי ו־Sentry. בניית ה־entrypoint המינימלי אינה הצלחה של האפליקציה המלאה או אישור לחבילת הפצה עצמאית. בדיקת EGL/pixel fallback של Otzaria/flutter_inappwebview#21 עברה בנפרד ב־Mesa surfaceless.

בנוסף לקבלה התפעולית המתוארת בפתיחה, אומתה זמינות סמלי `fl_*` הדרושים לתוסף המקומי במנוע 0.9.97; זו בדיקת תאימות סמלים ולא הוכחת ABI מלאה. ההתקנה הפעילה ונתוני המשתמש לא שונו במהלך עבודת ה־PR.

סיכון ותאימות: השינוי מביא את קוד Linux של ה־fork ואת דרישות WPEPlatform שלו; נדרש עדיין אימות GUI על שילובי driver/WPE נוספים. `master` הוא ref נע, כמו יתר רכיבי WebView בפרויקט. rollback הוא revert של commit זה, פתרון תלויות ובנייה מחדש; הוא עלול להחזיר את התקלה. אין שינוי נתונים או סכמה.
