### PR TITLE
ניווט: ניקוי חיפוש בין תזמון הגלילה לביצועה הפיל את בקר הגלילה

### DIFF
--- a/lib/text_book/view/toc_navigator_screen.dart
+++ b/lib/text_book/view/toc_navigator_screen.dart
@@ -139,14 +139,15 @@ class _TocViewerState extends State<TocViewer>
     final next = (start + delta).clamp(0, flat.length - 1);
     if (next == current) return;
 
-    setState(() => _highlightedEntryIndex = flat[next].entry.index);
-    final useFlat = display.totalCount > _kTocFlattenThreshold;
+    final targetIndex = flat[next].entry.index;
+    setState(() => _highlightedEntryIndex = targetIndex);
     SchedulerBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
+      final current = _displayDataFor(state.tableOfContents);
       _scrollEntryIntoView(
-        flat[next].entry.index,
-        display: display,
-        useFlat: useFlat,
+        targetIndex,
+        display: current,
+        useFlat: current.totalCount > _kTocFlattenThreshold,
       );
     });
   }
@@ -247,16 +248,15 @@ class _TocViewerState extends State<TocViewer>
 
     _ensureParentsOpen(state.tableOfContents, activeIndex);
 
-    // החלטה בין מסלול וירטואלי לרקורסיבי - חייב להיות זהה ללוגיקה ב-build,
-    // אחרת ננסה לגלול בקונטרולר שלא מחובר.
-    final display = _displayDataFor(state.tableOfContents);
-    final bool useFlat = display.totalCount > _kTocFlattenThreshold;
-
     SchedulerBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
 
       SchedulerBinding.instance.addPostFrameCallback((_) {
         if (!mounted || _isManuallyScrolling) return;
+        // ההחלטה וירטואלי/רקורסיבי נלקחת כאן ולא בזמן התזמון: שני frames
+        // עברו, וניקוי חיפוש בינתיים מחליף מסלול ומנתק את בקר הגלילה.
+        final display = _displayDataFor(state.tableOfContents);
+        final bool useFlat = display.totalCount > _kTocFlattenThreshold;
         if (_scrollEntryIntoView(
           activeIndex,
           display: display,

--- a/test/text_book/view/toc_navigator_screen_test.dart
+++ b/test/text_book/view/toc_navigator_screen_test.dart
@@ -587,6 +587,64 @@ Future<void> main() async {
     expect(tocOffset(), greaterThan(0));
   });
 
+  testWidgets(
+    'ניקוי חיפוש בין תזמון הגלילה לביצועה אינו זורק (מסלול שהוחלף)',
+    (tester) async {
+      // ספר גדול (מסלול וירטואלי) שחיפוש מצמצם למסלול הרקורסיבי. הגלילה
+      // לפריט הפעיל מתוזמנת שני frames קדימה; ניקוי החיפוש בינתיים מחזיר
+      // את הרשימה הוירטואלית ובקר הגלילה של המסלול הרקורסיבי מתנתק, בעוד
+      // ה-GlobalKey של הפריט (משותף לשני המסלולים) עדיין מוצא הקשר חי.
+      // היעד קרוב לראש, כך שהרשימה הוירטואלית בונה אותו ומפתחו חי.
+      final toc = List.generate(
+        600,
+        (i) => TocEntry(
+          text: i == 5 ? 'unique-target' : 'item $i',
+          index: i,
+          level: 1,
+        ),
+      );
+      final initial = _loadedState(toc: toc, visibleIndices: const [0]);
+      final bloc = _TestTextBookBloc(initial);
+      addTearDown(bloc.close);
+      final focusNode = FocusNode();
+      addTearDown(focusNode.dispose);
+
+      await tester.pumpWidget(
+        _wrap(
+          TocViewer(
+            scrollController: ItemScrollController(),
+            closeLeftPaneCallback: () {},
+            focusNode: focusNode,
+          ),
+          bloc,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextField), 'unique');
+      await tester.pump(const Duration(milliseconds: 300));
+      expect(find.byType(SingleChildScrollView), findsOneWidget);
+
+      // שינוי הפריט הפעיל מתזמן גלילה במסלול הרקורסיבי.
+      bloc.emitState(initial.copyWith(selectedIndex: 5));
+      await tester.pump();
+
+      // ניקוי מיידי — לפני שה-callback השני רץ.
+      // הקלט הגולמי — WidgetTester.enterText מריץ frame ביניים משלו,
+      // וה-callback השני היה רץ בו לפני שהניקוי מוחל.
+      tester.testTextInput.enterText('');
+      await tester.pump();
+      for (var i = 0; i < 4; i++) {
+        tester.binding.scheduleFrame();
+        await tester.pump(const Duration(milliseconds: 150));
+      }
+
+      expect(tester.takeException(), isNull);
+      expect(find.byType(SingleChildScrollView), findsNothing);
+    },
+    skip: !engineReady,
+  );
+
   testWidgets('emit חוזר עם אותו state לא קורס ולא משכפל פריטים', (
     tester,
   ) async {


### PR DESCRIPTION
בספר עם יותר מ-500 ערכי תוכן עניינים, חיפוש שמצמצם את התוצאות מעביר את החלונית מהרשימה הוירטואלית למסלול הרקורסיבי. הגלילה לפריט הפעיל מתוזמנת שני frames קדימה, וההחלטה באיזה מסלול לגלול נלקחה בזמן התזמון. ניקוי החיפוש בינתיים מחזיר את הרשימה הוירטואלית ומנתק את בקר הגלילה של המסלול הרקורסיבי, בעוד ה-GlobalKey של הפריט (משותף לשני המסלולים) עדיין מוצא הקשר חי — והגישה ל-position נפלה על 'Bad state: No element'.

ההחלטה עוברת לתוך ה-callback עצמו, בשני מקומות התזמון. הבדיקה החדשה משחזרת את הרצף ונכשלה באותה שורה לפני התיקון.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
