### PR TITLE
מצב ההגדרות ההתחלתי נבנה מהערכים השמורים ולא מברירות המחדל (issue #1280)

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1346,9 +1346,10 @@ class _AppBootstrapState extends State<AppBootstrap> {
           BlocProvider<SettingsBloc>(
             create: (_) => StartupTimeline.instance.phaseSync(
               'settingsBloc',
-              () =>
-                  SettingsBloc(repository: settingsRepository)
-                    ..add(LoadSettings()),
+              () => SettingsBloc(
+                repository: settingsRepository,
+                initialSettings: settingsRepository.readSettings(),
+              )..add(LoadSettings()),
             ),
           ),
           BlocProvider<LibraryBloc>(

--- a/lib/settings/engine/settings_bloc.dart
+++ b/lib/settings/engine/settings_bloc.dart
@@ -14,12 +14,24 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
   final SettingsRepository _repository;
   final Future<void> Function(String fontFamily) _ensureFontLoaded;
 
+  /// [initialSettings] — תמונת ההגדרות השמורות ([SettingsRepository.readSettings]);
+  /// בלעדיה המסך הראשון נבנה מברירות מחדל וקופץ אחרי LoadSettings (issue #1280).
   SettingsBloc({
-    required this._repository,
+    required SettingsRepository repository,
+    Map<String, dynamic>? initialSettings,
     @visibleForTesting
     Future<void> Function(String fontFamily)? ensureFontLoaded,
-  }) : _ensureFontLoaded = ensureFontLoaded ?? AppFonts.ensureFontLoaded,
-       super(SettingsState.initial()) {
+  }) : _repository = repository,
+       _ensureFontLoaded = ensureFontLoaded ?? AppFonts.ensureFontLoaded,
+       super(
+         initialSettings == null
+             ? SettingsState.initial()
+             : _stateFromSettings(
+                 initialSettings,
+                 protectedModePasswordSet: repository
+                     .hasProtectedModePassword(),
+               ),
+       ) {
     on<LoadSettings>(_onLoadSettings);
     on<UpdateDarkMode>(_onUpdateDarkMode);
     on<UpdateFollowSystemTheme>(_onUpdateFollowSystemTheme);
@@ -92,74 +104,9 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
     final settings = await _repository.loadSettings();
 
     emit(
-      SettingsState(
-        isDarkMode: settings['isDarkMode'],
-        followSystemTheme: settings['followSystemTheme'] ?? false,
-        seedColor: settings['seedColor'],
-        darkSeedColor: settings['darkSeedColor'],
-        textMaxWidth: settings['textMaxWidth'],
-        fontSize: settings['fontSize'],
-        fontFamily: settings['fontFamily'],
-        commentatorsFontFamily: settings['commentatorsFontFamily'],
-        fontBold: settings['fontBold'] ?? false,
-        commentatorsFontBold: settings['commentatorsFontBold'] ?? false,
-        commentatorsFontSize: settings['commentatorsFontSize'],
-        lineHeight: settings['lineHeight'],
-        showOtzarHachochma: settings['showOtzarHachochma'],
-        showHebrewBooks: settings['showHebrewBooks'],
-        showExternalBooks: settings['showExternalBooks'],
-        autoUpdateIndex: settings['autoUpdateIndex'],
-        textDisplayPolicy: settings['textDisplayPolicy'] as TextDisplayPolicy?,
-        defaultContinuousReadingMode:
-            settings['defaultContinuousReadingMode'] ?? false,
-        defaultSidebarOpen: settings['defaultSidebarOpen'],
-        defaultCommentaryOpen: settings['defaultCommentaryOpen'],
-        pinSidebar: settings['pinSidebar'],
-        sidebarWidth: settings['sidebarWidth'],
-        facetFilteringWidth: settings['facetFilteringWidth'],
-        externalResultsFirst: settings['externalResultsFirst'] ?? false,
-        commentaryPaneWidth: settings['commentaryPaneWidth'],
-        copyWithHeaders: settings['copyWithHeaders'],
-        copyHeaderFormat: settings['copyHeaderFormat'],
-        isFullscreen: settings['isFullscreen'],
-        libraryViewMode: settings['libraryViewMode'],
-        libraryShowPreview: settings['libraryShowPreview'],
-        searchShowPreview: settings['searchShowPreview'] ?? true,
-        shortcuts: Map<String, String>.unmodifiable(
-          Map<String, String>.from(settings['shortcuts'] as Map),
-        ),
-        enablePerBookSettings: settings['enablePerBookSettings'],
-        pdfBookViewByDefault: settings['pdfBookViewByDefault'] ?? false,
-        talmudBavliOpenFormat: settings['talmudBavliOpenFormat'] ?? 'text',
-        isOfflineMode: settings['isOfflineMode'] ?? false,
-        softwareAndBookUpdatesEnabled:
-            settings['softwareAndBookUpdatesEnabled'] ?? true,
-        enableHtmlLinks: settings['enableHtmlLinks'] ?? true,
-        personalNotesCollapsedByDefault:
-            settings['personalNotesCollapsedByDefault'] ?? true,
-        compactMenuMode: settings['compactMenuMode'] ?? false,
-        readingTabsPlacement:
-            settings['readingTabsPlacement'] ??
-            SettingsRepository.readingTabsPlacementTop,
-        readingTabsColumnWidth:
-            settings['readingTabsColumnWidth'] ??
-            SettingsRepository.defaultReadingTabsColumnWidth,
-        readingTabsColumnCollapsed:
-            settings['readingTabsColumnCollapsed'] ?? false,
-        mergeUserBooksIntoLibrary:
-            settings['mergeUserBooksIntoLibrary'] ?? false,
-        protectedModeEnabled: settings['protectedModeEnabled'] ?? false,
+      _stateFromSettings(
+        settings,
         protectedModePasswordSet: _repository.hasProtectedModePassword(),
-        hiddenBuiltInToolIds:
-            (settings['hiddenBuiltInToolIds'] as Set<String>?) ?? <String>{},
-        builtInToolsPinnedToNavRail:
-            (settings['builtInToolsPinnedToNavRail'] as Set<String>?) ??
-            <String>{},
-        builtInToolsOrder:
-            (settings['builtInToolsOrder'] as List<String>?) ?? <String>[],
-        settingsLanguageCode:
-            (settings['settingsLanguageCode'] as String?) ??
-            kDefaultSettingsLanguageCode,
       ),
     );
 
@@ -171,6 +118,80 @@ class SettingsBloc extends Bloc<SettingsEvent, SettingsState> {
     // גופן מערכת מתאפס ל-fallback אחרי הפעלה מחדש (issue #849).
     await _ensureFontLoaded(
       settings['pageShapeBottomFont'] as String? ?? AppFonts.defaultFont,
+    );
+  }
+
+  static SettingsState _stateFromSettings(
+    Map<String, dynamic> settings, {
+    required bool protectedModePasswordSet,
+  }) {
+    return SettingsState(
+      isDarkMode: settings['isDarkMode'],
+      followSystemTheme: settings['followSystemTheme'] ?? false,
+      seedColor: settings['seedColor'],
+      darkSeedColor: settings['darkSeedColor'],
+      textMaxWidth: settings['textMaxWidth'],
+      fontSize: settings['fontSize'],
+      fontFamily: settings['fontFamily'],
+      commentatorsFontFamily: settings['commentatorsFontFamily'],
+      fontBold: settings['fontBold'] ?? false,
+      commentatorsFontBold: settings['commentatorsFontBold'] ?? false,
+      commentatorsFontSize: settings['commentatorsFontSize'],
+      lineHeight: settings['lineHeight'],
+      showOtzarHachochma: settings['showOtzarHachochma'],
+      showHebrewBooks: settings['showHebrewBooks'],
+      showExternalBooks: settings['showExternalBooks'],
+      autoUpdateIndex: settings['autoUpdateIndex'],
+      textDisplayPolicy: settings['textDisplayPolicy'] as TextDisplayPolicy?,
+      defaultContinuousReadingMode:
+          settings['defaultContinuousReadingMode'] ?? false,
+      defaultSidebarOpen: settings['defaultSidebarOpen'],
+      defaultCommentaryOpen: settings['defaultCommentaryOpen'],
+      pinSidebar: settings['pinSidebar'],
+      sidebarWidth: settings['sidebarWidth'],
+      facetFilteringWidth: settings['facetFilteringWidth'],
+      externalResultsFirst: settings['externalResultsFirst'] ?? false,
+      commentaryPaneWidth: settings['commentaryPaneWidth'],
+      copyWithHeaders: settings['copyWithHeaders'],
+      copyHeaderFormat: settings['copyHeaderFormat'],
+      isFullscreen: settings['isFullscreen'],
+      libraryViewMode: settings['libraryViewMode'],
+      libraryShowPreview: settings['libraryShowPreview'],
+      searchShowPreview: settings['searchShowPreview'] ?? true,
+      shortcuts: Map<String, String>.unmodifiable(
+        Map<String, String>.from(settings['shortcuts'] as Map),
+      ),
+      enablePerBookSettings: settings['enablePerBookSettings'],
+      pdfBookViewByDefault: settings['pdfBookViewByDefault'] ?? false,
+      talmudBavliOpenFormat: settings['talmudBavliOpenFormat'] ?? 'text',
+      isOfflineMode: settings['isOfflineMode'] ?? false,
+      softwareAndBookUpdatesEnabled:
+          settings['softwareAndBookUpdatesEnabled'] ?? true,
+      enableHtmlLinks: settings['enableHtmlLinks'] ?? true,
+      personalNotesCollapsedByDefault:
+          settings['personalNotesCollapsedByDefault'] ?? true,
+      compactMenuMode: settings['compactMenuMode'] ?? false,
+      readingTabsPlacement:
+          settings['readingTabsPlacement'] ??
+          SettingsRepository.readingTabsPlacementTop,
+      readingTabsColumnWidth:
+          settings['readingTabsColumnWidth'] ??
+          SettingsRepository.defaultReadingTabsColumnWidth,
+      readingTabsColumnCollapsed:
+          settings['readingTabsColumnCollapsed'] ?? false,
+      mergeUserBooksIntoLibrary: settings['mergeUserBooksIntoLibrary'] ?? false,
+      protectedModeEnabled: settings['protectedModeEnabled'] ?? false,
+      protectedModePasswordSet: protectedModePasswordSet,
+      hiddenBuiltInToolIds:
+          (settings['hiddenBuiltInToolIds'] as Set<String>?) ?? <String>{},
+      builtInToolsPinnedToNavRail:
+          (settings['builtInToolsPinnedToNavRail'] as Set<String>?) ??
+          <String>{},
+      builtInToolsOrder:
+          (settings['builtInToolsOrder'] as List<String>?) ?? <String>[],
+      settingsLanguageCode:
+          (settings['settingsLanguageCode'] as String?) ??
+          kDefaultSettingsLanguageCode,
     );
   }
 

--- a/lib/settings/engine/settings_repository.dart
+++ b/lib/settings/engine/settings_repository.dart
@@ -288,7 +288,12 @@ class SettingsRepository {
     // Initialize default settings to disk if needed
     await _initializeDefaultsIfNeeded();
     await removeUnrecognizedShortcuts();
+    return readSettings();
+  }
 
+  /// קריאה סינכרונית של ההגדרות השמורות — למצב ההתחלתי של ה-bloc, כדי
+  /// שהמסך הראשון לא ייבנה מברירות מחדל ויקפוץ אחרי הטעינה (issue #1280).
+  Map<String, dynamic> readSettings() {
     return {
       'isDarkMode': _settings.getValue<bool>(keyDarkMode, defaultValue: false),
       'followSystemTheme': _settings.getValue<bool>(
@@ -426,7 +431,7 @@ class SettingsRepository {
         keySearchShowPreview,
         defaultValue: true,
       ),
-      'shortcuts': await getShortcuts(),
+      'shortcuts': readShortcuts(),
       'enablePerBookSettings': _settings.getValue<bool>(
         keyEnablePerBookSettings,
         defaultValue: false,
@@ -995,7 +1000,9 @@ class SettingsRepository {
     await _settings.setValue(keyCalendarIcsSubscriptions, value);
   }
 
-  Future<Map<String, String>> getShortcuts() async {
+  Future<Map<String, String>> getShortcuts() async => readShortcuts();
+
+  Map<String, String> readShortcuts() {
     // Start with the default shortcuts
     final shortcuts = Map<String, String>.from(
       ShortcutValidator.defaultShortcuts,

--- a/test/settings/settings_bloc_test.dart
+++ b/test/settings/settings_bloc_test.dart
@@ -31,49 +31,49 @@ void main() {
       settingsBloc.close();
     });
 
+    final mockSettings = {
+      'isDarkMode': true,
+      'followSystemTheme': false,
+      'seedColor': Colors.blue,
+      'darkSeedColor': const Color(0xFFCE93D8),
+      'textMaxWidth': 800.0,
+      'fontSize': 18.0,
+      'fontFamily': 'Rubik',
+      'commentatorsFontFamily': 'NotoRashiHebrew',
+      // issue #849 — נטען בעליית התוכנה כדי שגופן מערכת לא יתאפס ל-fallback.
+      'pageShapeBottomFont': 'NotoSerifHebrew',
+      'commentatorsFontSize': 22.0,
+      'lineHeight': 1.5,
+      'showOtzarHachochma': true,
+      'showHebrewBooks': true,
+      'showExternalBooks': true,
+      'autoUpdateIndex': false,
+      'defaultContinuousReadingMode': true,
+      'defaultSidebarOpen': true,
+      'defaultCommentaryOpen': true,
+      'pinSidebar': true,
+      'sidebarWidth': 300.0,
+      'facetFilteringWidth': 235.0,
+      'commentaryPaneWidth': 400.0,
+      'copyWithHeaders': 'none',
+      'copyHeaderFormat': 'same_line_after_brackets',
+      'isFullscreen': false,
+      'libraryViewMode': 'grid',
+      'libraryShowPreview': true,
+      'searchShowPreview': true,
+      'enablePerBookSettings': true,
+      'pdfBookViewByDefault': false,
+      'shortcuts': <String, String>{},
+      'isOfflineMode': false,
+      'softwareAndBookUpdatesEnabled': true,
+      'personalNotesCollapsedByDefault': true,
+    };
+
     test('initial state is correct', () {
       expect(settingsBloc.state, equals(SettingsState.initial()));
     });
 
     group('LoadSettings', () {
-      final mockSettings = {
-        'isDarkMode': true,
-        'followSystemTheme': false,
-        'seedColor': Colors.blue,
-        'darkSeedColor': const Color(0xFFCE93D8),
-        'textMaxWidth': 800.0,
-        'fontSize': 18.0,
-        'fontFamily': 'Rubik',
-        'commentatorsFontFamily': 'NotoRashiHebrew',
-        // issue #849 — נטען בעליית התוכנה כדי שגופן מערכת לא יתאפס ל-fallback.
-        'pageShapeBottomFont': 'NotoSerifHebrew',
-        'commentatorsFontSize': 22.0,
-        'lineHeight': 1.5,
-        'showOtzarHachochma': true,
-        'showHebrewBooks': true,
-        'showExternalBooks': true,
-        'autoUpdateIndex': false,
-        'defaultContinuousReadingMode': true,
-        'defaultSidebarOpen': true,
-        'defaultCommentaryOpen': true,
-        'pinSidebar': true,
-        'sidebarWidth': 300.0,
-        'facetFilteringWidth': 235.0,
-        'commentaryPaneWidth': 400.0,
-        'copyWithHeaders': 'none',
-        'copyHeaderFormat': 'same_line_after_brackets',
-        'isFullscreen': false,
-        'libraryViewMode': 'grid',
-        'libraryShowPreview': true,
-        'searchShowPreview': true,
-        'enablePerBookSettings': true,
-        'pdfBookViewByDefault': false,
-        'shortcuts': <String, String>{},
-        'isOfflineMode': false,
-        'softwareAndBookUpdatesEnabled': true,
-        'personalNotesCollapsedByDefault': true,
-      };
-
       blocTest<SettingsBloc, SettingsState>(
         'emits updated state when LoadSettings is added',
         build: () {
@@ -680,7 +680,7 @@ void main() {
         final bloc = SettingsBloc(
           repository: mockRepository,
           initialSettings: {
-            'shortcuts': <String, String>{},
+            ...mockSettings,
             'readingTabsPlacement': SettingsRepository.readingTabsPlacementSide,
           },
         );

--- a/test/settings/settings_bloc_test.dart
+++ b/test/settings/settings_bloc_test.dart
@@ -9,6 +9,7 @@ import 'package:mockito/mockito.dart';
 import 'package:otzaria/core/app_paths.dart';
 import 'package:otzaria/settings/engine/settings_bloc.dart';
 import 'package:otzaria/settings/engine/settings_event.dart';
+import 'package:otzaria/settings/engine/settings_repository.dart';
 import 'package:otzaria/settings/engine/settings_state.dart';
 import 'package:otzaria/settings/services/per_book_settings_service.dart';
 import '../helpers/memory_settings_cache.dart';
@@ -670,6 +671,33 @@ void main() {
           expect(overrideJson?['commentatorsBelow'], isTrue);
         },
       );
+    });
+    // issue #1280 — הטאבים נצבעו למעלה ורק אחרי הטעינה קפצו הצידה: המצב
+    // ההתחלתי נבנה מברירות המחדל ולא מההגדרות השמורות.
+    group('מצב התחלתי מההגדרות השמורות (issue #1280)', () {
+      test('מיקום הטאבים בצד נכון כבר במצב ההתחלתי, בלי LoadSettings', () {
+        when(mockRepository.hasProtectedModePassword()).thenReturn(false);
+        final bloc = SettingsBloc(
+          repository: mockRepository,
+          initialSettings: {
+            'shortcuts': <String, String>{},
+            'readingTabsPlacement': SettingsRepository.readingTabsPlacementSide,
+          },
+        );
+        addTearDown(bloc.close);
+
+        expect(
+          bloc.state.readingTabsPlacement,
+          SettingsRepository.readingTabsPlacementSide,
+        );
+      });
+
+      test('בלי הגדרות התחלתיות המצב הוא ברירת המחדל', () {
+        expect(
+          settingsBloc.state.readingTabsPlacement,
+          SettingsRepository.readingTabsPlacementTop,
+        );
+      });
     });
   });
 }

--- a/test_results/2026-09-09-settings-initial-state-1280.md
+++ b/test_results/2026-09-09-settings-initial-state-1280.md
@@ -1,0 +1,43 @@
+# issue #1280 — טעינת הגדרת מיקום הטאבים מאוחרת
+
+תאריך: 2026-09-09 | ענף: `fix/settings-initial-state-sync-1280` | בסיס: `upstream/dev` (1491afd5a) | קומיט אימות: `bb6ca8635`
+
+## הבאג שאומת
+
+`SettingsBloc` נוצר עם `SettingsState.initial()` — ברירות המחדל — ורק `LoadSettings`
+האסינכרוני (כתיבת ברירות מחדל בהפעלה ראשונה, ניקוי קיצורים, ו-`AppFonts.ensureFontLoaded`
+לגופני מערכת) מחליף אותו במצב השמור. עד שהוא מסתיים המסך נבנה עם `readingTabsPlacementTop`,
+ואז הטאבים קופצים הצידה — בדיוק כפי שדווח. כל הקריאות מ-`Settings` הן סינכרוניות
+(`Settings.init` רץ לפני `runApp`), ולכן אין סיבה שהמצב ההתחלתי יתעלם מהן.
+
+## הפתרון
+
+- `SettingsRepository.readSettings()` — תמונת ההגדרות השמורות, סינכרונית; `loadSettings()`
+  משתמש בה אחרי האתחולים. `getShortcuts()` נשען על `readShortcuts()` הסינכרוני.
+- `SettingsBloc` מקבל `initialSettings` ובונה ממנו את המצב ההתחלתי דרך `_stateFromSettings`
+  — אותה פונקציה שמשמשת גם את `LoadSettings` (במקום בלוק ה-`emit` המשוכפל).
+- `main.dart` מעביר `settingsRepository.readSettings()`.
+
+## בדיקות
+
+| קובץ | מה נבדק |
+|---|---|
+| `test/settings/settings_bloc_test.dart` | חדש: bloc שנבנה עם `initialSettings` מתחיל עם מיקום טאבים "בצד" בלי `LoadSettings` (נכשל על הבסיס — הפרמטר לא היה קיים); בלי הגדרות התחלתיות המצב הוא ברירת המחדל. `mockSettings` הועלה לקבוצה החיצונית לשימוש משותף |
+
+בדיקות ממוקדות `test/settings` + `test/navigation`: עברו כולן פרט ל-`change_location_dialog_test` (כשל בסיס מוכר).
+
+## אימות ויזואלי
+
+בנייה `flutter build windows --debug` של הבסיס ושל הענף, מיקום טאבים "בצד" בהגדרות,
+צילום רצף פריימים מרגע הופעת החלון (`open/inspection`). במחשב הזה החלון מופיע רק אחרי
+שההגדרות כבר נטענו (גופנים מצורפים נטענים מיד), ולכן **ההבזק לא נראה באף אחת מהבניות** —
+הפריים הראשון בשתיהן מציג את הטאבים בצד. הבאג מתועד בקוד (מצב התחלתי = ברירות מחדל) ומשוחזר
+בבדיקת היחידה; ההבזק שדווח תלוי במשך `ensureFontLoaded`/האתחולים במכונת המדווח.
+
+## סוויטה מלאה
+
+`flutter test` על הענף: **12,458 עברו, 9 דולגו, 10 נכשלו**. תשעה הם כשלי הבסיס המוכרים
+(release_packaging, compaction ×3, tab_context_menu, personal_notes_file_backed_book,
+search_scope_menu, change_location_dialog, shamor_zachor). העשירי — `data_providers/database_library_provider_test` "buildLibraryCatalog שומר מחבר" — נכשל
+באותה צורה גם על `upstream/dev` נקי במכונה שקטה (מחיקת תיקיית temp נכשלת: "used by another process"
+אחרי `database is locked`) — כשל בסיס סביבתי, לא קשור לשינוי.


### PR DESCRIPTION
Fixes #1280

## הבאג
`SettingsBloc` נוצר עם `SettingsState.initial()` (ברירות המחדל), ורק `LoadSettings` האסינכרוני — כתיבת ברירות מחדל בהפעלה ראשונה, ניקוי קיצורים ו-`AppFonts.ensureFontLoaded` לגופני מערכת — מחליף אותו במצב השמור. עד אז המסך נבנה עם טאבים למעלה, ואז הם קופצים הצידה. כל הקריאות מ-`Settings` סינכרוניות (`Settings.init` רץ לפני `runApp`), כך שאין סיבה שהמצב ההתחלתי יתעלם מהן.

## התיקון
- `SettingsRepository.readSettings()` — תמונת ההגדרות השמורות, סינכרונית; `loadSettings()` משתמש בה אחרי האתחולים, ו-`getShortcuts()` נשען על `readShortcuts()`.
- `SettingsBloc(initialSettings: …)` בונה את המצב ההתחלתי דרך `_stateFromSettings` — אותה פונקציה שמשמשת את `LoadSettings` (בלוק ה-`emit` המשוכפל הוחלף בה).
- `main.dart` מעביר `settingsRepository.readSettings()`.

## אימות ויזואלי
מיקום טאבים "בצד", רצף פריימים מרגע הופעת החלון (`open/inspection`), בניית debug של הבסיס מול הענף:

| לפני (dev 1491afd5a) | אחרי |
|---|---|
| ![before](https://raw.githubusercontent.com/dudua99/otzaria/pr-screenshots/1280/before-strip.png) | ![after](https://raw.githubusercontent.com/dudua99/otzaria/pr-screenshots/1280/after-strip.png) |

![first frames](https://raw.githubusercontent.com/dudua99/otzaria/pr-screenshots/1280/compare.png)

בכנות: במחשב שלי ההבזק **לא נראה באף בנייה** — החלון מופיע רק אחרי שההגדרות נטענו (גופנים מצורפים נטענים מיד), והפריים הראשון בשתי הבניות כבר מציג את הטאבים בצד. משך ההבזק תלוי באתחולים האסינכרוניים (בעיקר `ensureFontLoaded` לגופן מערכת) במכונת המדווח. הבאג עצמו מוכח בקוד ובבדיקת היחידה: המצב ההתחלתי התעלם מהערך השמור.

## בדיקות
- קומיט אימות `bb6ca8635`: bloc שנבנה עם הגדרות שמורות חייב להתחיל עם "בצד" בלי `LoadSettings` (נכשל על הבסיס).
- `test/settings` + `test/navigation`: עברו (פרט לכשל הבסיס `change_location_dialog`).
- סוויטה מלאה: 12,458 עברו, 9 דולגו, 10 נכשלו — 9 כשלי הבסיס המוכרים ו-`database_library_provider_test` שנכשל זהה גם על `dev` נקי (סביבתי); פירוט ב-`test_results/2026-09-09-settings-initial-state-1280.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
