### PR TITLE
תיקון issue #1219 — בחירת תיקיית ספרייה באנדרואיד נופלת ב"שגיאה 13"

### DIFF
--- a/lib/empty_library/bloc/empty_library_bloc.dart
+++ b/lib/empty_library/bloc/empty_library_bloc.dart
@@ -165,12 +165,13 @@ class EmptyLibraryBloc extends Bloc<EmptyLibraryEvent, EmptyLibraryState> {
       if (backupDir != null) {
         await _restoreDatabaseFiles(backupDir, backupPath!);
       }
-      emit(
-        _error(
-          errorMessage: 'שגיאה בייבוא הספרייה: $e',
-          selectedPath: event.sourceFolder,
-        ),
-      );
+      // Scoped Storage באנדרואיד: התיקייה נראית אך אינה ניתנת לקריאה (#1219).
+      final message = e is PathAccessException
+          ? 'אין לתוכנה הרשאת קריאה לקובץ המקור ${e.path}. '
+                'באנדרואיד יש לבחור את קובץ ${DatabaseConstants.databaseFileName} '
+                'דרך "בחר קובץ ספרייה".'
+          : 'שגיאה בייבוא הספרייה: $e';
+      emit(_error(errorMessage: message, selectedPath: event.sourceFolder));
     } finally {
       if (writeSessionStarted) {
         await SqliteDataProvider.instance.reopenAfterExternalWrite(

--- a/lib/settings/dialogs/library_setup_dialog.dart
+++ b/lib/settings/dialogs/library_setup_dialog.dart
@@ -84,43 +84,80 @@ const _kLibraryAssets = <({String label, String consequence})>[
   (label: _kTalmudAssetLabel, consequence: 'ספרי התלמוד בבלי לא ייכללו.'),
 ];
 
+/// תוצאת סריקת תיקיית מקור: הנכסים שזוהו, והאם התוכנה מורשית לקרוא אותם.
+@visibleForTesting
+class LibraryFolderScan {
+  final List<String> found;
+  final bool readable;
+  const LibraryFolderScan({required this.found, required this.readable});
+}
+
+/// בדיקת קריאה בפועל של קובץ שנמצא. ב-Android Scoped Storage `exists()` מחזיר
+/// true גם לקובץ שאין לאפליקציה הרשאה לפתוח (issue #1219).
+@visibleForTesting
+Future<void> Function(File file)? debugLibraryFolderReadProbe;
+
+Future<void> _probeRead(File file) async {
+  final handle = await file.open();
+  await handle.close();
+}
+
 /// סורק תיקיית מקור ומחזיר תוויות של נכסי הספרייה שזוהו בה, בגרסה דחוסה או
 /// רגילה. seforim.db הוא הנכס הנדרש; השאר נלווים ומיובאים אם קיימים.
-Future<List<String>> _scanFolderAssets(String folder) async {
-  Future<bool> anyExists(List<String> names) async {
+/// קובץ שקיים אך אינו ניתן לקריאה מסמן את התיקייה כולה כלא-נגישה.
+@visibleForTesting
+Future<LibraryFolderScan> scanLibraryFolderAssets(String folder) async {
+  Future<String?> firstExisting(List<String> names) async {
     for (final name in names) {
-      if (await File(p.join(folder, name)).exists()) return true;
+      final file = File(p.join(folder, name));
+      if (await file.exists()) return file.path;
     }
-    return false;
+    return null;
   }
 
   final found = <String>[];
-  if (await anyExists([
+  String? probePath;
+  final dbPath = await firstExisting([
     DatabaseConstants.databaseFileName,
     DatabaseConstants.databaseArchiveFileName,
-  ])) {
+  ]);
+  if (dbPath != null) {
     found.add(_kSeforimAssetLabel);
+    probePath = dbPath;
   }
-  if (await anyExists([
+  final catalogPath = await firstExisting([
     DatabaseConstants.externalCatalogDatabaseFileName,
     DatabaseConstants.externalCatalogArchiveFileName,
-  ])) {
+  ]);
+  if (catalogPath != null) {
     found.add(_kCatalogAssetLabel);
+    probePath ??= catalogPath;
   }
-  if (await File(
-    p.join(folder, DatabaseConstants.lexicalDatabaseFileName),
-  ).exists()) {
+  final lexicalPath = await firstExisting([
+    DatabaseConstants.lexicalDatabaseFileName,
+  ]);
+  if (lexicalPath != null) {
     found.add(_kLexicalAssetLabel);
+    probePath ??= lexicalPath;
   }
-  if (await File(
-        p.join(folder, DatabaseConstants.talmudBavliArchiveFileName),
-      ).exists() ||
+  final talmudArchive = await firstExisting([
+    DatabaseConstants.talmudBavliArchiveFileName,
+  ]);
+  if (talmudArchive != null ||
       await Directory(
         p.join(folder, DatabaseConstants.talmudBavliFolderName),
       ).exists()) {
     found.add(_kTalmudAssetLabel);
+    probePath ??= talmudArchive;
   }
-  return found;
+  if (probePath != null) {
+    try {
+      await (debugLibraryFolderReadProbe ?? _probeRead)(File(probePath));
+    } on PathAccessException {
+      return const LibraryFolderScan(found: [], readable: false);
+    }
+  }
+  return LibraryFolderScan(found: found, readable: true);
 }
 
 class _LibrarySetupDialogContent extends StatefulWidget {
@@ -146,6 +183,7 @@ class _LibrarySetupDialogContentState
 
   /// תיקיית המקור לייבוא (פעולת [_LibraryAction.chooseFile]) והנכסים שזוהו בה.
   String? _sourceFolder;
+  bool _sourceFolderUnreadable = false;
   List<String> _detectedAssets = const [];
 
   String? _sourceArchive;
@@ -195,9 +233,9 @@ class _LibrarySetupDialogContentState
           })
           .catchError((_) {});
       // סורק אילו נכסים כבר קיימים בספרייה — כדי לא להזהיר על מה שכבר יש.
-      _scanFolderAssets(widget.currentLibraryPath!)
-          .then((assets) {
-            if (mounted) setState(() => _systemAssets = assets);
+      scanLibraryFolderAssets(widget.currentLibraryPath!)
+          .then((scan) {
+            if (mounted) setState(() => _systemAssets = scan.found);
           })
           .catchError((_) {});
     }
@@ -222,11 +260,12 @@ class _LibrarySetupDialogContentState
       dialogTitle: context.settingsText('בחר תיקייה המכילה את קבצי הספרייה'),
     );
     if (folder == null || !mounted) return;
-    final detected = await _scanFolderAssets(folder);
+    final scan = await scanLibraryFolderAssets(folder);
     if (!mounted) return;
     setState(() {
       _sourceFolder = folder;
-      _detectedAssets = detected;
+      _detectedAssets = scan.found;
+      _sourceFolderUnreadable = !scan.readable;
     });
   }
 
@@ -255,6 +294,7 @@ class _LibrarySetupDialogContentState
     setState(() {
       _sourceFolder = p.dirname(file.path!);
       _detectedAssets = [_kSeforimAssetLabel];
+      _sourceFolderUnreadable = false;
     });
   }
 
@@ -345,6 +385,12 @@ class _LibrarySetupDialogContentState
     if (_sourceFolder == null) {
       return context.settingsText(
         'בחר תיקייה שקיימים בה קובצי הספרייה והמערכת',
+      );
+    }
+    if (_sourceFolderUnreadable) {
+      return context.settingsText(
+        'לתוכנה אין הרשאת קריאה לתיקייה שנבחרה — יש לבחור את קובץ {file} דרך "בחר קובץ ספרייה"',
+        args: {'file': DatabaseConstants.databaseFileName},
       );
     }
     final missing = _kLibraryAssets

--- a/lib/settings/l10n/settings_catalogs.g.dart
+++ b/lib/settings/l10n/settings_catalogs.g.dart
@@ -657,6 +657,7 @@ const Map<String, Map<String, String>> kSettingsCatalogs = {
     'לפחות X מילים': 'At least X words',
     'לפחות מספר מילים שתבחר מופיעות בתוצאה.': 'At least the number of words you choose appears in the result.',
     'לפי שפת מערכת ההפעלה': 'Use device language',
+    'לתוכנה אין הרשאת קריאה לתיקייה שנבחרה — יש לבחור את קובץ {file} דרך "בחר קובץ ספרייה"': 'Otzaria has no permission to read the selected folder — pick the {file} file with "Select a Library File" instead',
     'מאגר הספרים וחיפוש': 'Library and Search',
     'מאגר תורני חינמי, רחב ומהיר לשימוש בכל מקום.': 'A Free Torah Library — Extensive, Fast, and Accessible Everywhere..',
     'מאוזן': 'Balanced',

--- a/lib/settings/l10n/settings_en.arb
+++ b/lib/settings/l10n/settings_en.arb
@@ -231,6 +231,7 @@
   "יש לבחור את {file}": "You need to select {file}",
   "בחר ארכיון ספרייה (ZIP או ZST)": "Select a library archive file (ZIP or ZST)",
   "בחר תיקייה שקיימים בה קובצי הספרייה והמערכת": "Select a folder that contains the library and system files",
+  "לתוכנה אין הרשאת קריאה לתיקייה שנבחרה — יש לבחור את קובץ {file} דרך \"בחר קובץ ספרייה\"": "Otzaria has no permission to read the selected folder — pick the {file} file with \"Select a Library File\" instead",
   "כל הקבצים זוהו": "All Files Found",
   "חסר קובץ הספרייה (seforim.db) — לא ניתן להמשיך בלי הספרייה": "The library file (seforim.db) is missing — you cannot continue without it",
   "{label} חסר — {consequence}": "{label} is missing — {consequence}",

--- a/test/settings/dialogs/library_setup_dialog_test.dart
+++ b/test/settings/dialogs/library_setup_dialog_test.dart
@@ -1,7 +1,12 @@
+import 'dart:io';
+
+import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:otzaria/settings/dialogs/library_setup_dialog.dart';
 import 'package:otzaria/widgets/widgets_exports.dart';
+// ignore: depend_on_referenced_packages
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
 Widget _host(void Function(BuildContext) onOpen) => MaterialApp(
   home: Scaffold(
@@ -61,6 +66,23 @@ Future<void> _select(WidgetTester tester, String optionTitle) async {
   await tester.ensureVisible(title);
   await tester.tap(title);
   await tester.pumpAndSettle();
+}
+
+/// בורר תיקייה מזויף: מחזיר תמיד את [folder], כמו משתמש שבחר אותה.
+class _FolderFilePickerPlatform extends FilePickerPlatform
+    with MockPlatformInterfaceMixin {
+  _FolderFilePickerPlatform(this.folder);
+  final String folder;
+
+  @override
+  Future<String?> getDirectoryPath({
+    String? dialogTitle,
+    String? initialDirectory,
+    AndroidOptions androidOptions = const AndroidOptions(),
+    WindowsOptions windowsOptions = const WindowsOptions(),
+    LinuxOptions linuxOptions = const LinuxOptions(),
+    WebOptions webOptions = const WebOptions(),
+  }) async => folder;
 }
 
 void main() {
@@ -197,5 +219,70 @@ void main() {
         expect(find.text('בחר קובץ ספרייה'), findsOneWidget);
       },
     );
+  });
+
+  group('בחירת תיקייה שאינה ניתנת לקריאה (issue #1219)', () {
+    late Directory temp;
+
+    setUp(() async {
+      temp = await Directory.systemTemp.createTemp('otzaria_1219_');
+      await File('${temp.path}/seforim.db').writeAsBytes([0, 1, 2]);
+      FilePickerPlatform.instance = _FolderFilePickerPlatform(temp.path);
+    });
+
+    tearDown(() async {
+      debugLibraryFolderReadProbe = null;
+      await temp.delete(recursive: true);
+    });
+
+    test(
+      'scanLibraryFolderAssets: קובץ קיים אך חסום לקריאה → לא נגיש',
+      () async {
+        debugLibraryFolderReadProbe = (file) async =>
+            throw PathAccessException(file.path, const OSError('EACCES', 13));
+        final scan = await scanLibraryFolderAssets(temp.path);
+        expect(scan.readable, isFalse);
+        expect(scan.found, isEmpty);
+      },
+    );
+
+    test('scanLibraryFolderAssets: קובץ קריא → זוהה', () async {
+      final scan = await scanLibraryFolderAssets(temp.path);
+      expect(scan.readable, isTrue);
+      expect(scan.found, contains('ספריית הספרים (seforim.db)'));
+    });
+
+    testWidgets('תיקייה חסומה: הנחיה לבחור את הקובץ, ואישור מושבת', (
+      tester,
+    ) async {
+      debugLibraryFolderReadProbe = (file) async =>
+          throw PathAccessException(file.path, const OSError('EACCES', 13));
+      await _openSetup(tester);
+      await _select(tester, 'בחירת תיקייה מהמחשב');
+      await tester.ensureVisible(find.text('בחר תיקייה'));
+      // הסריקה קוראת מהדיסק — IO אמיתי אינו מסתיים תחת FakeAsync.
+      await tester.runAsync(() async {
+        await tester.tap(find.text('בחר תיקייה'));
+        await Future<void>.delayed(const Duration(milliseconds: 200));
+      });
+      await tester.pumpAndSettle();
+      expect(find.textContaining('אין הרשאת קריאה לתיקייה'), findsOneWidget);
+      expect(find.text('כל הקבצים זוהו'), findsNothing);
+      expect(_actionOnPressed(tester, 'אישור'), isNull);
+    });
+
+    testWidgets('תיקייה קריאה: כל הקבצים זוהו ואישור פעיל', (tester) async {
+      await _openSetup(tester);
+      await _select(tester, 'בחירת תיקייה מהמחשב');
+      await tester.ensureVisible(find.text('בחר תיקייה'));
+      // הסריקה קוראת מהדיסק — IO אמיתי אינו מסתיים תחת FakeAsync.
+      await tester.runAsync(() async {
+        await tester.tap(find.text('בחר תיקייה'));
+        await Future<void>.delayed(const Duration(milliseconds: 200));
+      });
+      await tester.pumpAndSettle();
+      expect(find.textContaining('הספרייה (seforim.db)'), findsNothing);
+      expect(_actionOnPressed(tester, 'אישור'), isNotNull);
+    });
   });
 }

--- a/test_results/2026-09-10-android-library-pick-permission-1219.md
+++ b/test_results/2026-09-10-android-library-pick-permission-1219.md
@@ -1,0 +1,47 @@
+# issue #1219 — בחירת תיקיית ספרייה באנדרואיד נופלת ב"שגיאה 13"
+
+תאריך: 2026-09-10 | ענף: `fix/android-library-pick-permission-1219` | בסיס: `upstream/dev` (8c365b5cd) | קומיט אימות: `e2e947f34`
+
+## הבאג שאומת
+
+שוחזר באמולטור Android 14 (API 34, google_apis x86_64) עם `seforim.db` ב-`/sdcard/Download/otzaria_lib`:
+"בחירת תיקייה מהמחשב" → "בחר תיקייה" → הדיאלוג הציג שהקובץ זוהה ("חסרים: קטלוג, מילון, תלמוד"), האישור
+הופעל, והייבוא נכשל ב-`PathAccessException ... (OS Error: Permission denied, errno = 13)`. ההודעה מוצגת
+מתחת לקפל הדיאלוג. מסלול "בחר קובץ ספרייה" (SAF) עבד: הקובץ הועתק ל-`app_flutter/books/seforim.db`.
+
+## המקור
+
+תחת Scoped Storage, `File.exists()` מחזיר `true` לקובץ באחסון המשותף גם כשאין הרשאת קריאה
+(`stat` מותר, `open` נחסם). `_scanFolderAssets` בדיאלוג הסתמך על `exists()` בלבד.
+הרשאות האחסון ב-manifest מוגבלות ל-API 32; באנדרואיד 13+ אין דרך לקרוא קובץ כזה דרך נתיב.
+
+## התיקון
+
+- `scanLibraryFolderAssets` (במקום `_scanFolderAssets`): אחרי זיהוי הקבצים פותח את הראשון שנמצא לקריאה;
+  `PathAccessException` מסמנת את התיקייה כלא-נגישה (`readable: false`, ללא נכסים). hook
+  `debugLibraryFolderReadProbe` לבדיקות.
+- `_sourceFolderUnreadable` בדיאלוג: כותרת משנה "לתוכנה אין הרשאת קריאה לתיקייה שנבחרה — יש לבחור את קובץ
+  seforim.db דרך "בחר קובץ ספרייה"", האישור נשאר מושבת. בחירת קובץ מאפסת את הדגל.
+- `EmptyLibraryBloc._onImportLibraryFolderRequested`: `PathAccessException` → הודעה מובנת עם אותה הנחיה.
+- תרגום לאנגלית ב-`settings_en.arb`, הקטלוג נוצר מחדש.
+
+## בדיקות
+
+| קובץ | מה נבדק |
+|---|---|
+| `test/settings/dialogs/library_setup_dialog_test.dart` | חדש (קבוצה "issue #1219"): סריקה עם probe שזורק `PathAccessException` → לא נגיש וללא נכסים; סריקה רגילה → seforim.db זוהה; widget: בורר תיקייה מזויף + probe חוסם → ההנחיה מוצגת, "כל הקבצים זוהו" לא, אישור מושבת; תיקייה קריאה → אישור פעיל. על הבסיס הקבוצה נכשלת (הסריקה מדווחת "כל הקבצים זוהו"). |
+
+`flutter test test/settings/dialogs/library_setup_dialog_test.dart`: **18 עברו**.
+`flutter test test/settings/l10n/ test/empty_library/`: **193 עברו**. `flutter analyze` נקי, `dart format` ללא שינויים.
+
+## אימות ויזואלי
+
+APK debug של הבסיס ושל הענף על האמולטור (Flutter ברינדור תוכנה — ה-GPU של האמולטור מקריס את qemu במחשב
+הבדיקה). לפני: "Still Missing: קטלוג…" ואחרי אישור errno 13; אחרי: ההנחיה ואישור מושבת (עברית ואנגלית).
+הצילומים בענף `pr-screenshots` (תיקייה `1219`).
+
+## סוויטה מלאה
+
+`flutter test` על הענף (במקביל לאמולטור): **12,626 עברו, 23 דולגו, 9 נכשלו** — כולם כשלי הבסיס המוכרים:
+release_packaging, compaction ×3, personal_notes_file_backed_book, search_scope_menu (flaky),
+change_location_dialog, shamor_zachor, database_library_provider "buildLibraryCatalog".


### PR DESCRIPTION
Fixes #1219

## הבאג
באנדרואיד, "בחירת תיקייה מהמחשב" → "בחר תיקייה" על תיקייה באחסון המשותף (למשל `Download`) מציגה "כל הקבצים זוהו", מאפשרת אישור, והייבוא נכשל ב:

```
שגיאה בייבוא הספרייה: PathAccessException: Cannot copy file to '.../app_flutter/books/seforim.db.new',
path = '/storage/emulated/0/Download/otzaria_lib/seforim.db' (OS Error: Permission denied, errno = 13)
```

זו "שגיאה 13" שדווחה בפורום. ההודעה מוצגת מתחת לקפל של הדיאלוג, ולכן חלק מהמשתמשים ראו רק ש"אישור לא עושה כלום".

## הסיבה
תחת Android Scoped Storage, `File.exists()` מחזיר `true` לקובץ בתיקייה משותפת גם כשלאפליקציה אין הרשאה לפתוח אותו (`stat` מותר, `open` נחסם). סריקת התיקייה בדיאלוג הסתמכה על `exists()` בלבד, ולכן דיווחה שהקבצים נמצאו. הרשאות האחסון ב-manifest מוגבלות ל-API 32, ובאנדרואיד 13+ אין דרך לקרוא קובץ כזה דרך נתיב — המסלול הנתמך הוא בחירת הקובץ עצמו (SAF), שכבר קיים בדיאלוג ("בחר קובץ ספרייה") ועובד.

## התיקון
- הסריקה בודקת קריאה בפועל (פתיחת הקובץ שנמצא) ולא רק קיום. תיקייה שקיימת אך חסומה מסומנת כלא-נגישה: האישור נשאר מושבת, וכותרת המשנה מנחה לבחור את `seforim.db` דרך "בחר קובץ ספרייה".
- אם כשל הרשאה עולה בזמן הייבוא עצמו, ההודעה הטכנית מוחלפת בהודעה מובנת עם אותה הנחיה.
- תרגום לאנגלית נוסף ל-ARB והקטלוג נוצר מחדש.

## אימות ויזואלי (אמולטור Android 14, API 34)
| לפני: התיקייה "זוהתה" | לפני: אישור → errno 13 (מתחת לקפל) |
|---|---|
| ![before](https://raw.githubusercontent.com/dudua99/otzaria/pr-screenshots/1219/before_folder_detected.png) | ![before-error](https://raw.githubusercontent.com/dudua99/otzaria/pr-screenshots/1219/before_errno13.png) |

| אחרי (עברית) | אחרי (אנגלית) |
|---|---|
| ![after-he](https://raw.githubusercontent.com/dudua99/otzaria/pr-screenshots/1219/after_he.png) | ![after-en](https://raw.githubusercontent.com/dudua99/otzaria/pr-screenshots/1219/after_en.png) |

מסלול "בחר קובץ ספרייה" אומת גם הוא באמולטור: הקובץ מועתק דרך המטמון של file_picker אל `app_flutter/books/seforim.db`.

## בדיקות
- קומיט אימות: `test/settings/dialogs/library_setup_dialog_test.dart` — קבוצה "issue #1219": סריקה של תיקייה שבה הקובץ קיים אך פתיחתו זורקת `PathAccessException` (בדיקת יחידה + בדיקת widget עם בורר תיקייה מזויף). נכשלת על dev, עוברת אחרי התיקון.
- `flutter test test/settings/dialogs/library_setup_dialog_test.dart` — 18 עוברות.
- `flutter test test/settings/l10n/ test/empty_library/` — 193 עוברות.
- `flutter analyze` — נקי. `dart format` — ללא שינויים.
- סוויטה מלאה: ראה `test_results/2026-09-10-android-library-pick-permission-1219.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
