### PR TITLE
שדה החיפוש של חלונית הניווט מורם לפי רוחב החלונית ולא לפי רוחב החלון (issue #1268)

### DIFF
--- a/lib/tabs/view/split_pane_view.dart
+++ b/lib/tabs/view/split_pane_view.dart
@@ -6,6 +6,7 @@ import 'package:otzaria/tabs/models/combined_tab.dart';
 import 'package:otzaria/tabs/models/tab.dart';
 import 'package:otzaria/tabs/view/pane_drop_geometry.dart';
 import 'package:otzaria/theme/theme_exports.dart';
+import 'package:otzaria/widgets/navigation/nav_panel_search.dart';
 
 export 'pane_drop_geometry.dart'
     show
@@ -82,7 +83,12 @@ class SplitPaneView extends StatelessWidget {
     return ClipRect(
       child: KeyedSubtree(
         key: GlobalObjectKey(pane),
-        child: paneBuilder(pane),
+        child: LayoutBuilder(
+          builder: (context, constraints) => NavPanelPaneWidthScope(
+            width: constraints.maxWidth,
+            child: paneBuilder(pane),
+          ),
+        ),
       ),
     );
   }

--- a/lib/tabs/view/split_pane_view.dart
+++ b/lib/tabs/view/split_pane_view.dart
@@ -80,13 +80,17 @@ class SplitPaneView extends StatelessWidget {
     OpenedTab pane,
     Widget Function(OpenedTab pane) paneBuilder,
   ) {
+    // _SplitNode בונה את החלוניות פעם אחת לפני ה-ValueListenableBuilder, כדי
+    // שגרירת המפריד תפרוס אותן מחדש בלי לבנות את תצוגות הספרים. ה-child חייב
+    // להישאר מחוץ ל-LayoutBuilder, שנקרא מחדש בכל שינוי רוחב.
+    final child = paneBuilder(pane);
     return ClipRect(
       child: KeyedSubtree(
         key: GlobalObjectKey(pane),
         child: LayoutBuilder(
           builder: (context, constraints) => NavPanelPaneWidthScope(
             width: constraints.maxWidth,
-            child: paneBuilder(pane),
+            child: child,
           ),
         ),
       ),

--- a/lib/text_book/view/text_book_screen.dart
+++ b/lib/text_book/view/text_book_screen.dart
@@ -1692,7 +1692,7 @@ class _TextBookViewerBlocState extends State<TextBookViewerBloc>
         isOpen: state.showLeftPane,
         paneWidth: paneWidth,
         isPinned: state.pinLeftPane,
-        onTogglePin: MediaQuery.of(context).size.width >= 600
+        onTogglePin: NavPanelSearch.canHoist(context)
             ? () => context.read<TextBookBloc>().add(
                 TogglePinLeftPane(!state.pinLeftPane),
               )

--- a/lib/widgets/navigation/nav_panel_search.dart
+++ b/lib/widgets/navigation/nav_panel_search.dart
@@ -201,10 +201,13 @@ const double kNavPanelSearchHoistMinWidth = 600.0;
 /// עזר לזיהוי המצב: בתוך חלונית ניווט שדה החיפוש עולה לסרגל שמעליה, ולכן
 /// הלשונית אינה מציירת שדה מקומי. מחוץ לחלונית (דיאלוג, מסך אחר) היא כן.
 abstract final class NavPanelSearch {
-  /// האם המסך רחב דיו כדי ששדה החיפוש יעלה לסרגל העליון. במסך צר הוא נשאר
-  /// בתוך החלונית, ששם יש לו את מלוא רוחבה.
+  /// האם החלונית רחבה דיה כדי ששדה החיפוש יעלה לסרגל העליון. בחלונית צרה הוא
+  /// נשאר בתוכה, ששם יש לו את מלוא רוחבה. בתצוגה מפוצלת החלון רחב אך החלונית
+  /// צרה — ולכן נמדדת החלונית ([NavPanelPaneWidthScope]), לא החלון (issue #1268).
   static bool canHoist(BuildContext context) =>
-      MediaQuery.sizeOf(context).width >= kNavPanelSearchHoistMinWidth;
+      (NavPanelPaneWidthScope.maybeOf(context) ??
+          MediaQuery.sizeOf(context).width) >=
+      kNavPanelSearchHoistMinWidth;
 
   static bool isHoisted(BuildContext context) =>
       canHoist(context) &&
@@ -217,6 +220,26 @@ abstract final class NavPanelSearch {
     BuildContext context, {
     required bool autoSelected,
   }) => !autoSelected || canHoist(context);
+}
+
+/// רוחב החלונית (הטאב) שבה מוצג הספר — מסופק ע"י מארח החלוניות, כדי שהחלטות
+/// רוחב יתייחסו לחלונית ולא לחלון כולו.
+class NavPanelPaneWidthScope extends InheritedWidget {
+  final double width;
+
+  const NavPanelPaneWidthScope({
+    super.key,
+    required this.width,
+    required super.child,
+  });
+
+  static double? maybeOf(BuildContext context) => context
+      .dependOnInheritedWidgetOfExactType<NavPanelPaneWidthScope>()
+      ?.width;
+
+  @override
+  bool updateShouldNotify(NavPanelPaneWidthScope oldWidget) =>
+      oldWidget.width != width;
 }
 
 /// מסמן את אינדקס הלשונית שבתוכה יושב התוכן — כדי שהפרסום יגיע לסרגל רק

--- a/lib/widgets/navigation/nav_panel_search.dart
+++ b/lib/widgets/navigation/nav_panel_search.dart
@@ -239,7 +239,8 @@ class NavPanelPaneWidthScope extends InheritedWidget {
 
   @override
   bool updateShouldNotify(NavPanelPaneWidthScope oldWidget) =>
-      oldWidget.width != width;
+      (oldWidget.width >= kNavPanelSearchHoistMinWidth) !=
+      (width >= kNavPanelSearchHoistMinWidth);
 }
 
 /// מסמן את אינדקס הלשונית שבתוכה יושב התוכן — כדי שהפרסום יגיע לסרגל רק

--- a/test/tabs/view/split_pane_view_test.dart
+++ b/test/tabs/view/split_pane_view_test.dart
@@ -577,6 +577,33 @@ void main() {
       expect(_CountingPane.initCount['ב'], 1);
     });
 
+    testWidgets('גרירת מפריד אינה קוראת שוב ל-paneBuilder', (tester) async {
+      final calls = <String, int>{};
+      Widget paneBuilder(OpenedTab pane) {
+        calls.update(pane.title, (count) => count + 1, ifAbsent: () => 1);
+        return _CountingPane(pane.title, key: ValueKey(pane));
+      }
+
+      final root = CombinedTab(
+        rightTab: _LeafTab('א'),
+        leftTab: _LeafTab('ב'),
+      );
+      await tester.pumpWidget(_host(root, paneBuilder: paneBuilder));
+
+      expect(calls['א'], 1);
+      expect(calls['ב'], 1);
+
+      await tester.drag(
+        find.byType(MouseRegion).last,
+        const Offset(-60, 0),
+        warnIfMissed: false,
+      );
+      await tester.pumpAndSettle();
+
+      expect(calls['א'], 1);
+      expect(calls['ב'], 1);
+    });
+
     testWidgets('החלפת טאב מפוצל באחר בונה את החלוניות החדשות בלבד', (
       tester,
     ) async {

--- a/test/widgets/nav_panel_search_test.dart
+++ b/test/widgets/nav_panel_search_test.dart
@@ -6,6 +6,8 @@ import 'package:flutter_settings_screens/flutter_settings_screens.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:otzaria/widgets/navigation/app_top_bar.dart';
 import 'package:otzaria/widgets/lists/nav_tree_tile.dart';
+import 'package:otzaria/tabs/models/tab.dart';
+import 'package:otzaria/tabs/view/split_pane_view.dart';
 import 'package:otzaria/widgets/navigation/nav_panel_search.dart';
 import 'package:otzaria/widgets/navigation/nav_side_panel.dart';
 import 'package:otzaria/widgets/text/otzaria_search_field.dart';
@@ -353,6 +355,70 @@ void main() {
       tester.getSize(find.byType(NavPanelSearchBar)).width,
       300 - AppTopBar.horizontalPadding(false),
     );
+  });
+
+  // issue #1268 — בתצוגה מפוצלת החלון רחב אך החלונית צרה: השדה "הורם" לסרגל
+  // צר מדי ונעלם (עלה על כפתור ההגדרות). ההחלטה חייבת להיות לפי רוחב החלונית.
+  group('הרמת השדה לפי רוחב החלונית ולא לפי רוחב החלון (issue #1268)', () {
+    testWidgets('חלונית צרה בתוך חלון רחב — אין הרמה', (tester) async {
+      tester.view.physicalSize = const Size(1200, 800);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.reset);
+
+      bool? canHoist;
+      await tester.pumpWidget(
+        wrap(
+          Row(
+            children: [
+              SizedBox(
+                width: 300,
+                child: NavPanelPaneWidthScope(
+                  width: 300,
+                  child: Builder(
+                    builder: (context) {
+                      canHoist = NavPanelSearch.canHoist(context);
+                      return const SizedBox.shrink();
+                    },
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      );
+
+      expect(canHoist, isFalse);
+    });
+
+    testWidgets('כל חלונית ב-SplitPaneView מקבלת את רוחבה', (tester) async {
+      tester.view.physicalSize = const Size(1200, 800);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.reset);
+
+      double? paneWidth;
+      await tester.pumpWidget(
+        wrap(
+          Row(
+            children: [
+              SizedBox(
+                width: 320,
+                child: SplitPaneView.buildPane(
+                  _FakePane('א'),
+                  (_) => Builder(
+                    builder: (context) {
+                      paneWidth = NavPanelPaneWidthScope.maybeOf(context);
+                      return const SizedBox.shrink();
+                    },
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      );
+
+      expect(paneWidth, 320);
+    });
   });
 
   testWidgets('מחוץ לחלונית ניווט אין הגבהה — הלשונית מציירת שדה מקומי', (
@@ -751,4 +817,12 @@ void main() {
     expect(tester.binding.focusManager.primaryFocus, beforeFocus);
     expect(find.text('אבג'), findsOneWidget);
   });
+}
+
+class _FakePane extends OpenedTab {
+  _FakePane(super.title);
+  @override
+  OpenedTab clone() => this;
+  @override
+  Map<String, dynamic> toJson() => {'type': '_FakePane', 'title': title};
 }

--- a/test_results/2026-09-09-nav-search-hoist-by-pane-width-1268.md
+++ b/test_results/2026-09-09-nav-search-hoist-by-pane-width-1268.md
@@ -1,0 +1,39 @@
+# issue #1268 — שורת החיפוש נעלמת בתצוגה מפוצלת
+
+תאריך: 2026-09-09 | ענף: `fix/nav-search-hoist-by-pane-width-1268` | בסיס: `upstream/dev` (1491afd5a) | קומיט אימות: `56cb42939`
+
+## הבאג שאומת
+
+`NavPanelSearch.canHoist` בדק את רוחב **החלון** (`MediaQuery` ≥ 600) כדי להחליט אם שדה
+החיפוש של חלונית הניווט עולה לסרגל העליון. בתצוגה מפוצלת החלון רחב והחלונית צרה: השדה הורם
+לסרגל בלי מקום, התכווץ לאייקון ליד כפתור ההגדרות, והחלונית לא ציירה שדה מקומי — הצילום שדווח.
+שוחזר: בראשית לצד רש"י על בראשית, חלון 1100 (חלונית ~480).
+
+## הפתרון
+
+`SplitPaneView.buildPane` (עוטף כל חלונית, יחידה או מפוצלת) מספק `NavPanelPaneWidthScope`
+מ-`LayoutBuilder`; `canHoist` קורא את רוחב החלונית ונופל ל-`MediaQuery` רק מחוץ לחלונית.
+כפתור הנעיצה בסרגל משתמש באותה החלטה במקום בבדיקת `MediaQuery` נפרדת.
+
+## בדיקות
+
+| קובץ | מה נבדק |
+|---|---|
+| `test/widgets/nav_panel_search_test.dart` | חדש: חלונית 300 בחלון 1200 → `canHoist` false; כל חלונית ב-`SplitPaneView` מקבלת את רוחבה (נכשלו על הבסיס — ה-scope לא היה קיים) |
+
+`nav_panel_search_test` + `split_pane_view_test` + `tab_strip_split_integration_test`: **58 עברו**.
+
+## אימות ויזואלי
+
+בניית debug של הבסיס ושל הענף, פיצול בראשית | רש"י, חלון 1100, חלונית הניווט פתוחה. לפני:
+אייקון חיפוש דחוס ליד ההגדרות ובלי שדה בחלונית; אחרי: שדה "איתור כותרת..." מלא בתוך החלונית.
+פס ה-overflow בקצה החלונית מופיע בשתי הבניות (בעיה נפרדת בבסיס). הצילומים בענף `pr-screenshots`
+(תיקייה `1268`).
+
+## סוויטה מלאה
+
+`flutter test` על הענף (במקביל לסוויטה נוספת): **12,456 עברו, 9 דולגו, 12 נכשלו**. שמונה כשלי
+בסיס מוכרים (release_packaging, compaction ×3, personal_notes_file_backed_book, search_scope_menu,
+change_location_dialog, shamor_zachor). `text_book_bloc_test` ×3 — עברו בבידוד (רגישים לעומס).
+`database_library_provider_test` "buildLibraryCatalog שומר מחבר" — נכשל באותה צורה גם על
+`upstream/dev` נקי במכונה שקטה (מחיקת תיקיית temp אחרי `database is locked`) — כשל בסיס סביבתי.


### PR DESCRIPTION
Fixes #1268

## הבאג
`NavPanelSearch.canHoist` החליט אם להרים את שדה החיפוש של חלונית הניווט לסרגל העליון לפי **רוחב החלון** (`MediaQuery` ≥ 600). בתצוגה מפוצלת החלון רחב אך החלונית צרה: השדה "הורם" לסרגל שאין בו מקום, התכווץ לאייקון זעיר ליד כפתור ההגדרות, והחלונית עצמה לא ציירה שדה מקומי — בדיוק הצילום שדווח.

## התיקון
ההחלטה נמדדת מול החלונית ולא מול החלון: `SplitPaneView.buildPane` (שעוטף כל חלונית — מפוצלת או יחידה) מספק `NavPanelPaneWidthScope` עם רוחב החלונית מ-`LayoutBuilder`, ו-`canHoist` קורא אותו (עם נפילה ל-`MediaQuery` מחוץ לחלונית, למשל בדיאלוגים). גם כפתור הנעיצה בסרגל משתמש באותה החלטה במקום בבדיקת `MediaQuery` נפרדת.

## אימות ויזואלי
בראשית לצד רש"י על בראשית, חלון ברוחב 1100 (כל חלונית כ-480), חלונית הניווט פתוחה. בניית debug של הבסיס (dev 1491afd5a) מול הענף:

| לפני — אייקון חיפוש דחוס ליד ההגדרות, בלי שדה בחלונית | אחרי — השדה בתוך החלונית מתחת ללשוניות |
|---|---|
| ![before](https://raw.githubusercontent.com/dudua99/otzaria/pr-screenshots/1268/before.png) | ![after](https://raw.githubusercontent.com/dudua99/otzaria/pr-screenshots/1268/after.png) |

![compare](https://raw.githubusercontent.com/dudua99/otzaria/pr-screenshots/1268/compare.png)

(פס ה-overflow הצהוב בקצה החלונית מופיע בשתי הבניות — בעיה נפרדת שקיימת בבסיס.)

## בדיקות
- קומיט אימות `56cb42939`: חלונית ברוחב 300 בתוך חלון 1200 — `canHoist` חייב להיות false; כל חלונית ב-`SplitPaneView` מקבלת את רוחבה (נכשלו על הבסיס — ה-scope לא היה קיים).
- `nav_panel_search_test`, `split_pane_view_test`, `tab_strip_split_integration_test`: 58 עברו.
- סוויטה מלאה: 12,456 עברו, 9 דולגו, 12 נכשלו — 8 כשלי הבסיס המוכרים, `text_book_bloc_test` ×3 שעברו בבידוד, ו-`database_library_provider_test` שנכשל זהה גם על `dev` נקי (סביבתי). פירוט ב-`test_results/2026-09-09-nav-search-hoist-by-pane-width-1268.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
