### PR TITLE
הערות אישיות: בתיבת הריחוף רק תפריט ההעתקה של אוצריא, בלי תפריט העורך (issue #1271)

### DIFF
--- a/lib/personal_notes/widgets/personal_note_content_view.dart
+++ b/lib/personal_notes/widgets/personal_note_content_view.dart
@@ -5,6 +5,7 @@ import 'package:flutter_quill/flutter_quill.dart' as quill;
 import 'package:otzaria/personal_notes/models/personal_note.dart';
 import 'package:otzaria/personal_notes/utils/note_link_detection.dart';
 import 'package:otzaria/widgets/dialogs/app_dialogs.dart';
+import 'package:otzaria/widgets/misc/app_selection_area.dart';
 
 /// מציג את ההערות של שורה בחלון קריאה ממורכז.
 Future<bool?> showPersonalNotesDialog({
@@ -132,11 +133,18 @@ class _PersonalNoteContentViewState extends State<PersonalNoteContentView> {
   Widget build(BuildContext context) {
     final controller = _controller;
     if (controller != null) {
+      // בתוך AppSelectionArea תפריט ההעתקה מגיע ממנו — תפריט Flutter של
+      // העורך היה נפתח לצדו (issue #1271).
+      final hostHasOwnMenu =
+          context.findAncestorWidgetOfExactType<AppSelectionArea>() != null;
       final editor = quill.QuillEditor(
         controller: controller,
         focusNode: _focusNode!,
         scrollController: _scrollController!,
         config: quill.QuillEditorConfig(
+          contextMenuBuilder: hostHasOwnMenu
+              ? (context, _) => const SizedBox.shrink()
+              : null,
           autoFocus: false,
           expands: false,
           padding: EdgeInsets.zero,

--- a/test/personal_notes/personal_note_content_view_context_menu_test.dart
+++ b/test/personal_notes/personal_note_content_view_context_menu_test.dart
@@ -1,0 +1,77 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:otzaria/personal_notes/models/personal_note.dart';
+import 'package:otzaria/personal_notes/widgets/personal_note_content_view.dart';
+import 'package:otzaria/widgets/misc/app_selection_area.dart';
+
+/// issue #1271 — בתיבת הריחוף של הערה (עטופה ב-AppSelectionArea) לחיצה ימנית
+/// פתחה גם את תפריט ההעתקה של אוצריא וגם את תפריט Flutter של עורך ההערה.
+void main() {
+  PersonalNote note() => PersonalNote(
+    id: 'pn_1',
+    bookId: 'Test',
+    lineNumber: 1,
+    displayTitle: 'כותרת',
+    lastKnownLineNumber: null,
+    status: PersonalNoteStatus.located,
+    content: jsonEncode([
+      {'insert': 'תוכן ההערה לבדיקה'},
+      {'insert': '\n'},
+    ]),
+    contentPlain: 'תוכן ההערה לבדיקה',
+    contentFormat: PersonalNoteContentFormat.quillDelta,
+    createdAt: DateTime(2025, 1, 1),
+    updatedAt: DateTime(2025, 1, 2),
+  );
+
+  Future<void> rightClickText(WidgetTester tester) async {
+    await tester.tapAt(
+      tester.getCenter(find.text('תוכן ההערה לבדיקה', findRichText: true)),
+      buttons: kSecondaryMouseButton,
+    );
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('בתוך AppSelectionArea נפתח רק תפריט ההעתקה של אוצריא', (
+    tester,
+  ) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.windows;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: AppSelectionArea(child: PersonalNoteContentView(note: note())),
+        ),
+      ),
+    );
+
+    await rightClickText(tester);
+    debugDefaultTargetPlatformOverride = null;
+
+    expect(find.text('העתק'), findsOneWidget, reason: 'תפריט אוצריא');
+    expect(
+      find.byType(AdaptiveTextSelectionToolbar),
+      findsNothing,
+      reason: 'תפריט Flutter של העורך אסור שיופיע לצד תפריט אוצריא (issue #1271)',
+    );
+  });
+
+  testWidgets('בלי AppSelectionArea תפריט ההעתקה של העורך נשאר זמין', (
+    tester,
+  ) async {
+    debugDefaultTargetPlatformOverride = TargetPlatform.windows;
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(body: PersonalNoteContentView(note: note())),
+      ),
+    );
+
+    await rightClickText(tester);
+    debugDefaultTargetPlatformOverride = null;
+
+    expect(find.byType(AdaptiveTextSelectionToolbar), findsOneWidget);
+  });
+}

--- a/test_results/2026-09-09-note-preview-double-context-menu.md
+++ b/test_results/2026-09-09-note-preview-double-context-menu.md
@@ -1,0 +1,45 @@
+# issue #1271 — תפריט העתקה כפול בתיבת הריחוף של הערה אישית
+
+תאריך: 2026-09-09 | ענף: `fix/note-preview-double-context-menu-1271` | קומיט אימות: `e70a7ac7f`
+
+## הבאג שאומת
+
+תיבת הריחוף של הערה על הטקסט (`LinkPreviewOverlay.showContent` ←
+`PersonalNotesListView`) עטופה ב-`AppSelectionArea`, שמספק את תפריט "העתק" של
+אוצריא. בתוכה `PersonalNoteContentView` מרנדר את ההערה ב-`QuillEditor` לקריאה
+בלי `contextMenuBuilder`, ולכן לחיצה ימנית פתחה גם את
+`AdaptiveTextSelectionToolbar` של Flutter — שני תפריטים זה לצד זה, כפי שדווח.
+בשאר המסכים העורכים/אזורי הבחירה כבר משתיקים את תפריט Flutter
+(`contextMenuBuilder: (_, _) => const SizedBox.shrink()`).
+
+## הפתרון
+
+`PersonalNoteContentView` משתיק את תפריט העורך רק כשיש `AppSelectionArea` מעליו
+(שם ההעתקה מסופקת ממנו). בלי מארח כזה — דיאלוג "הערה מקושרת" בחלונית ההערות —
+תפריט העורך הוא הדרך היחידה להעתיק, ולכן נשמר.
+
+## בדיקות
+
+`test/personal_notes/personal_note_content_view_context_menu_test.dart` (חדש):
+לחיצה ימנית בתוך `AppSelectionArea` ← "העתק" יחיד ובלי `AdaptiveTextSelectionToolbar`
+(נכשל על הבסיס: נמצא תפריט Flutter); בלי `AppSelectionArea` ← תפריט העורך נשאר.
+
+בדיקות ממוקדות `test/personal_notes/` + `link_preview_overlay_test`: עברו, כשל
+יחיד `personal_notes_file_backed_book_test` (הבסיס הסביבתי המוכר).
+
+## הערה על הבסיס
+
+הענף מבוסס על `d4503f480` (Merge #1220) ולא על ראש `dev`: ראש `dev` (511529810)
+אינו מתקמפל — `lib/library_update/` משתמש ב-API של `seforim_library_updater`
+שעדיין לא פורסם ל-`main` של החבילה (יושב ב-PR #11 שלה), וגם CI של `dev` אדום.
+
+## סוויטה מלאה
+
+`flutter test`: **12,337 עברו, 9 דולגו**. בריצה הראשונה נכשלו 91 בדיקות
+בקבצי מנוע החיפוש ותוספים בגלל DLL של המנוע שנותר מבניית Release ולא תאם
+את קוד ה-FRB (`frb_generated.rs: entered unreachable code`); אחרי בנייה
+מחדש של הפלאגין כולם עברו בהרצה חוזרת (316 בדיקות), למעט
+`shamor_zachor_data_provider_test` — שנכשל באותה צורה על הבסיס בכל שלושת
+ה-worktrees, בלי קשר לשינוי. שאר הכשלים: הבסיס הסביבתי המוכר
+(release_packaging, ‏3×file_sync_compaction, ‏personal_notes_file_backed_book,
+‏search_scope_menu flake, ‏change_location_dialog). אפס רגרסיות.


### PR DESCRIPTION
Fixes #1271

## הבאג שאומת
תיבת הריחוף של הערה על הטקסט עטופה ב-`AppSelectionArea` (שמספק "העתק"), ובתוכה `PersonalNoteContentView` מרנדר את ההערה ב-`QuillEditor` לקריאה בלי `contextMenuBuilder` — לחיצה ימנית פתחה גם את `AdaptiveTextSelectionToolbar` של Flutter. שאר אזורי הבחירה בתוכנה כבר משתיקים את תפריט Flutter באותה דרך.

## הפתרון
`PersonalNoteContentView` משתיק את תפריט העורך כשיש `AppSelectionArea` מעליו; בלי מארח כזה (דיאלוג "הערה מקושרת") תפריט העורך הוא הדרך היחידה להעתיק, ולכן נשמר.

## בדיקות
- חדש: `test/personal_notes/personal_note_content_view_context_menu_test.dart` — בתוך `AppSelectionArea`: "העתק" יחיד ובלי תפריט Flutter (נכשל על הבסיס, קומיט `e70a7ac7f`); בלי `AppSelectionArea`: תפריט העורך נשאר.
- `flutter analyze` נקי. `test/personal_notes/` עברו. סוויטה מלאה: 12,337 עברו; הכשלים = הבסיס הסביבתי המוכר + `shamor_zachor_data_provider_test` שנכשל זהה על הבסיס (פירוט ב-`test_results/2026-09-09-note-preview-double-context-menu.md`). אפס רגרסיות.

## הערה
הענף מבוסס על `d4503f480` (Merge #1220): ראש `dev` (511529810) אינו מתקמפל כרגע — `lib/library_update/` משתמש ב-API של `seforim_library_updater` שעדיין לא ב-`main` של החבילה (PR #11 שם), וגם CI של `dev` אדום.

## אימות ויזואלי (לפני/אחרי)

בניית debug של הבסיס (`d4503f480`) מול הענף. בראשית א, א עם שתי הערות אישיות על "ברא" ו"הארץ": ריחוף על "ברא" → תיבת הריחוף → לחיצה ימנית על טקסט ההערה.

| לפני — שני תפריטים: "העתק" של אוצריא וגם "העתקה / בחירת הכול" של Flutter | אחרי — "העתק" של אוצריא בלבד |
|---|---|
| ![before](https://raw.githubusercontent.com/dudua99/otzaria/pr-screenshots/1271/before.png) | ![after](https://raw.githubusercontent.com/dudua99/otzaria/pr-screenshots/1271/after.png) |

![compare](https://raw.githubusercontent.com/dudua99/otzaria/pr-screenshots/1271/compare.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

