### PR TITLE
fix(linux): resolve WebView from the Otzaria fork

### DIFF
--- a/.github/workflows/build-and-announce.yml
+++ b/.github/workflows/build-and-announce.yml
@@ -1093,15 +1093,17 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          found=0
-          while IFS= read -r FILE; do
-            found=1
-            sed -i 's|^  WebKitColor color;$|  WebKitColor color{};|' "$FILE"
-            sed -i 's|^  gboolean hasColor = webkit_web_view_get_theme_color(webview_, \&color);$|#if WEBKIT_CHECK_VERSION(2, 50, 0)\n  gboolean hasColor = webkit_web_view_get_theme_color(webview_, \&color);\n#else\n  gboolean hasColor = FALSE;\n#endif|' "$FILE"
-            grep -q "WEBKIT_CHECK_VERSION(2, 50, 0)" "$FILE" || { echo "::error::theme_color patch did not apply to $FILE"; exit 1; }
-            echo "patched: $FILE"
-          done < <(find "${PUB_CACHE:-$HOME/.pub-cache}/hosted/pub.dev" -path '*/flutter_inappwebview_linux-*/linux/in_app_webview/in_app_webview.cc')
-          [ "$found" = "1" ] || { echo "::error::in_app_webview.cc not found in pub cache"; exit 1; }
+          root_uri=$(jq -er '.packages[] | select(.name == "flutter_inappwebview_linux") | .rootUri' .dart_tool/package_config.json)
+          case "$root_uri" in
+            file://*) package_root="${root_uri#file://}" ;;
+            *) package_root=$(realpath -m ".dart_tool/$root_uri") ;;
+          esac
+          FILE="$package_root/linux/in_app_webview/in_app_webview.cc"
+          [ -f "$FILE" ] || { echo "::error::resolved flutter_inappwebview_linux source not found: $FILE"; exit 1; }
+          sed -i 's|^  WebKitColor color;$|  WebKitColor color{};|' "$FILE"
+          sed -i 's|^  gboolean hasColor = webkit_web_view_get_theme_color(webview_, \&color);$|#if WEBKIT_CHECK_VERSION(2, 50, 0)\n  gboolean hasColor = webkit_web_view_get_theme_color(webview_, \&color);\n#else\n  gboolean hasColor = FALSE;\n#endif|' "$FILE"
+          grep -q "WEBKIT_CHECK_VERSION(2, 50, 0)" "$FILE" || { echo "::error::theme_color patch did not apply to $FILE"; exit 1; }
+          echo "patched resolved flutter_inappwebview_linux source: $FILE"
 
       - name: Build Flutter Linux app (with retry)
         shell: bash

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -135,6 +135,12 @@ dependency_overrides:
       url: https://github.com/Otzaria/flutter_inappwebview
       ref: master
       path: flutter_inappwebview_macos
+  # תיקוני העברת התמונה בין WPE ל-Flutter נמצאים ב-fork, ולא ב-pub.dev.
+  flutter_inappwebview_linux:
+    git:
+      url: https://github.com/Otzaria/flutter_inappwebview
+      ref: master
+      path: flutter_inappwebview_linux
   # הגרסה שב-pub.dev קוראת ל-setStatusBarColor שהוצא משימוש ב-Android 15.
   flutter_inappwebview_android:
     git:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -135,7 +135,6 @@ dependency_overrides:
       url: https://github.com/Otzaria/flutter_inappwebview
       ref: master
       path: flutter_inappwebview_macos
-  # תיקוני העברת התמונה בין WPE ל-Flutter נמצאים ב-fork, ולא ב-pub.dev.
   flutter_inappwebview_linux:
     git:
       url: https://github.com/Otzaria/flutter_inappwebview

--- a/test/plugins/linux_webview_dependency_test.dart
+++ b/test/plugins/linux_webview_dependency_test.dart
@@ -1,0 +1,25 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('רכיב WebView של Linux נפתר מאותו checkout כמו ממשק הפלטפורמה', () {
+    final configFile = File('.dart_tool/package_config.json').absolute;
+    final config = jsonDecode(configFile.readAsStringSync()) as Map;
+    final packages = (config['packages'] as List).cast<Map>();
+
+    Uri checkoutOf(String name) {
+      final package = packages.singleWhere((entry) => entry['name'] == name);
+      return configFile.uri
+          .resolve(package['rootUri'] as String)
+          .resolve('../');
+    }
+
+    expect(
+      checkoutOf('flutter_inappwebview_linux'),
+      checkoutOf('flutter_inappwebview_platform_interface'),
+      reason: 'גרסת pub.dev חסרה את תיקוני WPE שבמאגר Otzaria',
+    );
+  });
+}


### PR DESCRIPTION
Resolves the Linux implementation from the Otzaria fork, like the other federated WebView packages.

The Linux release workflow now obtains the resolved package path from `.dart_tool/package_config.json`, so its WPE 2.48 compatibility patch works for Git dependencies as well as pub.dev dependencies.

This branch is rebased on current `dev`.