### PR TITLE
תיקון: library.resolveRef של תוסף לא החזיר ספרים אישיים לעולם

### DIFF
--- a/lib/plugins/view/plugin_tab_page.dart
+++ b/lib/plugins/view/plugin_tab_page.dart
@@ -143,6 +143,52 @@ bool shouldHandleCreationFailure({
   return failureUrl == expectedUrl;
 }
 
+/// בונה את הפונקציה שמחברת `library.resolveRef` של תוסף למנוע `find_ref`
+/// המלא — אותו מנוע שמאחורי דיאלוג "איתור מקורות" באוצריא עצמו.
+///
+/// `includePersonalBooks: true` תמיד: תוסף עם הרשאת `library.books.read`
+/// כבר מקבל ספרים אישיים ללא סינון דרך `library.findBooks`
+/// (`Library.getAllBooks()` כולל אותם) — הטוגל "כלול ספרים אישיים" בדיאלוג
+/// הוא שיקול רלוונטיות/ביצועים לחיפוש אינטראקטיבי, לא בקרת הרשאות.
+@visibleForTesting
+Future<
+  List<
+    ({
+      String title,
+      int index,
+      bool isPdf,
+      int bookId,
+      String reference,
+      String bookPath,
+      bool isSourceLine,
+      bool isUserBook,
+    })
+  >
+>
+Function(String)
+buildResolveReference(FindRefRepository findRefRepository) {
+  return (reference) async {
+    final results = await findRefRepository.findRefs(
+      reference,
+      includePersonalBooks: true,
+    );
+    return results
+        .map(
+          (r) => (
+            title: r.title,
+            index: r.segment.toInt(),
+            isPdf: r.isPdf,
+            bookId: r.bookId,
+            reference: r.reference,
+            bookPath: r.bookPath,
+            isSourceLine: r.isSourceLine,
+            isUserBook: r.isUserBook,
+          ),
+        )
+        .toList();
+  };
+}
+
 InAppWebViewSettings buildPluginTabWebViewSettings({
   required bool isDevelopment,
 }) {
@@ -284,23 +330,7 @@ class _PluginTabPageState extends State<PluginTabPage> {
         historyBloc: historyBloc,
         navigationBloc: navigationBloc,
       ),
-      resolveReference: (reference) async {
-        final results = await findRefRepository.findRefs(reference);
-        return results
-            .map(
-              (r) => (
-                title: r.title,
-                index: r.segment.toInt(),
-                isPdf: r.isPdf,
-                bookId: r.bookId,
-                reference: r.reference,
-                bookPath: r.bookPath,
-                isSourceLine: r.isSourceLine,
-                isUserBook: r.isUserBook,
-              ),
-            )
-            .toList();
-      },
+      resolveReference: buildResolveReference(findRefRepository),
       resolveRefToLine: (book, ref) =>
           PluginRefLineResolver().resolve(book: book, ref: ref),
       themePayloadBuilder: () {

--- a/test/plugins/view/plugin_tab_page_resolve_reference_test.dart
+++ b/test/plugins/view/plugin_tab_page_resolve_reference_test.dart
@@ -1,0 +1,56 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:otzaria/data/repository/data_repository.dart';
+import 'package:otzaria/find_ref/repository/find_ref_repository.dart';
+import 'package:otzaria/plugins/view/plugin_tab_page.dart';
+
+class MockDataRepository extends Mock implements DataRepository {}
+
+void main() {
+  group('buildResolveReference (library.resolveRef wiring)', () {
+    // ספר אישי יחיד, נמצא רק כשהחיפוש כולל ספרים אישיים — בדיוק כמו
+    // הבדיקות ב-find_ref_repository_test.dart עבור includePersonalBooks.
+    final personalBook = (
+      id: 99,
+      title: 'ספר פרטי',
+      filePath: null,
+      fileType: 'txt',
+      orderIndex: 1.0,
+      folderTitles: const <String>[],
+    );
+
+    FindRefRepository buildRepo() => FindRefRepository(
+      dataRepository: MockDataRepository(),
+      isReferenceBooksCacheLoaded: () => true,
+      warmUpReferenceBooksCache: () async {},
+      searchReferenceBooks: (_, {limit = 50}) => const [],
+      getTocEntriesForReference: (_, _, {queryTokens}) async => const [],
+      getAllUserBooks: () async => [personalBook],
+      getUserBookTocEntries: (_, _, {queryTokens}) async => const [],
+    );
+
+    test(
+      'ספר אישי מוחזר דרך library.resolveRef — לא רק דרך FindRefDialog '
+      '(issue: הטוגל "כלול ספרים אישיים" לא הועבר לתוסף)',
+      () async {
+        final resolveReference = buildResolveReference(buildRepo());
+        final results = await resolveReference('ספר');
+        expect(
+          results.any((r) => r.isUserBook && r.title == 'ספר פרטי'),
+          isTrue,
+        );
+      },
+    );
+
+    test(
+      'בלי הזרקת הפרמטר, findRefs היה מחזיר ברירת מחדל false ומחסיר את הספר',
+      () async {
+        // בדיקת-נגד: מוודאת שהתשתית עצמה (findRefs) עדיין דורשת opt-in מפורש,
+        // כדי שהבדיקה הקודמת אכן תלויה בכך ש-buildResolveReference מבקש
+        // includePersonalBooks: true ולא בהתנהגות ברירת המחדל של הרפוזיטורי.
+        final results = await buildRepo().findRefs('ספר');
+        expect(results.any((r) => r.isUserBook), isFalse);
+      },
+    );
+  });
+}


### PR DESCRIPTION
## הבאג

דיאלוג "איתור מקורות" של אוצריא עצמו (`lib/find_ref/view/find_ref_dialog.dart`) מציג טוגל "כלול ספרים אישיים" (`_keyIncludePersonalBooks`, נשמר תחת `key-find-ref-include-personal-books`) שמעביר `includePersonalBooks` ל-`FindRefRepository.findRefs(String ref, {bool includePersonalBooks = false})` (`lib/find_ref/repository/find_ref_repository.dart`).

אותו מנוע `find_ref` חשוף לתוספים דרך `library.resolveRef` (`lib/plugins/bridge/plugin_bridge_adapter.dart`, ה-`case 'resolveRef':`), שקורא ל-`_dependencies.resolveReference`. החיווט של אותה תלות ב-`lib/plugins/view/plugin_tab_page.dart` היה:

```dart
resolveReference: (reference) async {
  final results = await findRefRepository.findRefs(reference);
  ...
```

בלי `includePersonalBooks: true` — כך שכל קריאה קיבלה את ברירת המחדל `false`, בלי שום תלות בהגדרה של המשתמש, בהרשאות התוסף, או בכל דבר אחר. **ספר אישי לעולם לא הוחזר מ-`library.resolveRef` לאף תוסף**, גם כשהספר נסרק כהלכה ויש לו ערך TOC (מכותרות Word) תקין שאוצריא עצמו מציג. אושר בבדיקה חיה: ספר אישי אמיתי, עם ערך TOC אמיתי, לא הופיע בחיפוש `@`-mention של תוסף (שמפעיל `library.resolveRef`) בגלל הפרמטר החסר הזה בלבד.

בדקתי גם קריאה שנייה ל-`_dependencies.resolveReference` באותו קובץ (בתוך `reader.openBookAtRef`, סביב שורה 2290) — היא מפנה לאותו אובייקט תלות בדיוק, אז תיקון החיווט ב-`plugin_tab_page.dart` מתקן את שתי נקודות הקריאה כאחת. אין צורך בתיקון נפרד.

## ההחלטה: תמיד `true`, לא לפי ההגדרה השמורה

בדקתי אם התוסף צריך לקבל תמיד `includePersonalBooks: true`, או לכבד את אותה הגדרה שמורה שהדיאלוג קורא ממנה. הכרעתי לטובת **תמיד `true`**, מהסיבה הבאה:

תוסף עם הרשאת `library.books.read` ("חיפוש וצפייה ברשימת כל הספרים בספרייה") כבר מקבל ספרים אישיים **בלי שום סינון** דרך `library.findBooks` — `Library.getAllBooks()` שהוא בנוי עליה כוללת ספרים אישיים תמיד, בלי טוגל ובלי הגבלה. כלומר מנגנון ההרשאות של אוצריא כבר מניח שתוסף עם ההרשאה הזו רואה את כל הספרייה, כולל האישית. הטוגל בדיאלוג "איתור מקורות" הוא שיקול **רלוונטיות/ביצועים לחיפוש אינטראקטיבי תוך-הקלדה** (ספרים אישיים לא-מקוטלגים מוסיפים רעש/עומס לכל הקלדה), לא בקרת הרשאות או פרטיות. חסימת ספר אישי רק במסלול `resolveRef` הייתה יוצרת אי-עקביות שרירותית מול `findBooks` (שתוסף יכול לעקוף ממילא בקלות — לחפש שם ספר דרכו ואז לפתוח בו קטע), בלי שום תועלת אמיתית — ורק פחות שימושי לתוסף לגיטימי (כלי ציטוט/הערות אישיות) שיש לו סיבה טבעית לחפש בספר אישי.

## התיקון

`lib/plugins/view/plugin_tab_page.dart`: הוצאתי את ה-closure שבונה את `resolveReference` לפונקציה עצמאית `buildResolveReference(FindRefRepository)` (מסומנת `@visibleForTesting`, באותו דפוס בדיוק כמו `buildPluginTabWebViewSettings` הקיים כבר בקובץ) שמעבירה `includePersonalBooks: true` ל-`findRefs`. שינוי מינימלי — פרמטר אחד, בלי שינוי בהתנהגות הקיימת מעבר לכך.

## בדיקות

נוספה `test/plugins/view/plugin_tab_page_resolve_reference_test.dart`: בונה `FindRefRepository` עם ספר אישי יחיד (באותו דפוס הזרקה של `test/find_ref/find_ref_repository_test.dart`), ומוודאת ש-`buildResolveReference(...)('ספר')` **כן** מחזיר אותו — ושבלי ההזרקה (`findRefs` בברירת המחדל) הוא **לא** מוחזר, כדי לוודא שהבדיקה תלויה בפועל בפרמטר שהוספתי ולא בהתנהגות שהייתה קיימת ממילא.

**חסימה בסביבת הבדיקה שלי (לא קשורה לשינוי):** `test/plugins/view/plugin_tab_page_resolve_reference_test.dart` (וגם `test/plugins/view/plugin_tab_webview_settings_test.dart` **הקיים, בלי שום שינוי בו**) לא עלו לקומפילציה, כי `plugin_tab_page.dart` מייבא (דרך `main_window_screen.dart`) את `lib/library_update/`, ותלות ה-git `seforim_library_updater` (`ref: main` מול `Otzaria/otzaria_library_updater`) לא מסונכרנת כרגע מול מה ש-`lib/library_update/bloc/library_update_bloc.dart` ו-`lib/library_update/repository/library_update_repository.dart` מצפים לו (`isHeavyDelta`, `heavyDeltaReason`, `deltaUncompressedBytes`, `localDbSizeBytes`, `onVerifyProgress`, `onApplyProgress` — כולם חסרים ב-HEAD הנוכחי של `main` שם). `flutter analyze` על שני הקבצים האלה בנפרד (`lib/library_update/bloc/library_update_bloc.dart`, `lib/library_update/repository/library_update_repository.dart`) מציג את אותן 9 שגיאות — כלומר זו בעיה קיימת-מראש ולא-קשורה בענף `dev`, לא משהו שנגרם מהתיקון הזה.

מה שכן רץ ועבר בהצלחה:
- `flutter analyze lib/plugins/view/plugin_tab_page.dart test/plugins/view/plugin_tab_page_resolve_reference_test.dart` → **0 שגיאות/אזהרות**
- `flutter test test/find_ref/` → **267/269** (שני הכשלים היחידים הם `find_ref_book_by_id_test.dart` ו-`find_ref_dialog_view_test.dart`, מאותה בעיית תלות חיצונית — שניהם מייבאים בעקיפין את אותו `main_window_screen.dart`)
- `flutter test test/plugins/bridge/plugin_bridge_adapter_test.dart` (כולל קבוצת `PluginBridgeAdapter.library.resolveRef`) → **170/170 עבר**, ללא שינוי בהתנהגות הקיימת
- `dart format` על שני הקבצים ששונו

## קבצים ששונו

- `lib/plugins/view/plugin_tab_page.dart`
- `test/plugins/view/plugin_tab_page_resolve_reference_test.dart` (חדש)