### PR TITLE
קיצורי מקשים: מקש בודד לא נורה בזמן הקלדה בעורך ההערות (issue #1302)

### DIFF
--- a/lib/shortcuts/keyboard_shortcuts.dart
+++ b/lib/shortcuts/keyboard_shortcuts.dart
@@ -108,14 +108,20 @@ class _KeyboardShortcutsState extends State<KeyboardShortcuts> {
     LogicalKeyboardKey.numpad9.keyId: 9,
   };
 
-  /// בודק אם הפוקוס הנוכחי נמצא על שדה טקסט
+  /// בודק אם הפוקוס הנוכחי נמצא על שדה טקסט — כל widget שה-State שלו מקבל
+  /// קלט מהמקלדת (EditableText, וגם עורך Quill של ההערות; issue #1302).
   bool _isEditing() {
-    final focusNode = FocusManager.instance.primaryFocus;
-    if (focusNode == null || focusNode.context == null) return false;
-    // בדיקה מעמיקה יותר - האם הוידג'ט שמחזיק את הפוקוס הוא צאצא של EditableText
-    return focusNode.context!.widget is EditableText ||
-        focusNode.context!.findAncestorWidgetOfExactType<EditableText>() !=
-            null;
+    final context = FocusManager.instance.primaryFocus?.context;
+    if (context == null) return false;
+    if (context is StatefulElement && context.state is TextInputClient) {
+      return true;
+    }
+    var found = false;
+    context.visitAncestorElements((element) {
+      found = element is StatefulElement && element.state is TextInputClient;
+      return !found;
+    });
+    return found;
   }
 
   /// מטפל באירועי מקלדת ברמה הגלובלית - עובד גם כשיש TextField עם focus

--- a/test/shortcuts/keyboard_shortcuts_test.dart
+++ b/test/shortcuts/keyboard_shortcuts_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_settings_screens/flutter_settings_screens.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_quill/flutter_quill.dart' as quill;
 import 'package:otzaria/core/focus_repository.dart';
 import 'package:otzaria/history/bloc/history_bloc.dart';
 import 'package:otzaria/history/bloc/history_event.dart';
@@ -318,6 +319,125 @@ void main() {
         expect(tab.toggleTextViewNotifier.value, 1);
       },
     );
+  });
+
+  // issue #1302 — קיצור של אות בודדת ("פ" לחלונית המפרשים) נורה בזמן הקלדה
+  // בעורך ההערות האישיות: הזיהוי של "שדה טקסט בפוקוס" הכיר רק ב-EditableText,
+  // ועורך Quill מטפל בקלט בעצמו.
+  group('KeyboardShortcuts - קיצור של מקש בודד בעורך Quill (issue #1302)', () {
+    late MockSettingsBloc settingsBlocLocal;
+    late StreamController<SettingsState> settingsControllerLocal;
+
+    setUpAll(() async {
+      await Settings.init(cacheProvider: MemorySettingsCache());
+    });
+
+    setUp(() {
+      FocusRepository().resetForTesting();
+      settingsBlocLocal = MockSettingsBloc();
+      settingsControllerLocal = StreamController<SettingsState>.broadcast();
+      whenListen(
+        settingsBlocLocal,
+        settingsControllerLocal.stream,
+        initialState: SettingsState.initial().copyWith(
+          shortcuts: const {'key-shortcut-toggle-commentators-pane': 'p'},
+        ),
+      );
+    });
+
+    tearDown(() async {
+      await settingsControllerLocal.close();
+      FocusRepository().resetForTesting();
+    });
+
+    Future<TextBookTab> pumpEditor(
+      WidgetTester tester, {
+      required Widget child,
+    }) async {
+      final tab = TextBookTab(
+        book: TextBook(title: 'ספר בדיקה'),
+        index: 0,
+        blocOverride: _StubTextBookBloc(),
+      );
+      addTearDown(tab.dispose);
+      final tabsBloc = _StubTabsBloc(
+        TabsState(tabs: [tab], currentTabIndex: 0),
+      );
+      final historyBloc = _StubHistoryBloc();
+      final navigationBloc = _StubNavigationBloc();
+      addTearDown(() async {
+        await tabsBloc.close();
+        await historyBloc.close();
+        await navigationBloc.close();
+      });
+      await tester.pumpWidget(
+        MultiBlocProvider(
+          providers: [
+            BlocProvider<SettingsBloc>.value(value: settingsBlocLocal),
+            BlocProvider<TabsBloc>.value(value: tabsBloc),
+            BlocProvider<HistoryBloc>.value(value: historyBloc),
+            BlocProvider<NavigationBloc>.value(value: navigationBloc),
+            Provider<FocusRepository>.value(value: FocusRepository()),
+          ],
+          child: MaterialApp(
+            home: Scaffold(
+              body: KeyboardShortcuts(
+                onFindRefRequested: () {},
+                child: child,
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+      return tab;
+    }
+
+    testWidgets('בלי שדה טקסט — המקש הבודד מגלגל את החלונית', (tester) async {
+      final focusNode = FocusNode();
+      addTearDown(focusNode.dispose);
+      final tab = await pumpEditor(
+        tester,
+        child: Focus(
+          focusNode: focusNode,
+          child: const SizedBox(width: 100, height: 100),
+        ),
+      );
+      focusNode.requestFocus();
+      await tester.pump();
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.keyP);
+      await tester.pump();
+
+      expect(tab.toggleCommentatorsPaneNotifier.value, 1);
+    });
+
+    testWidgets('בעורך Quill בפוקוס — המקש הבודד נשאר הקלדה', (tester) async {
+      final controller = quill.QuillController.basic();
+      final focusNode = FocusNode();
+      final scrollController = ScrollController();
+      addTearDown(() {
+        controller.dispose();
+        focusNode.dispose();
+        scrollController.dispose();
+      });
+      final tab = await pumpEditor(
+        tester,
+        child: quill.QuillEditor(
+          controller: controller,
+          focusNode: focusNode,
+          scrollController: scrollController,
+          config: const quill.QuillEditorConfig(autoFocus: true),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(focusNode.hasFocus, isTrue);
+
+      await tester.sendKeyEvent(LogicalKeyboardKey.keyP);
+      await tester.pump();
+
+      expect(tab.toggleCommentatorsPaneNotifier.value, 0);
+    });
   });
 
   group('KeyboardShortcuts - חיפוש מתקדם אופציונלי', () {

--- a/test_results/2026-09-10-shortcuts-quill-editor-1302.md
+++ b/test_results/2026-09-10-shortcuts-quill-editor-1302.md
@@ -1,0 +1,40 @@
+# issue #1302 — קיצור של אות בודדת נורה בזמן הקלדה בהערות אישיות
+
+תאריך: 2026-09-10 | ענף: `fix/shortcuts-quill-editor-1302` | בסיס: `upstream/dev` (8c365b5cd) | קומיט אימות: `2536f1898`
+
+## הבאג שאומת
+
+`KeyboardShortcuts._isEditing` זיהה "שדה טקסט בפוקוס" רק לפי `EditableText` — הבסיס של
+`TextField`/`RtlTextField`. עורך ההערות האישיות הוא `QuillEditor` של flutter_quill, שמטפל
+בקלט בעצמו (`QuillRawEditorState` מממש `TextInputClient` ולא יורש מ-`EditableText`), ולכן
+קיצור של אות בודדת ("פ" לחלונית המפרשים) נורה בזמן ההקלדה בו — בדיוק כפי שדווח, בעוד שבשאר
+תיבות ההקלדה זה תוקן.
+
+## הפתרון
+
+הזיהוי הוחלף לקריטריון הכללי: ה-State של ה-widget בפוקוס (או של אב שלו) מממש
+`TextInputClient` — נכון ל-`EditableTextState` וגם לעורך Quill, בלי תלות של מודול הקיצורים
+בחבילת העורך.
+
+## בדיקות
+
+| קובץ | מה נבדק |
+|---|---|
+| `test/shortcuts/keyboard_shortcuts_test.dart` | חדש: קיצור `p` לחלונית המפרשים — בלי שדה טקסט מגלגל את החלונית; ב-`QuillEditor` בפוקוס נשאר הקלדה (נכשל על הבסיס: 1 במקום 0) |
+
+`test/shortcuts/keyboard_shortcuts_test.dart`: **28 עברו**.
+
+## אימות ויזואלי
+
+קיצור החלונית הוגדר ל-`p` בהגדרות; בראשית, הערה חדשה מהתפריט, הקלדת `abc` ואז `p`.
+בניית debug של הבסיס (dev 8c365b5cd) מול הענף. לפני: ה-`p` סגר את חלונית ההערות
+(הקיצור נורה) ולא הוקלד; אחרי: `p` מוקלד בעורך והחלונית נשארת. הצילומים בענף
+`pr-screenshots` (תיקייה `1302`).
+
+## סוויטה מלאה
+
+`flutter test` על הענף (במקביל לסוויטה נוספת ולאמולטור): **12,622 עברו, 23 דולגו, 11 נכשלו**.
+עשרה כשלי בסיס מוכרים (release_packaging, compaction ×3, tab_context_menu,
+personal_notes_file_backed_book, search_scope_menu, change_location_dialog, shamor_zachor,
+database_library_provider "buildLibraryCatalog" — נכשל זהה על dev נקי). אחד רגיש-עומס שעבר
+בבידוד: `core/windowing/single_window_regression_test`.


### PR DESCRIPTION
Fixes #1302

## הבאג
`KeyboardShortcuts._isEditing` זיהה "שדה טקסט בפוקוס" רק לפי `EditableText` (הבסיס של `TextField`/`RtlTextField`). עורך ההערות האישיות הוא `QuillEditor`, שמטפל בקלט בעצמו — `QuillRawEditorState` מממש `TextInputClient` ואינו יורש מ-`EditableText` — ולכן קיצור של אות בודדת ("פ" לחלונית המפרשים) נורה בזמן ההקלדה בו, בעוד שבשאר תיבות ההקלדה זה כבר תוקן.

## התיקון
הזיהוי הוחלף לקריטריון הכללי: ה-State של ה-widget בפוקוס (או של אב שלו) מממש `TextInputClient`. זה נכון ל-`EditableTextState` וגם לעורך Quill, בלי תלות של מודול הקיצורים בחבילת העורך.

## אימות ויזואלי
קיצור החלונית הוגדר ל-`p`; הערה חדשה בבראשית, הקלדת `abc` ואז `p`. בניית debug של הבסיס (dev 8c365b5cd) מול הענף:

| לפני — `p` סגר את חלונית ההערות ולא הוקלד | אחרי — `p` מוקלד, החלונית נשארת |
|---|---|
| ![before](https://raw.githubusercontent.com/dudua99/otzaria/pr-screenshots/1302/before.png) | ![after](https://raw.githubusercontent.com/dudua99/otzaria/pr-screenshots/1302/after.png) |

## בדיקות
- קומיט אימות `2536f1898`: קיצור `p` — בלי שדה טקסט מגלגל את החלונית; ב-`QuillEditor` בפוקוס חייב להישאר הקלדה (נכשל על הבסיס: 1 במקום 0).
- `test/shortcuts/keyboard_shortcuts_test.dart`: 28 עברו.
- סוויטה מלאה: 12,622 עברו, 23 דולגו, 11 נכשלו — 10 כשלי הבסיס המוכרים ואחד רגיש-עומס שעבר בבידוד. פירוט ב-`test_results/2026-09-10-shortcuts-quill-editor-1302.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
